### PR TITLE
 feat(v0.1): skills system, multi-provider LLM, audit CLI, error codes, background serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,32 @@ $env:TAVILY_API_KEY = "tvly-…"
 synthadoc --version
 ```
 
+### Step 6 — Start the Synthadoc engine
+
+The engine must be running before you can ingest sources or run queries. Start it against the demo wiki (install it first if you haven't — see the Quick-Start Guide below):
+
+```bash
+# Foreground — keeps the terminal; logs stream to the console
+synthadoc serve -w history-of-computing
+
+# Background — releases the terminal; logs go to the wiki log file
+synthadoc serve -w history-of-computing --background
+```
+
+The server binds to `http://127.0.0.1:7070` by default. Leave it running while you work — the Obsidian plugin, CLI ingest commands, and query commands all talk to it.
+
+To stop a background server:
+
+```bash
+# Linux / macOS
+kill <PID>
+
+# Windows (PowerShell or cmd.exe)
+taskkill /PID <PID> /F
+```
+
+The PID is printed when the background server starts and saved to `<wiki-root>/.synthadoc/server.pid`.
+
 ---
 
 ## Quick-Start Guide

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Synthadoc — Design Document
 
-**Version:** 0.1 (updated 2026-04-11)  
+**Version:** 0.1 (updated 2026-04-12)  
 **Audience:** Product users who want to understand how the system works; developers adding features, skills, and plugins.
 
 ---
@@ -636,6 +636,37 @@ Registry stored at `~/.synthadoc/wikis.json`:
 }
 ```
 
+### Error codes
+
+Every user-facing error carries a stable code in the format `[ERR-<CATEGORY>-<NNN>]`. Codes are printed to stderr and embedded in job `error` fields, making them greppable in logs.
+
+**File:** `synthadoc/errors.py`
+
+| Code | Meaning |
+|------|---------|
+| `ERR-SRV-001` | No server listening for the requested wiki |
+| `ERR-SRV-002` | Port already bound by another process |
+| `ERR-SRV-003` | Server returned a 4xx/5xx HTTP response |
+| `ERR-SRV-004` | Background server process exited immediately |
+| `ERR-WIKI-001` | Wiki root directory does not exist |
+| `ERR-WIKI-002` | Directory exists but missing `wiki/` subfolder |
+| `ERR-WIKI-003` | `wiki/` directory is not writable |
+| `ERR-WIKI-004` | Install target already exists on disk |
+| `ERR-WIKI-005` | Unknown demo template name |
+| `ERR-WIKI-006` | Name not in `~/.synthadoc/wikis.json` |
+| `ERR-CFG-001` | Required API key environment variable not set |
+| `ERR-CFG-002` | Provider name not recognised |
+| `ERR-SKILL-001` | No skill matched the source string |
+| `ERR-SKILL-002` | Required pip package for skill not installed |
+| `ERR-SKILL-003` | URL returned 403 (bot/paywall protection) |
+| `ERR-SKILL-004` | `TAVILY_API_KEY` not set for web search |
+| `ERR-INGEST-001` | Source file or directory not found |
+| `ERR-INGEST-002` | Source file exists but is empty |
+| `ERR-INGEST-003` | `--batch` target is not a directory |
+| `ERR-JOB-001` | Job ID does not exist in `jobs.db` |
+
+**CLI errors** go through the `cli_error(code, message, hint)` helper, which prints `[ERR-XXX-NNN] message` to stderr with an optional hint line and exits with code 1. **Agent and skill errors** embed the code directly in the exception message string so it surfaces in the job `error` field.
+
 ---
 
 ## 11. Configuration
@@ -1222,3 +1253,7 @@ Five providers supported: `anthropic`, `openai`, `gemini`, `groq`, `ollama`. Gem
 ### Web search intent matching
 
 All five intent phrases (`search for`, `find on the web`, `look up`, `web search`, `browse`) are now matched by a single compiled regex (`_INTENT_RE`) that strips the prefix from the query sent to Tavily. The colon after the phrase is optional — `search for quantum computing` and `search for: quantum computing` are both handled correctly.
+
+### Error code system
+
+Every user-facing error now carries a stable code in the format `[ERR-<CATEGORY>-<NNN>]` (e.g. `[ERR-SRV-001]`). The central registry lives in `synthadoc/errors.py`. CLI errors go through the `cli_error()` helper; agent and skill errors embed the code in the exception message so it surfaces in the job `error` field. See [Section 10 — CLI](#10-cli) for the full code table.

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -18,7 +18,7 @@ _GLOBAL_SKILLS_DIR = Path.home() / ".synthadoc" / "skills"
 
 class SkillNotFoundError(Exception):
     def __init__(self, source: str, available: list[str] = None):
-        msg = f"[SKILL-001] No skill matched: {source!r}."
+        msg = f"[ERR-SKILL-001] No skill matched: {source!r}."
         if available:
             msg += f" Available: {', '.join(sorted(available))}"
         super().__init__(msg)
@@ -148,7 +148,7 @@ class SkillAgent:
                 importlib.metadata.distribution(dist_name)
             except importlib.metadata.PackageNotFoundError:
                 raise ImportError(
-                    f"[SKILL-002] Skill '{meta.name}' requires '{pkg}' — run: pip install {pkg}"
+                    f"[ERR-SKILL-002] Skill '{meta.name}' requires '{pkg}' — run: pip install {pkg}"
                 )
 
     async def extract(self, source: str) -> ExtractedContent:

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -18,7 +18,7 @@ _GLOBAL_SKILLS_DIR = Path.home() / ".synthadoc" / "skills"
 
 class SkillNotFoundError(Exception):
     def __init__(self, source: str, available: list[str] = None):
-        msg = f"No skill for: {source!r}."
+        msg = f"[SKILL-001] No skill matched: {source!r}."
         if available:
             msg += f" Available: {', '.join(sorted(available))}"
         super().__init__(msg)
@@ -148,7 +148,7 @@ class SkillAgent:
                 importlib.metadata.distribution(dist_name)
             except importlib.metadata.PackageNotFoundError:
                 raise ImportError(
-                    f"Skill '{meta.name}' requires '{pkg}' — run: pip install {pkg}"
+                    f"[SKILL-002] Skill '{meta.name}' requires '{pkg}' — run: pip install {pkg}"
                 )
 
     async def extract(self, source: str) -> ExtractedContent:

--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -9,6 +9,7 @@ import typer
 
 from synthadoc.config import load_config
 from synthadoc.cli.install import resolve_wiki_path
+from synthadoc import errors as E
 
 
 def server_url(wiki: str) -> str:
@@ -28,8 +29,8 @@ def get(wiki: str, path: str, **params) -> dict:
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.HTTPStatusError as e:
-        typer.echo(f"Server error: {e.response.status_code} {e.response.text}", err=True)
-        raise typer.Exit(1)
+        E.cli_error(E.SRV_HTTP_ERROR,
+                    f"Server returned {e.response.status_code}: {e.response.text.strip()}")
 
 
 def post(wiki: str, path: str, body: dict) -> dict:
@@ -41,8 +42,8 @@ def post(wiki: str, path: str, body: dict) -> dict:
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.HTTPStatusError as e:
-        typer.echo(f"Server error: {e.response.status_code} {e.response.text}", err=True)
-        raise typer.Exit(1)
+        E.cli_error(E.SRV_HTTP_ERROR,
+                    f"Server returned {e.response.status_code}: {e.response.text.strip()}")
 
 
 def delete(wiki: str, path: str) -> dict:
@@ -54,15 +55,13 @@ def delete(wiki: str, path: str) -> dict:
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.HTTPStatusError as e:
-        typer.echo(f"Server error: {e.response.status_code} {e.response.text}", err=True)
-        raise typer.Exit(1)
+        E.cli_error(E.SRV_HTTP_ERROR,
+                    f"Server returned {e.response.status_code}: {e.response.text.strip()}")
 
 
 def _no_server(wiki: str) -> None:
-    typer.echo(
-        f"\nError: no synthadoc server is running for wiki '{wiki}'.\n"
-        f"Start it with:\n"
-        f"  synthadoc serve -w {wiki}\n",
-        err=True,
+    E.cli_error(
+        E.SRV_NOT_RUNNING,
+        f"No synthadoc server is running for wiki '{wiki}'.",
+        f"Start it with:\n  synthadoc serve -w {wiki}",
     )
-    raise typer.Exit(1)

--- a/synthadoc/cli/ingest.py
+++ b/synthadoc/cli/ingest.py
@@ -27,13 +27,14 @@ def ingest_cmd(
     """Enqueue a source for ingestion. Requires synthadoc serve to be running."""
     sources = []
     if batch and source:
+        from synthadoc import errors as E
         p = Path(source)
         if not p.exists():
-            typer.echo(f"Error: directory not found: {p.resolve()}", err=True)
-            raise typer.Exit(1)
+            E.cli_error(E.INGEST_NOT_FOUND, f"Directory not found: {p.resolve()}")
         if not p.is_dir():
-            typer.echo(f"Error: {p.resolve()} is not a directory. Use --batch with a folder.", err=True)
-            raise typer.Exit(1)
+            E.cli_error(E.INGEST_NOT_DIR,
+                        f"{p.resolve()} is not a directory.",
+                        "Use --batch with a folder path.")
         sources = [str(f) for f in p.rglob("*") if f.is_file() and f.suffix in _SUPPORTED]
         if not sources:
             typer.echo(

--- a/synthadoc/cli/install.py
+++ b/synthadoc/cli/install.py
@@ -11,6 +11,7 @@ from typing import Optional
 import typer
 
 from synthadoc.cli.main import app
+from synthadoc import errors as E
 
 _REGISTRY = Path.home() / ".synthadoc" / "wikis.json"
 
@@ -68,30 +69,28 @@ def install_cmd(
         if name in registry:
             entry = registry[name]
             kind = f"demo ({entry['demo']})" if entry.get("demo") else "wiki"
-            typer.echo(
-                f"'{name}' is already installed as a {kind} at {dest}.\n"
-                f"To reinstall, run: synthadoc uninstall {name}  then install again.",
-                err=True,
+            E.cli_error(
+                E.WIKI_ALREADY_EXISTS,
+                f"'{name}' is already installed as a {kind} at {dest}.",
+                f"To reinstall: synthadoc uninstall {name}  then install again.",
             )
         else:
-            typer.echo(
-                f"Error: '{name}' already exists at {dest} but is not tracked by synthadoc.\n"
+            E.cli_error(
+                E.WIKI_ALREADY_EXISTS,
+                f"'{name}' already exists at {dest} but is not tracked by synthadoc.",
                 f"It may be a leftover from a previous install. To remove it:\n"
                 f"  rm -rf \"{dest}\"    # Linux / macOS\n"
                 f"  Remove-Item -Recurse -Force \"{dest}\"    # Windows PowerShell\n"
                 f"Then run install again.",
-                err=True,
             )
-        raise typer.Exit(1)
 
     if demo:
         if name not in _DEMOS:
-            typer.echo(
-                f"Error: no demo template named '{name}'.\n"
+            E.cli_error(
+                E.WIKI_DEMO_NOT_FOUND,
+                f"No demo template named '{name}'.",
                 f"Available demos: {', '.join(_DEMOS)}",
-                err=True,
             )
-            raise typer.Exit(1)
         shutil.copytree(_DEMOS[name], dest)
         # Ensure operational directories exist — the demo template may not include
         # empty dirs (git doesn't track them) and shutil.copytree won't create them.
@@ -124,15 +123,14 @@ def uninstall_cmd(
     registry = _read_registry()
 
     if name not in registry:
-        typer.echo(
-            f"Wiki '{name}' is not in the registry — it may have already been uninstalled,\n"
-            f"or it was never installed via `synthadoc install`.\n"
+        E.cli_error(
+            E.WIKI_NOT_REGISTERED,
+            f"Wiki '{name}' is not in the registry.",
+            f"It may have already been uninstalled or was never installed via `synthadoc install`.\n"
             f"If the directory still exists, remove it manually:\n"
             f"  rm -rf <path-to-wiki>    # Linux / macOS\n"
             f"  Remove-Item -Recurse -Force <path-to-wiki>    # Windows PowerShell",
-            err=True,
         )
-        raise typer.Exit(1)
 
     dest = Path(registry[name]["path"])
 

--- a/synthadoc/cli/lint.py
+++ b/synthadoc/cli/lint.py
@@ -65,8 +65,8 @@ def lint_report(
 
     wiki_dir = resolve_wiki_path(wiki) / "wiki"
     if not wiki_dir.exists():
-        typer.echo(f"Error: wiki directory not found at {wiki_dir}", err=True)
-        raise typer.Exit(1)
+        from synthadoc import errors as E
+        E.cli_error(E.WIKI_NOT_FOUND, f"Wiki directory not found: {wiki_dir}")
 
     pages = list(wiki_dir.glob("*.md"))
 

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -14,6 +14,7 @@ import typer
 
 from synthadoc.cli.main import app
 from synthadoc.cli.install import resolve_wiki_path
+from synthadoc import errors as E
 
 # Internal env var set on the detached child to suppress duplicate banner output.
 _NO_BANNER_ENV = "_SYNTHADOC_NO_BANNER"
@@ -31,34 +32,37 @@ def _check_port(port: int) -> None:
         try:
             s.bind(("127.0.0.1", port))
         except OSError:
-            raise SystemExit(
-                f"\nError: port {port} is already in use.\n"
-                f"Another synthadoc server (or a different process) is listening on that port.\n\n"
+            E.cli_error(
+                E.SRV_PORT_IN_USE,
+                f"Port {port} is already in use.",
                 f"  Option 1 — Stop the existing process and retry.\n"
                 f"  Option 2 — Use a different port:\n"
                 f"               synthadoc serve -w <wiki> --port {port + 1}\n"
-                f"             (update the Server URL in the Obsidian plugin settings to match)\n"
+                f"             (update the Server URL in the Obsidian plugin settings to match)",
             )
 
 
 def _check_wiki(root: Path) -> None:
     """Fail early if the wiki directory is missing or incomplete."""
     if not root.exists():
-        raise SystemExit(
-            f"\nError: wiki directory not found: {root}\n"
+        E.cli_error(
+            E.WIKI_NOT_FOUND,
+            f"Wiki directory not found: {root}",
             f"Run 'synthadoc install <name> --target <dir>' to create a wiki,\n"
-            f"or check that the --wiki name matches a registered wiki.\n"
+            f"or check that the --wiki name matches a registered wiki.",
         )
     wiki_dir = root / "wiki"
     if not wiki_dir.is_dir():
-        raise SystemExit(
-            f"\nError: {root} does not look like a synthadoc wiki (missing wiki/ subfolder).\n"
-            f"If this is a new wiki, run 'synthadoc install' to set it up properly.\n"
+        E.cli_error(
+            E.WIKI_INVALID,
+            f"{root} does not look like a synthadoc wiki (missing wiki/ subfolder).",
+            "If this is a new wiki, run 'synthadoc install' to set it up properly.",
         )
     if not os.access(wiki_dir, os.W_OK):
-        raise SystemExit(
-            f"\nError: wiki directory is not writable: {wiki_dir}\n"
-            f"Check file permissions.\n"
+        E.cli_error(
+            E.WIKI_NOT_WRITABLE,
+            f"Wiki directory is not writable: {wiki_dir}",
+            "Check file permissions.",
         )
 
 
@@ -120,12 +124,11 @@ def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path) -> N
     # Brief pause — detect immediate crashes before telling the user it worked.
     time.sleep(1.5)
     if proc.poll() is not None:
-        typer.echo(
-            f"\nError: background server exited immediately (code {proc.returncode}).\n"
+        E.cli_error(
+            E.SRV_BG_CRASH,
+            f"Background server exited immediately (code {proc.returncode}).",
             f"Check logs: {log_path}",
-            err=True,
         )
-        raise typer.Exit(1)
 
     typer.echo(
         f"\nServer running in background\n"

--- a/synthadoc/errors.py
+++ b/synthadoc/errors.py
@@ -19,36 +19,36 @@ JOB    Job management errors (not found)
 from __future__ import annotations
 
 # ── Server ────────────────────────────────────────────────────────────────────
-SRV_NOT_RUNNING  = "SRV-001"   # No server listening for the requested wiki
-SRV_PORT_IN_USE  = "SRV-002"   # Port already bound by another process
-SRV_HTTP_ERROR   = "SRV-003"   # Server returned a 4xx/5xx response
-SRV_BG_CRASH     = "SRV-004"   # Background server process exited immediately
+SRV_NOT_RUNNING  = "ERR-SRV-001"   # No server listening for the requested wiki
+SRV_PORT_IN_USE  = "ERR-SRV-002"   # Port already bound by another process
+SRV_HTTP_ERROR   = "ERR-SRV-003"   # Server returned a 4xx/5xx response
+SRV_BG_CRASH     = "ERR-SRV-004"   # Background server process exited immediately
 
 # ── Wiki ──────────────────────────────────────────────────────────────────────
-WIKI_NOT_FOUND       = "WIKI-001"  # Wiki root directory does not exist
-WIKI_INVALID         = "WIKI-002"  # Directory exists but missing wiki/ subfolder
-WIKI_NOT_WRITABLE    = "WIKI-003"  # wiki/ directory is not writable
-WIKI_ALREADY_EXISTS  = "WIKI-004"  # Install target already exists on disk
-WIKI_DEMO_NOT_FOUND  = "WIKI-005"  # Unknown demo template name
-WIKI_NOT_REGISTERED  = "WIKI-006"  # Name not in ~/.synthadoc/wikis.json
+WIKI_NOT_FOUND       = "ERR-WIKI-001"  # Wiki root directory does not exist
+WIKI_INVALID         = "ERR-WIKI-002"  # Directory exists but missing wiki/ subfolder
+WIKI_NOT_WRITABLE    = "ERR-WIKI-003"  # wiki/ directory is not writable
+WIKI_ALREADY_EXISTS  = "ERR-WIKI-004"  # Install target already exists on disk
+WIKI_DEMO_NOT_FOUND  = "ERR-WIKI-005"  # Unknown demo template name
+WIKI_NOT_REGISTERED  = "ERR-WIKI-006"  # Name not in ~/.synthadoc/wikis.json
 
 # ── Config / Environment ──────────────────────────────────────────────────────
-CFG_MISSING_API_KEY  = "CFG-001"   # Required env var (API key) not set
-CFG_UNKNOWN_PROVIDER = "CFG-002"   # Provider name not recognised
+CFG_MISSING_API_KEY  = "ERR-CFG-001"   # Required env var (API key) not set
+CFG_UNKNOWN_PROVIDER = "ERR-CFG-002"   # Provider name not recognised
 
 # ── Skills ────────────────────────────────────────────────────────────────────
-SKILL_NOT_FOUND   = "SKILL-001"  # No skill matched the source string
-SKILL_MISSING_DEP = "SKILL-002"  # Required pip package not installed
-SKILL_URL_BLOCKED = "SKILL-003"  # URL returned 403 (bot/paywall protection)
-SKILL_WEB_NO_KEY  = "SKILL-004"  # TAVILY_API_KEY not set for web search
+SKILL_NOT_FOUND   = "ERR-SKILL-001"  # No skill matched the source string
+SKILL_MISSING_DEP = "ERR-SKILL-002"  # Required pip package not installed
+SKILL_URL_BLOCKED = "ERR-SKILL-003"  # URL returned 403 (bot/paywall protection)
+SKILL_WEB_NO_KEY  = "ERR-SKILL-004"  # TAVILY_API_KEY not set for web search
 
 # ── Ingest ────────────────────────────────────────────────────────────────────
-INGEST_NOT_FOUND  = "INGEST-001"  # Source file or directory not found
-INGEST_EMPTY      = "INGEST-002"  # Source file exists but is empty
-INGEST_NOT_DIR    = "INGEST-003"  # --batch target exists but is not a directory
+INGEST_NOT_FOUND  = "ERR-INGEST-001"  # Source file or directory not found
+INGEST_EMPTY      = "ERR-INGEST-002"  # Source file exists but is empty
+INGEST_NOT_DIR    = "ERR-INGEST-003"  # --batch target exists but is not a directory
 
 # ── Jobs ──────────────────────────────────────────────────────────────────────
-JOB_NOT_FOUND = "JOB-001"   # Job ID does not exist in jobs.db
+JOB_NOT_FOUND = "ERR-JOB-001"   # Job ID does not exist in jobs.db
 
 
 def cli_error(code: str, message: str, hint: str = "") -> None:

--- a/synthadoc/errors.py
+++ b/synthadoc/errors.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Paul Chen / axoviq.com
+"""Synthadoc error code registry.
+
+Every user-facing error carries a short, stable code so that errors can be
+searched, documented, and handled programmatically.
+
+Format: <CATEGORY>-<NNN>
+
+Categories
+----------
+SRV    Server lifecycle errors (not running, port conflict, HTTP errors)
+WIKI   Wiki filesystem errors (not found, invalid structure, not writable)
+CFG    Configuration / environment errors (missing API key, bad provider)
+SKILL  Skill dispatch and execution errors (not found, missing dep, blocked)
+INGEST Ingest source errors (file not found, empty, wrong type)
+JOB    Job management errors (not found)
+"""
+from __future__ import annotations
+
+# ── Server ────────────────────────────────────────────────────────────────────
+SRV_NOT_RUNNING  = "SRV-001"   # No server listening for the requested wiki
+SRV_PORT_IN_USE  = "SRV-002"   # Port already bound by another process
+SRV_HTTP_ERROR   = "SRV-003"   # Server returned a 4xx/5xx response
+SRV_BG_CRASH     = "SRV-004"   # Background server process exited immediately
+
+# ── Wiki ──────────────────────────────────────────────────────────────────────
+WIKI_NOT_FOUND       = "WIKI-001"  # Wiki root directory does not exist
+WIKI_INVALID         = "WIKI-002"  # Directory exists but missing wiki/ subfolder
+WIKI_NOT_WRITABLE    = "WIKI-003"  # wiki/ directory is not writable
+WIKI_ALREADY_EXISTS  = "WIKI-004"  # Install target already exists on disk
+WIKI_DEMO_NOT_FOUND  = "WIKI-005"  # Unknown demo template name
+WIKI_NOT_REGISTERED  = "WIKI-006"  # Name not in ~/.synthadoc/wikis.json
+
+# ── Config / Environment ──────────────────────────────────────────────────────
+CFG_MISSING_API_KEY  = "CFG-001"   # Required env var (API key) not set
+CFG_UNKNOWN_PROVIDER = "CFG-002"   # Provider name not recognised
+
+# ── Skills ────────────────────────────────────────────────────────────────────
+SKILL_NOT_FOUND   = "SKILL-001"  # No skill matched the source string
+SKILL_MISSING_DEP = "SKILL-002"  # Required pip package not installed
+SKILL_URL_BLOCKED = "SKILL-003"  # URL returned 403 (bot/paywall protection)
+SKILL_WEB_NO_KEY  = "SKILL-004"  # TAVILY_API_KEY not set for web search
+
+# ── Ingest ────────────────────────────────────────────────────────────────────
+INGEST_NOT_FOUND  = "INGEST-001"  # Source file or directory not found
+INGEST_EMPTY      = "INGEST-002"  # Source file exists but is empty
+INGEST_NOT_DIR    = "INGEST-003"  # --batch target exists but is not a directory
+
+# ── Jobs ──────────────────────────────────────────────────────────────────────
+JOB_NOT_FOUND = "JOB-001"   # Job ID does not exist in jobs.db
+
+
+def cli_error(code: str, message: str, hint: str = "") -> None:
+    """Print a categorised error and exit with code 1.
+
+    Only call from CLI-layer code. Agents and skills raise standard Python
+    exceptions (with the error code embedded in the message string).
+
+    Parameters
+    ----------
+    code:
+        One of the constants defined in this module, e.g. ``SRV_NOT_RUNNING``.
+    message:
+        Human-readable description of what went wrong.
+    hint:
+        Optional follow-up text (suggested fix, next step).
+    """
+    import typer
+    lines = [f"\n[{code}] {message}"]
+    if hint:
+        lines.append(hint)
+    lines.append("")
+    typer.echo("\n".join(lines), err=True)
+    raise typer.Exit(1)

--- a/synthadoc/providers/__init__.py
+++ b/synthadoc/providers/__init__.py
@@ -4,30 +4,24 @@ from __future__ import annotations
 import os
 from synthadoc.config import Config, AgentConfig
 from synthadoc.providers.base import LLMProvider
+from synthadoc import errors as E
 
 
 def _require_env(var: str, provider: str, url: str) -> str:
     value = os.environ.get(var, "").strip()
     if not value:
-        raise SystemExit(
-            f"\nError: {var} is not set.\n"
-            f"synthadoc uses {provider} as its LLM provider.\n\n"
+        E.cli_error(
+            E.CFG_MISSING_API_KEY,
+            f"{var} is not set. synthadoc uses {provider} as its LLM provider.",
             f"  1. Get your API key at: {url}\n"
             f"  2. Set it for the current session:\n"
-            f"       Linux / macOS (bash/zsh):\n"
-            f"         export {var}=<your-key>\n"
-            f"       Windows cmd.exe:\n"
-            f"         set {var}=<your-key>\n"
-            f"       Windows PowerShell:\n"
-            f"         $env:{var}='<your-key>'\n\n"
-            f"  3. To set it permanently (survives terminal restarts):\n"
+            f"       Linux / macOS:   export {var}=<your-key>\n"
+            f"       Windows cmd.exe: set {var}=<your-key>\n"
+            f"       PowerShell:      $env:{var}='<your-key>'\n"
+            f"  3. To persist across sessions:\n"
             f"       Linux / macOS:  echo 'export {var}=<your-key>' >> ~/.bashrc\n"
             f"       Windows:        [System.Environment]::SetEnvironmentVariable('{var}', '<your-key>', 'User')\n"
-            f"                       (run in PowerShell, then reopen all terminals)\n\n"
-            f"  Note: variables set in one terminal session (cmd.exe / PowerShell / bash)\n"
-            f"  are not visible in other sessions until set permanently.\n\n"
-            f"  Alternatively, set provider = \"ollama\" in .synthadoc/config.toml\n"
-            f"  to use a local model with no API key required.\n"
+            f"  Alternatively, set provider = \"ollama\" in .synthadoc/config.toml to use a local model.",
         )
     return value
 
@@ -63,4 +57,5 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
     if name == "ollama":
         from synthadoc.providers.ollama import OllamaProvider
         return OllamaProvider(config=agent_cfg)
-    raise ValueError(f"Unknown provider: {name!r}")
+    E.cli_error(E.CFG_UNKNOWN_PROVIDER, f"Unknown provider: {name!r}",
+                "Supported providers: anthropic, openai, gemini, groq, ollama")

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -23,7 +23,7 @@ class UrlSkill(BaseSkill):
             resp = await client.get(source)
             if resp.status_code == 403:
                 raise PermissionError(
-                    f"[SKILL-003] URL blocked (403 Forbidden): {source} — "
+                    f"[ERR-SKILL-003] URL blocked (403 Forbidden): {source} — "
                     "site requires a browser or login. Try a different source."
                 )
             resp.raise_for_status()

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -23,7 +23,7 @@ class UrlSkill(BaseSkill):
             resp = await client.get(source)
             if resp.status_code == 403:
                 raise PermissionError(
-                    f"URL blocked (403 Forbidden): {source} — "
+                    f"[SKILL-003] URL blocked (403 Forbidden): {source} — "
                     "site requires a browser or login. Try a different source."
                 )
             resp.raise_for_status()

--- a/synthadoc/skills/web_search/scripts/main.py
+++ b/synthadoc/skills/web_search/scripts/main.py
@@ -42,7 +42,7 @@ class WebSearchSkill(BaseSkill):
         api_key = os.environ.get("TAVILY_API_KEY", "").strip()
         if not api_key:
             raise EnvironmentError(
-                "[SKILL-004] TAVILY_API_KEY is not set. Get a free key at https://tavily.com "
+                "[ERR-SKILL-004] TAVILY_API_KEY is not set. Get a free key at https://tavily.com "
                 "and set it with: export TAVILY_API_KEY=<your-key>"
             )
         max_results = int(

--- a/synthadoc/skills/web_search/scripts/main.py
+++ b/synthadoc/skills/web_search/scripts/main.py
@@ -42,7 +42,7 @@ class WebSearchSkill(BaseSkill):
         api_key = os.environ.get("TAVILY_API_KEY", "").strip()
         if not api_key:
             raise EnvironmentError(
-                "TAVILY_API_KEY is not set. Get a free key at https://tavily.com "
+                "[SKILL-004] TAVILY_API_KEY is not set. Get a free key at https://tavily.com "
                 "and set it with: export TAVILY_API_KEY=<your-key>"
             )
         max_results = int(

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -80,24 +80,29 @@ def _make_cfg(provider: str, model: str) -> "Config":
     return Config(agents=AgentsConfig(default=AgentConfig(provider=provider, model=model)))
 
 
-def test_make_provider_missing_anthropic_key_exits(monkeypatch):
-    """make_provider must raise SystemExit with a helpful message when key is absent."""
+def test_make_provider_missing_anthropic_key_exits(monkeypatch, capsys):
+    """make_provider must exit with a helpful message when key is absent."""
+    import click
     from synthadoc.providers import make_provider
     monkeypatch.setenv("ANTHROPIC_API_KEY", "")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(click.exceptions.Exit) as exc_info:
         make_provider("ingest", _make_cfg("anthropic", "claude-opus-4-6"))
-    msg = str(exc_info.value)
-    assert "ANTHROPIC_API_KEY" in msg
-    assert "console.anthropic.com" in msg
+    assert exc_info.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "ANTHROPIC_API_KEY" in err
+    assert "console.anthropic.com" in err
+    assert "ERR-CFG-001" in err
 
 
-def test_make_provider_missing_openai_key_exits(monkeypatch):
+def test_make_provider_missing_openai_key_exits(monkeypatch, capsys):
     """Same early-exit behaviour for OpenAI provider."""
+    import click
     from synthadoc.providers import make_provider
     monkeypatch.setenv("OPENAI_API_KEY", "")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(click.exceptions.Exit) as exc_info:
         make_provider("ingest", _make_cfg("openai", "gpt-4o"))
-    assert "OPENAI_API_KEY" in str(exc_info.value)
+    assert exc_info.value.exit_code == 1
+    assert "OPENAI_API_KEY" in capsys.readouterr().err
 
 
 def test_make_provider_ollama_requires_no_key(monkeypatch):
@@ -109,22 +114,28 @@ def test_make_provider_ollama_requires_no_key(monkeypatch):
     assert isinstance(provider, OllamaProvider)
 
 
-def test_make_provider_missing_gemini_key_exits(monkeypatch):
+def test_make_provider_missing_gemini_key_exits(monkeypatch, capsys):
+    import click
     from synthadoc.providers import make_provider
     monkeypatch.setenv("GEMINI_API_KEY", "")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(click.exceptions.Exit) as exc_info:
         make_provider("ingest", _make_cfg("gemini", "gemini-2.0-flash"))
-    assert "GEMINI_API_KEY" in str(exc_info.value)
-    assert "aistudio.google.com" in str(exc_info.value)
+    assert exc_info.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "GEMINI_API_KEY" in err
+    assert "aistudio.google.com" in err
 
 
-def test_make_provider_missing_groq_key_exits(monkeypatch):
+def test_make_provider_missing_groq_key_exits(monkeypatch, capsys):
+    import click
     from synthadoc.providers import make_provider
     monkeypatch.setenv("GROQ_API_KEY", "")
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(click.exceptions.Exit) as exc_info:
         make_provider("ingest", _make_cfg("groq", "llama-3.3-70b-versatile"))
-    assert "GROQ_API_KEY" in str(exc_info.value)
-    assert "console.groq.com" in str(exc_info.value)
+    assert exc_info.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "GROQ_API_KEY" in err
+    assert "console.groq.com" in err
 
 
 def test_make_provider_gemini_uses_openai_provider_with_base_url(monkeypatch):
@@ -145,10 +156,13 @@ def test_make_provider_groq_uses_openai_provider_with_base_url(monkeypatch):
     assert "groq" in str(provider._client.base_url)
 
 
-def test_unknown_provider_raises_value_error():
+def test_unknown_provider_raises_value_error(capsys):
+    import click
     from synthadoc.providers import make_provider
-    with pytest.raises((ValueError, SystemExit)):
+    with pytest.raises(click.exceptions.Exit) as exc_info:
         make_provider("ingest", _make_cfg("unknown_llm", "some-model"))
+    assert exc_info.value.exit_code == 1
+    assert "ERR-CFG-002" in capsys.readouterr().err
 
 
 def test_config_rejects_unknown_provider():


### PR DESCRIPTION
What

  Deliver the complete v0.1 feature set: a plugin-based skills system, multi-provider LLM support, audit/cost CLI commands, a lightweight
  error code registry, and a background server mode.

  Why

  v0.1 milestone — transforms the initial prototype into a shippable release with extensible architecture, operational observability, and a
  polished user experience from install to first ingest.

  Changes

  Skills system overhaul
  - Refactored all skills from flat .py files into self-describing plugin directories (SKILL.md, scripts/main.py) — pdf, url, markdown, docx,
   xlsx, pptx, image, web_search
  - Added synthadoc/skills/registry.py with SKILL.md parsing and a JSON registry cache
  - SkillAgent rewritten with two-pass dispatch (extension match → intent match) to prevent URL path words from triggering wrong skills
  - New web_search skill (Tavily API) with bot-blocked domain filtering and fan-out child sources

  Error code system
  - New synthadoc/errors.py — central registry of 20 stable ERR-<CATEGORY>-NNN codes across SRV, WIKI, CFG, SKILL, INGEST, JOB categories
  - cli_error() helper used across all CLI commands; agent/skill exceptions embed codes in message strings

  Multi-provider LLM support
  - Five providers: anthropic, openai, gemini, groq, ollama
  - Gemini and Groq reuse OpenAIProvider with a base_url override

  CLI additions
  - synthadoc audit history / cost / events — query audit.db directly
  - synthadoc serve --background / -b — detach server using pythonw.exe on Windows, start_new_session on Unix; prints PID and saves to
  server.pid
  - synthadoc/__main__.py added to support python -m synthadoc
  - cli/logo.py — ASCII banner with dynamic port and server URL

  Obsidian plugin
  - Web search modal (Synthadoc: Web search... command palette entry)
  - Jobs modal for live job status
  - Backdrop-click fix to prevent closing all modals unintentionally

  Demo wiki
  - history-of-computing demo with 10 pre-built pages and 4 raw sources (PDF, XLSX, PPTX, PNG)

  Docs
  - README fully rewritten with installation steps (including new Step 6 — start server), Quick-Start Guide, and command reference
  - docs/design.md updated with error code table, background serve, skills plugin architecture, and v0.1 feature reference
  - docs/demo-guide.md full walkthrough added

  Tests
  - New test suites: test_ingest_agent, test_skill_agent, test_registry, test_web_search, test_audit_cli
  - Provider tests updated to assert click.exceptions.Exit and check stderr for error codes