### PR TITLE
v0.1 complete — startup banner, doc updates, pyproject cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,18 @@ For full architecture details, data models, API reference, and plugin developmen
 
 ---
 
-## What's Included in v1
+## What's Included in v0.1
 
 - **3 agents** — IngestAgent (two-pass synthesis), QueryAgent (BM25 + LLM), LintAgent (contradiction + orphan detection + auto-resolution)
-- **6 built-in skills** — PDF, URL, Markdown/TXT, DOCX, XLSX/CSV, Image (vision)
+- **7 built-in skills** — PDF, URL, Markdown/TXT, DOCX, XLSX/CSV, Image (vision), Web search (v0.2 stub)
+- **Folder-based skill system** — each skill is a self-contained folder with a `SKILL.md` manifest; intent-based dispatch alongside extension matching; drop a folder in `skills/` to add a new format without touching core code
 - **3 access surfaces** — CLI (thin HTTP client), HTTP REST API, MCP server
-- **Obsidian plugin** — ingest, query, lint, jobs — all from the command palette
+- **Obsidian plugin** — ingest (with file picker when no note is active), query (responsive modal, stays open), lint report, jobs list, web search placeholder — all from the command palette; ribbon shows engine health + page count
 - **3-layer cache** — embedding cache, LLM response cache, provider prompt cache
 - **Cost guards** — configurable soft-warn and hard-gate USD thresholds
 - **Hook system** — shell commands on 8 lifecycle events; blocking or background
-- **Job queue** — SQLite-backed, persistent, retry with exponential backoff
+- **Job queue** — SQLite-backed, persistent, retry with exponential backoff; non-retryable errors (`failed`) distinguished from exhausted-retry errors (`dead`)
+- **Startup banner** — ASCII logo with version, port, wiki, and PID on `synthadoc serve`; plain-text version served at `GET /`
 - **Multi-wiki** — unlimited isolated wikis, each on its own port
 - **OpenTelemetry** — traces, metrics, structured logs; OTLP export optional
 - **Cross-platform** — Windows, Linux, macOS
@@ -623,10 +625,13 @@ Edit `<wiki-root>/AGENTS.md` to give the LLM domain-specific instructions — wh
 
 ---
 
-## v2 Roadmap
+## v0.2 Roadmap
+
+Target: week of 2026-04-25.
 
 | Feature | Notes |
 |---------|-------|
+| **Web search skill** | Full `WebSearchSkill` implementation — `synthadoc ingest "search for: <query>"` fetches and compiles top results |
 | **Web UI** | Browser-based dashboard; view pages, run jobs, inspect contradictions without Obsidian |
 | **Vector search + re-ranking** | `fastembed` (already an optional dependency); replaces BM25-only with hybrid BM25 + vector |
 | **Graph-aware retrieval** | Multi-hop queries traverse the wikilink graph, not just single-page BM25 hits |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,10 @@ dev = [
 [project.scripts]
 synthadoc = "synthadoc.cli.main:app"
 
-[project.entry-points."synthadoc.skills"]
-pdf      = "synthadoc.skills.pdf:PdfSkill"
-url      = "synthadoc.skills.url:UrlSkill"
-markdown = "synthadoc.skills.markdown:MarkdownSkill"
-docx     = "synthadoc.skills.docx:DocxSkill"
-xlsx     = "synthadoc.skills.xlsx:XlsxSkill"
-image    = "synthadoc.skills.image:ImageSkill"
+# Built-in skills are discovered automatically via folder scan (_BUILTIN_SKILLS_DIR).
+# Community / pip-installed skills declare their skill folder path here:
+# [project.entry-points."synthadoc.skills"]
+# my_skill = "/absolute/path/to/my_skill_folder"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/synthadoc/cli/logo.py
+++ b/synthadoc/cli/logo.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Paul Chen / axoviq.com
+"""Terminal banner and web index for Synthadoc."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# ──────────────────────────────────────────────
+#  ASCII art — open book inside a circular badge
+# ──────────────────────────────────────────────
+_LOGO = r"""
+      .-+###############+-.
+    .##                   ##.
+   ##    .----.   .----.    ##
+  ##    /######\ /######\    ##
+  ##    |######| |######|    ##
+  ##    | [SD] | | wiki |    ##
+  ##    |######| |######|    ##
+  ##    \######/ \######/    ##
+   ##    '----'   '----'    ##
+    '##                   ##'
+      '-+###############+-'
+"""
+
+# Name banner (plain ASCII, no font rendering issues)
+_NAME = r"""
+  +--------------------------------------------+
+  |   S Y N T H A D O C                       |
+  |   Domain-agnostic LLM wiki engine          |
+  +--------------------------------------------+
+"""
+
+# ──────────────────────────────────────────────
+#  ANSI helpers
+# ──────────────────────────────────────────────
+_GREEN  = "\033[32m"
+_CYAN   = "\033[36m"
+_YELLOW = "\033[33m"
+_WHITE  = "\033[97m"
+_DIM    = "\033[2m"
+_BOLD   = "\033[1m"
+_RESET  = "\033[0m"
+
+
+def _color_supported() -> bool:
+    if os.environ.get("NO_COLOR") or os.environ.get("TERM") == "dumb":
+        return False
+    return hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def _c(code: str, text: str, use_color: bool) -> str:
+    return f"{code}{text}{_RESET}" if use_color else text
+
+
+# ──────────────────────────────────────────────
+#  Public API
+# ──────────────────────────────────────────────
+def print_banner(
+    port: int,
+    wiki: str,
+    version: str = "0.1.0",
+    mode: str = "HTTP + MCP",
+) -> None:
+    """Print the startup banner to stdout."""
+    use_color = _color_supported()
+
+    logo_lines = _LOGO.strip("\n").splitlines()
+    info_lines = [
+        _c(_BOLD + _WHITE,  f"  S Y N T H A D O C  {version}", use_color),
+        _c(_DIM,            f"  {'-' * 32}", use_color),
+        _c(_CYAN,           "  Domain-agnostic LLM wiki engine", use_color),
+        "",
+        _c(_WHITE,          f"  Mode:  {mode}", use_color),
+        _c(_WHITE,          f"  Port:  {port}", use_color),
+        _c(_WHITE,          f"  Wiki:  {wiki}", use_color),
+        _c(_WHITE,          f"  PID:   {os.getpid()}", use_color),
+        "",
+        _c(_DIM,            "  https://github.com/paulmchen/synthadoc", use_color),
+    ]
+
+    # Pad shorter list so we can zip
+    n = max(len(logo_lines), len(info_lines))
+    logo_lines += [""] * (n - len(logo_lines))
+    info_lines += [""] * (n - len(info_lines))
+
+    logo_width = max(len(l) for l in logo_lines)
+
+    print()
+    for logo_line, info_line in zip(logo_lines, info_lines):
+        colored_logo = _c(_GREEN, f"{logo_line:<{logo_width}}", use_color)
+        print(f"  {colored_logo}    {info_line}")
+    print()
+
+
+def banner_text(version: str = "0.1.0") -> str:
+    """Return the plain-text banner (no ANSI) for README / web index."""
+    logo_lines = _LOGO.strip("\n").splitlines()
+    name_lines = _NAME.strip("\n").splitlines()
+
+    lines: list[str] = []
+    lines.append("")
+    lines.extend(logo_lines)
+    lines.append("")
+    lines.extend(name_lines)
+    lines.append(f"  Version {version}  —  Domain-agnostic LLM wiki engine")
+    lines.append("  https://github.com/paulmchen/synthadoc")
+    lines.append("")
+    return "\n".join(lines)

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -120,13 +120,16 @@ def serve_cmd(
 
     _check_network(provider)
 
+    from synthadoc.cli.logo import print_banner
+    mode = "MCP (stdio)" if mcp_only else "HTTP" if http_only else "HTTP + MCP"
+    print_banner(port=effective_port, wiki=str(root), mode=mode)
+
     if not mcp_only:
         from synthadoc.integration.http_server import create_app
         http_app = create_app(wiki_root=root)
-        typer.echo(f"HTTP API running on http://127.0.0.1:{effective_port}")
-        uvicorn.run(http_app, host="127.0.0.1", port=effective_port)
+        uvicorn.run(http_app, host="127.0.0.1", port=effective_port,
+                    log_level="warning")
     else:
         from synthadoc.integration.mcp_server import create_mcp_server
         mcp = create_mcp_server(wiki_root=root)
-        typer.echo("MCP server running (stdio transport)")
         mcp.run()

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -97,6 +97,25 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
         allow_headers=["Content-Type"],
     )
 
+    @app.get("/", response_class=Response)
+    async def index():
+        from synthadoc.cli.logo import banner_text
+        import synthadoc
+        text = banner_text(version=synthadoc.__version__)
+        text += (
+            f"  Endpoints\n"
+            f"  ---------------------------------\n"
+            f"  GET  /health          liveness probe\n"
+            f"  GET  /status          wiki stats\n"
+            f"  POST /jobs/ingest     enqueue ingest job\n"
+            f"  POST /jobs/lint       enqueue lint job\n"
+            f"  GET  /jobs            list jobs\n"
+            f"  GET  /jobs/{{id}}       job detail\n"
+            f"  POST /query           query the wiki\n"
+            f"  GET  /lint/report     orphans + contradictions\n"
+        )
+        return Response(content=text, media_type="text/plain; charset=utf-8")
+
     @app.get("/health")
     async def health():
         return {"status": "ok"}


### PR DESCRIPTION
 ## Summary

  - **Startup banner** — ASCII logo printed on `synthadoc serve`; engine health,
    port, wiki, and PID displayed alongside the art; `GET /` returns plain-text
    version for quick reference via curl
  - **pyproject.toml** — removed stale flat-file skill entry-points (built-ins
    now discovered via folder scan); added comment for community skill convention
  - **README** — updated to v0.1/v0.2 versioning; feature list reflects skills v2,
    Obsidian plugin improvements, banner, and job-state semantics
  - **docs/design.md** — version 0.1, new Obsidian Plugin section, skills system
    rewritten for folder-based model, job states clarified, v0.2 roadmap

  ## This completes v0.1

  All features are committed and tested:
  - 172 Python tests passing
  - 26 TypeScript plugin tests passing

  ## Release plan
  - **v0.1** — this PR (target: 2026-04-18)
  - **v0.2** — web search full implementation (target: 2026-04-25)

  ## Test plan
  - [ ] `pytest` — 172 passed
  - [ ] `npm run test` in `obsidian-plugin/` — 26 passed
  - [ ] `synthadoc serve` shows banner on startup
  - [ ] `curl http://127.0.0.1:7070/` returns plain-text banner + endpoint list