### PR TITLE
 feat: synthadoc v0.1 release — skill system, Obsidian plugin, web search, demo polish, and serve improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For full architecture details, data models, API reference, and plugin developmen
 - **Cost guards** — configurable soft-warn and hard-gate USD thresholds
 - **Hook system** — shell commands on `on_ingest_complete` and `on_lint_complete` lifecycle events; blocking or background; context passed as JSON on stdin; community hook library in [`hooks/`](hooks/)
 - **Job queue** — SQLite-backed, persistent, retry with exponential backoff; non-retryable errors (`failed`) distinguished from exhausted-retry errors (`dead`)
-- **Startup banner** — ASCII logo with version, port, wiki, and PID on `synthadoc serve`; plain-text version served at `GET /`
+- **Startup banner** — ASCII logo with version, port, wiki, and PID on `synthadoc serve`; plain-text version served at `GET /`; `--background` flag detaches the server and returns the shell immediately (logs → file only)
 - **Multi-wiki** — unlimited isolated wikis, each on its own port
 - **OpenTelemetry** — traces, metrics, structured logs; OTLP export optional
 - **Cross-platform** — Windows, Linux, macOS
@@ -341,8 +341,12 @@ synthadoc demo list
 ### Running the server
 
 ```bash
-# Start HTTP API + job worker
+# Start HTTP API + job worker (foreground — terminal stays attached)
 synthadoc serve -w my-wiki
+
+# Detach to background — banner shown, then shell is released
+# All logs go to <wiki>/.synthadoc/logs/synthadoc.log
+synthadoc serve -w my-wiki --background
 
 # Custom port
 synthadoc serve -w my-wiki --port 7071

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -269,16 +269,28 @@ In **Graph view** (`Ctrl/Cmd+G`) you should see 10 interconnected nodes. The `in
 ### Step 1 — Start the server
 
 The server must be running before any ingest, query, or lint command can execute.
-Open a dedicated terminal and leave it running throughout the demo:
+
+**Option A — Background mode (recommended):** the banner is shown and the shell is immediately released. All logs go to `<wiki>/.synthadoc/logs/synthadoc.log`. Use the same terminal for all subsequent commands.
+
+```
+synthadoc serve -w history-of-computing --background
+```
+
+After ~1.5 seconds you will see:
+
+```
+Server running in background
+  PID   <pid>
+  Port  7070
+  Logs  C:\Users\you\wikis\history-of-computing\.synthadoc\logs\synthadoc.log
+
+To stop: taskkill /PID <pid> /F
+```
+
+**Option B — Foreground mode:** the server runs in this terminal and logs print live. Open a second terminal for all subsequent commands.
 
 ```
 synthadoc serve -w history-of-computing
-```
-
-Expected output:
-
-```
-HTTP API running on http://127.0.0.1:7070
 ```
 
 ![synthadoc serve startup](synthadoc-serve.png)
@@ -286,8 +298,6 @@ HTTP API running on http://127.0.0.1:7070
 The banner confirms the port, wiki path, and PID. If you see
 `Warning: TAVILY_API_KEY is not set`, web search jobs will not work — set the key
 before Step 10 if you plan to use that feature.
-
-Use a **second terminal** for all commands below. All plugin commands are now active.
 
 > **Obsidian ribbon:** The ribbon is the narrow vertical icon strip on the far left edge of
 > the Obsidian window. Once the Synthadoc plugin is enabled, the Synthadoc book icon

--- a/docs/design.md
+++ b/docs/design.md
@@ -564,7 +564,7 @@ synthadoc
 ├── install <name> --target <dir> [--demo]
 ├── uninstall <name>
 ├── demo list
-├── serve [-w wiki] [--port N] [--mcp-only] [--http-only] [--verbose]
+├── serve [-w wiki] [--port N] [--background] [--mcp-only] [--http-only] [--verbose]
 ├── ingest <source> [-w wiki] [--batch] [--file manifest] [--force] [--analyse-only]
 ├── query "<question>" [-w wiki] [--save]
 ├── lint
@@ -954,6 +954,7 @@ Root logger (level: DEBUG)
 │   Level  : cfg.logs.level (default INFO); overridden to DEBUG if --verbose
 │   Format : "HH:MM:SS LEVEL  logger — message"
 │   Target : stderr
+│   Note   : suppressed when --background spawns the detached child process
 │
 └── File handler (RotatingFileHandler)
     Level  : DEBUG always
@@ -963,6 +964,8 @@ Root logger (level: DEBUG)
 ```
 
 Suppressed to WARNING: `httpx`, `httpcore`, `uvicorn.access`, `anthropic`, `openai`.
+
+**Background mode (`--background` / `-b`):** the parent process prints the startup banner, spawns a detached child process (`pythonw.exe` on Windows, `start_new_session=True` on Unix), and exits — returning the shell to the user. The child runs without a console handler; all output goes to the file handler only. PID is written to `<wiki-root>/.synthadoc/server.pid`.
 
 ### Log record fields
 

--- a/synthadoc/__main__.py
+++ b/synthadoc/__main__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Paul Chen / axoviq.com
+"""Allows running synthadoc as a module: python -m synthadoc <command>"""
+from synthadoc.cli.main import app
+
+app()

--- a/synthadoc/cli/logo.py
+++ b/synthadoc/cli/logo.py
@@ -33,7 +33,7 @@ _NAME = r"""
 
 from synthadoc import __version__ as _VERSION
 
-_REPO_URL = "https://github.com/Axoviq-ai/synthadoc"
+_DEFAULT_SERVER_URL = "http://127.0.0.1:7070"
 
 # ──────────────────────────────────────────────
 #  ANSI helpers
@@ -80,7 +80,7 @@ def print_banner(
         _c(_WHITE,          f"  Wiki:  {wiki}", use_color),
         _c(_WHITE,          f"  PID:   {os.getpid()}", use_color),
         "",
-        _c(_DIM,            f"  {_REPO_URL}", use_color),
+        _c(_DIM,            f"  http://127.0.0.1:{port}", use_color),
     ]
 
     # Pad shorter list so we can zip
@@ -108,6 +108,6 @@ def banner_text(version: str = _VERSION) -> str:
     lines.append("")
     lines.extend(name_lines)
     lines.append(f"  Version {version}  —  Domain-agnostic LLM wiki engine")
-    lines.append(f"  {_REPO_URL}")
+    lines.append(f"  {_DEFAULT_SERVER_URL}")
     lines.append("")
     return "\n".join(lines)

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import os
 import socket
+import sys
+import time
+import subprocess
 from pathlib import Path
 from typing import Optional
 
@@ -11,6 +14,9 @@ import typer
 
 from synthadoc.cli.main import app
 from synthadoc.cli.install import resolve_wiki_path
+
+# Internal env var set on the detached child to suppress duplicate banner output.
+_NO_BANNER_ENV = "_SYNTHADOC_NO_BANNER"
 
 _PROVIDER_HOSTS = {
     "anthropic": ("api.anthropic.com", 443),
@@ -74,6 +80,57 @@ def _check_network(provider: str) -> None:
         )
 
 
+def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path) -> None:
+    """Detach the server as a background process and return to the shell."""
+    # Reconstruct child command from the current interpreter + script path,
+    # dropping --background / -b so the child runs in foreground mode.
+    executable = sys.argv[0]
+    child_args = [a for a in sys.argv[1:] if a not in ("--background", "-b")]
+    cmd = [executable] + child_args
+
+    env = {**os.environ, _NO_BANNER_ENV: "1"}
+
+    popen_kwargs: dict = dict(
+        args=cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        env=env,
+    )
+    if sys.platform == "win32":
+        # Keep the child alive after the parent exits on Windows.
+        DETACHED_PROCESS = 0x00000008
+        CREATE_NEW_PROCESS_GROUP = 0x00000200
+        popen_kwargs["creationflags"] = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(**popen_kwargs)
+
+    # Persist PID so the user (or a stop command) can terminate the server.
+    pid_path = wiki_root / ".synthadoc" / "server.pid"
+    pid_path.write_text(str(proc.pid), encoding="utf-8")
+
+    # Brief pause — detect immediate crashes before telling the user it worked.
+    time.sleep(1.5)
+    if proc.poll() is not None:
+        typer.echo(
+            f"\nError: background server exited immediately (code {proc.returncode}).\n"
+            f"Check logs: {log_path}",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    typer.echo(
+        f"\nServer running in background\n"
+        f"  PID   {proc.pid}\n"
+        f"  Port  {effective_port}\n"
+        f"  Logs  {log_path}\n"
+        f"\nTo stop: kill {proc.pid}"
+        + (f"  (or: taskkill /PID {proc.pid} /F)" if sys.platform == "win32" else "")
+    )
+
+
 @app.command("serve")
 def serve_cmd(
     wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
@@ -83,6 +140,9 @@ def serve_cmd(
     http_only: bool = typer.Option(False, "--http-only"),
     verbose: bool = typer.Option(False, "--verbose", "-v",
         help="Set console log level to DEBUG (file always logs DEBUG)."),
+    background: bool = typer.Option(False, "--background", "-b",
+        help="Detach the server to the background. Banner is shown then the shell is released; "
+             "all subsequent logs go to the wiki log file."),
 ):
     """Start MCP + HTTP API servers (localhost only).
 
@@ -137,9 +197,15 @@ def serve_cmd(
 
     _check_network(provider)
 
-    from synthadoc.cli.logo import print_banner
-    mode = "MCP (stdio)" if mcp_only else "HTTP" if http_only else "HTTP + MCP"
-    print_banner(port=effective_port, wiki=str(root), mode=mode)
+    if not os.environ.get(_NO_BANNER_ENV):
+        from synthadoc.cli.logo import print_banner
+        mode = "MCP (stdio)" if mcp_only else "HTTP" if http_only else "HTTP + MCP"
+        print_banner(port=effective_port, wiki=str(root), mode=mode)
+
+    if background:
+        log_path = root / ".synthadoc" / "logs" / "synthadoc.log"
+        _spawn_background(root, effective_port, log_path)
+        return
 
     if not mcp_only:
         from synthadoc.integration.http_server import create_app

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -82,31 +82,34 @@ def _check_network(provider: str) -> None:
 
 def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path) -> None:
     """Detach the server as a background process and return to the shell."""
-    # Reconstruct child command from the current interpreter + script path,
-    # dropping --background / -b so the child runs in foreground mode.
-    executable = sys.argv[0]
-    child_args = [a for a in sys.argv[1:] if a not in ("--background", "-b")]
-    cmd = [executable] + child_args
+    # Strip --background / -b from the forwarded args.
+    server_args = [a for a in sys.argv[1:] if a not in ("--background", "-b")]
 
-    env = {**os.environ, _NO_BANNER_ENV: "1"}
-
-    popen_kwargs: dict = dict(
-        args=cmd,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        stdin=subprocess.DEVNULL,
-        env=env,
-    )
     if sys.platform == "win32":
-        # CREATE_NO_WINDOW: child gets no console — it won't keep the parent's
-        # console window locked after the parent exits.
-        # CREATE_NEW_PROCESS_GROUP: child gets its own signal group so Ctrl-C
-        # in the parent terminal doesn't propagate to the server.
-        popen_kwargs["creationflags"] = (
-            subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
+        # pythonw.exe runs Python with no console window at all — the child
+        # process has zero console association, so the parent's CMD/PowerShell
+        # window returns to the prompt as soon as the parent exits.
+        pythonw = Path(sys.executable).with_name("pythonw.exe")
+        interpreter = str(pythonw) if pythonw.exists() else sys.executable
+        cmd = [interpreter, "-m", "synthadoc"] + server_args
+        popen_kwargs: dict = dict(
+            args=cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            env={**os.environ, _NO_BANNER_ENV: "1"},
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
         )
     else:
-        popen_kwargs["start_new_session"] = True
+        cmd = [sys.argv[0]] + server_args
+        popen_kwargs = dict(
+            args=cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            env={**os.environ, _NO_BANNER_ENV: "1"},
+            start_new_session=True,
+        )
 
     proc = subprocess.Popen(**popen_kwargs)
 

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -98,10 +98,13 @@ def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path) -> N
         env=env,
     )
     if sys.platform == "win32":
-        # Keep the child alive after the parent exits on Windows.
-        DETACHED_PROCESS = 0x00000008
-        CREATE_NEW_PROCESS_GROUP = 0x00000200
-        popen_kwargs["creationflags"] = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
+        # CREATE_NO_WINDOW: child gets no console — it won't keep the parent's
+        # console window locked after the parent exits.
+        # CREATE_NEW_PROCESS_GROUP: child gets its own signal group so Ctrl-C
+        # in the parent terminal doesn't propagate to the server.
+        popen_kwargs["creationflags"] = (
+            subprocess.CREATE_NO_WINDOW | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
     else:
         popen_kwargs["start_new_session"] = True
 


### PR DESCRIPTION
 What

  Ships the complete synthadoc v0.1 feature set: a folder-based skill plugin system, live Tavily web search, a full-featured Obsidian plugin,
   a packaged demo wiki, and a round of pre-release bug fixes and polish including background server mode.

  Why

  v0.1 needs to be demonstrable end-to-end — ingest from any source type, query, lint, view in Obsidian, and audit — without requiring the
  user to touch source code or fight environment issues.

  Changes

  Skill system
  - Refactored flat skill files into folder-based plugin structure (skills/<name>/SKILL.md + scripts/main.py)
  - Added skills/registry.py with mtime-based cache and parse_skill_md
  - New skills: web_search (Tavily), pptx, xlsx/csv; all existing skills migrated to folder layout
  - SkillAgent two-pass dispatch: extension match before intent match — fixes Scribd/IEEE URLs routing to PDF skill
  - URL skill: browser User-Agent header to reduce 403s; cleaner PermissionError on remaining 403s
  - Web search: filter bot-blocked and paywalled domains (Quora, Medium, Reddit, IEEE, ACM, etc.) before queuing jobs

  Obsidian plugin
  - Added JobsModal with live job list, status badges, and backdrop-click protection
  - Added WebSearchModal and IngestUrlModal; all modals now block backdrop clicks
  - Auto-resolve lint command added to command palette
  - Rebuilt main.js shipped to vault

  Server
  - --background / -b flag: prints banner then detaches server; shell returns immediately
  - Uses pythonw.exe -m synthadoc on Windows (zero console association); start_new_session=True on Unix
  - PID written to <wiki>/.synthadoc/server.pid; logs go to file only in background mode
  - Added synthadoc/__main__.py so package is runnable via python -m synthadoc

  Demo and packaging
  - Moved demo from examples/ to synthadoc/demos/ — now included in wheel installs
  - synthadoc install history-of-computing --demo works from a pip-installed package
  - Full demo wiki with pre-built pages, raw sources (PDF, PNG, PPTX, XLSX), dashboard, README

  Orphan detection
  - WikiPage gains orphan: bool frontmatter field; lint agent writes it after each run
  - Obsidian dashboard uses WHERE orphan = true instead of file.inlinks (race-prone)
  - Strip wikilink aliases ([[slug|Display Text]]) before slug normalisation; exclude dashboard from orphan list

  Bug fixes
  - PDF skill: FileNotFoundError propagates instead of being wrapped in ValueError
  - MCP server removed from v0.1 docs (code intact; deferred post-v0.1)

  Docs
  - Full demo walkthrough in docs/demo-guide.md with screenshots (serve, query, jobs, audit, graph view)
  - Background serve mode documented in README, demo-guide (Step 1 Option A/B), and design.md
  - README: comparison table, architecture diagram, what's-included list, CLI examples

  Other
  - synthadoc audit history/cost/events CLI
  - ASCII startup banner (synthadoc/cli/logo.py)
  - hooks/ with git-auto-commit.py example and README
  - Expanded test coverage: ingest agent, lint agent, audit CLI, skill registry, web search, providers