### PR TITLE
Issues found in MacOS + doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Get a free key at [tavily.com](https://tavily.com). Without it, web search jobs 
 ```bash
 git clone https://github.com/paulmchen/synthadoc.git
 cd synthadoc
-pip3 install -e .
+pip3 install -e ".[dev]"
 ```
 
 ### Step 2 — Run the Python test suite

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Get a free key at [tavily.com](https://tavily.com). Without it, web search jobs 
 ```bash
 git clone https://github.com/paulmchen/synthadoc.git
 cd synthadoc
-pip install -e ".[dev]"
+pip3 install -e .
 ```
 
 ### Step 2 — Run the Python test suite

--- a/synthadoc/cli/install.py
+++ b/synthadoc/cli/install.py
@@ -144,6 +144,13 @@ def install_cmd(
         # Ensure operational directories exist — the demo template may not include
         # empty dirs (git doesn't track them) and shutil.copytree won't create them.
         (dest / ".synthadoc" / "logs").mkdir(parents=True, exist_ok=True)
+        # Write config.toml — .synthadoc/ is git-ignored so it can't be bundled
+        # in the demo template; generate it here the same way init_wiki does.
+        from synthadoc.cli._init import _CONFIG_TOML
+        (dest / ".synthadoc" / "config.toml").write_text(
+            _CONFIG_TOML.format(domain=domain, port=effective_port),
+            encoding="utf-8", newline="\n",
+        )
     else:
         from synthadoc.cli._init import init_wiki
         init_wiki(dest, domain, port=effective_port)

--- a/tests/core/test_hooks.py
+++ b/tests/core/test_hooks.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
-import json, time, pytest
+import json, sys, time, pytest
 from synthadoc.core.hooks import HookExecutor
+
+_PY = sys.executable
 
 
 def test_hook_receives_json_context(tmp_path):
@@ -10,7 +12,7 @@ def test_hook_receives_json_context(tmp_path):
     script.write_text(
         f"import sys,json\ndata=json.load(sys.stdin)\n"
         f"open(r'{output}','w').write(json.dumps(data))\n", encoding="utf-8")
-    executor = HookExecutor({"on_ingest_complete": f"python {script}"})
+    executor = HookExecutor({"on_ingest_complete": f"{_PY} {script}"})
     executor.fire("on_ingest_complete", {"event": "on_ingest_complete", "wiki": "test"})
     time.sleep(0.5)
     assert output.exists()
@@ -24,7 +26,7 @@ def test_unknown_event_is_noop():
 def test_blocking_hook_raises_on_failure(tmp_path):
     script = tmp_path / "fail.py"
     script.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
-    executor = HookExecutor({"on_ingest_complete": {"cmd": f"python {script}", "blocking": True}})
+    executor = HookExecutor({"on_ingest_complete": {"cmd": f"{_PY} {script}", "blocking": True}})
     with pytest.raises(RuntimeError, match="Hook failed"):
         executor.fire_blocking("on_ingest_complete", {"event": "on_ingest_complete"})
 
@@ -34,7 +36,7 @@ def test_nonblocking_hook_failure_logs_warning_does_not_raise(tmp_path, caplog):
     import logging, time
     script = tmp_path / "fail_nb.py"
     script.write_text("import sys; sys.exit(1)\n", encoding="utf-8")
-    executor = HookExecutor({"on_ingest_complete": f"python {script}"})
+    executor = HookExecutor({"on_ingest_complete": f"{_PY} {script}"})
     with caplog.at_level(logging.WARNING):
         executor.fire("on_ingest_complete", {"event": "on_ingest_complete"})
         time.sleep(0.5)
@@ -49,7 +51,7 @@ def test_on_job_dead_hook_fires(tmp_path):
         f"import sys, json\ndata=json.load(sys.stdin)\n"
         f"open(r'{output}','w').write(json.dumps(data))\n", encoding="utf-8"
     )
-    executor = HookExecutor({"on_dead_job": f"python {script}"})
+    executor = HookExecutor({"on_dead_job": f"{_PY} {script}"})
     executor.fire("on_dead_job", {"event": "on_dead_job", "job_id": "abc", "wiki": "test"})
     time.sleep(0.5)
     assert output.exists()


### PR DESCRIPTION
 1. tests/core/test_hooks.py — cross-platform Python interpreter
  Replaced hardcoded "python {script}" with f"{_PY} {script}" (where _PY = sys.executable) in all four test hooks. macOS only has python3 in PATH, so the subprocess
  was silently failing.

  2. synthadoc/cli/install.py — demo install missing config.toml
  When installing a demo wiki (--demo), the code copied wiki content but never wrote .synthadoc/config.toml. That file is git-ignored so it can't be bundled in the
  template. Added a step after shutil.copytree to write it the same way init_wiki does for fresh installs. Without it, any command that calls server_url() (e.g.
  status, query) immediately raises ERR-WIKI-006.

  3. Installed missing packages
  - pytest-asyncio and mcp — listed in pyproject.toml dev dependencies but not installed; caused all async tests to fail
  - respx — same situation; caused three test_url_skill_* tests to fail
  - pytest-benchmark — needed for pytest tests/performance/