### PR TITLE
feat: provider resilience, Gemini default, and gap detection fixes (v0.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,25 +217,26 @@ cd ..
 
 ### Step 4 — Set your API keys
 
-Synthadoc defaults to **Groq** as the LLM provider — it's free, fast, and requires no
-credit card. Get a key at **console.groq.com** (API Keys → Create key).
+Synthadoc defaults to **Gemini Flash** as the LLM provider — it's free, requires no
+credit card, and offers 1 million tokens per day. Get a key at
+**aistudio.google.com/app/apikey** (click "Create API key").
 
 Web search uses **Tavily** (`TAVILY_API_KEY`) — optional, only needed for
 `synthadoc ingest "search for: …"` jobs.
 
 ```bash
 # macOS / Linux — add to ~/.bashrc or ~/.zshrc to persist
-export GROQ_API_KEY=gsk_…            # default — free tier, fast Llama models
-export GEMINI_API_KEY=AIza…          # alternative free tier — 15 RPM / 1M tokens/day
+export GEMINI_API_KEY=AIza…          # default — free tier, 1M tokens/day
+export GROQ_API_KEY=gsk_…            # alternative free tier — 100K tokens/day
 export ANTHROPIC_API_KEY=sk-ant-…    # paid alternative — highest quality
 export TAVILY_API_KEY=tvly-…         # web search (optional)
 
 # Windows cmd — current session only
-set GROQ_API_KEY=gsk_…
+set GEMINI_API_KEY=AIza…
 set TAVILY_API_KEY=tvly-…
 
 # Windows cmd — permanent (open a new cmd window after running)
-setx GROQ_API_KEY gsk_…
+setx GEMINI_API_KEY AIza…
 setx TAVILY_API_KEY tvly-…
 ```
 

--- a/README.md
+++ b/README.md
@@ -217,22 +217,30 @@ cd ..
 
 ### Step 4 — Set your API keys
 
-The demo wiki defaults to using **Anthropic** (`ANTHROPIC_API_KEY`) as the LLM provider. Web search uses **Tavily** (`TAVILY_API_KEY`). You can switch to a free-tier provider (Gemini Flash or Groq) by editing `<wiki-root>/.synthadoc/config.toml` after installation.
+Synthadoc defaults to **Groq** as the LLM provider — it's free, fast, and requires no
+credit card. Get a key at **console.groq.com** (API Keys → Create key).
+
+Web search uses **Tavily** (`TAVILY_API_KEY`) — optional, only needed for
+`synthadoc ingest "search for: …"` jobs.
 
 ```bash
 # macOS / Linux — add to ~/.bashrc or ~/.zshrc to persist
-export ANTHROPIC_API_KEY=sk-ant-…    # default LLM provider for the demo
-export GEMINI_API_KEY=AIza…          # free-tier alternative — 15 RPM / 1M tokens/day
-export TAVILY_API_KEY=tvly-…         # web search (synthadoc ingest "search for: …")
+export GROQ_API_KEY=gsk_…            # default — free tier, fast Llama models
+export GEMINI_API_KEY=AIza…          # alternative free tier — 15 RPM / 1M tokens/day
+export ANTHROPIC_API_KEY=sk-ant-…    # paid alternative — highest quality
+export TAVILY_API_KEY=tvly-…         # web search (optional)
 
-# Windows cmd — current session
-set ANTHROPIC_API_KEY=sk-ant-…
+# Windows cmd — current session only
+set GROQ_API_KEY=gsk_…
 set TAVILY_API_KEY=tvly-…
 
 # Windows cmd — permanent (open a new cmd window after running)
-setx ANTHROPIC_API_KEY sk-ant-…
+setx GROQ_API_KEY gsk_…
 setx TAVILY_API_KEY tvly-…
 ```
+
+To switch provider, edit `[agents]` in `<wiki-root>/.synthadoc/config.toml` and restart
+`synthadoc serve`. See [Appendix — Switching LLM providers](docs/demo-guide.md#appendix--switching-llm-providers) for step-by-step instructions.
 
 ### Step 5 — Verify
 

--- a/docs/badges.json
+++ b/docs/badges.json
@@ -2,6 +2,6 @@
   "cli_commands": 25,
   "obsidian_commands": 15,
   "skills": 8,
-  "coverage": 83,
+  "coverage": 82,
   "coverage_color": "brightgreen"
 }

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -406,7 +406,7 @@ If the wiki doesn't cover a topic yet, Synthadoc detects the gap automatically a
 > After ingesting, re-run your query to get a richer answer.
 ```
 
-The gap is triggered when fewer than 3 pages are retrieved OR the best BM25 match scores below the configured threshold (`gap_score_threshold = 2.0` in `synthadoc.toml`). The suggested search strings are generated automatically by `SearchDecomposeAgent`.
+The gap is triggered when fewer than 3 pages are retrieved OR the best BM25 match scores below the configured threshold (`gap_score_threshold = 2.0` in `.synthadoc/config.toml`). The suggested search strings are generated automatically by `SearchDecomposeAgent`.
 
 ---
 
@@ -945,11 +945,16 @@ audit trail are provider-agnostic — switching does not require re-ingesting an
 
 | Provider    | Key env var         | Free tier                  |
 | ----------- | ------------------- | -------------------------- |
-| `anthropic` | `ANTHROPIC_API_KEY` | No                         |
-| `openai`    | `OPENAI_API_KEY`    | No                         |
-| `gemini`    | `GEMINI_API_KEY`    | Yes (15 RPM, 1M tok/day)   |
-| `groq`      | `GROQ_API_KEY`      | Yes (Llama/Mixtral models) |
-| `ollama`    | _(none)_            | Yes (fully local)          |
+| `anthropic` | `ANTHROPIC_API_KEY` | No — pay-per-token                            |
+| `openai`    | `OPENAI_API_KEY`    | No — pay-per-token                            |
+| `gemini`    | `GEMINI_API_KEY`    | Yes — 15 RPM / 1M tokens per day             |
+| `groq`      | `GROQ_API_KEY`      | Yes — fast Llama models, generous daily quota |
+| `ollama`    | _(none)_            | Yes — fully local, no rate limits             |
+
+> **Hit a quota limit?** Gemini free tier enforces a per-minute token cap that can be
+> exhausted during a long ingest session. If you see a `429 RateLimitError`, either wait
+> a few minutes and retry, or switch to Groq (Option C below) which has a larger daily
+> free quota and is faster.
 
 ### Option A — Anthropic (Claude)
 
@@ -1002,6 +1007,49 @@ default = { provider = "gemini", model = "gemini-2.0-flash" }
 ```
 
 Restart `synthadoc serve` to pick up the change.
+
+> **Gemini free tier limits:** 15 requests per minute and 1 million input tokens per day.
+> A long batch ingest can exhaust the per-minute token cap — if you see a `429` error,
+> wait 60 seconds and retry, or switch to Groq (Option C) which has a higher burst limit.
+
+### Option C — Groq (free tier, fast inference)
+
+Groq offers free API access to Llama 3 models with generous daily quotas and very fast
+inference speeds — a good fallback when Gemini quotas are exhausted.
+
+1. Go to **console.groq.com** → sign up (no credit card needed) → **API Keys** → create a key
+2. Set the key:
+
+**Windows (cmd.exe — current session):**
+
+```cmd
+set GROQ_API_KEY=gsk_your-key-here
+```
+
+**Windows (cmd.exe — permanent, survives reboot):**
+
+```cmd
+setx GROQ_API_KEY gsk_your-key-here
+```
+
+> After `setx`, open a new cmd window for the variable to take effect.
+
+**Linux / macOS:**
+
+```bash
+export GROQ_API_KEY="gsk_your-key-here"
+```
+
+3. Update the wiki config:
+
+Open `<wiki-root>/.synthadoc/config.toml` and set:
+
+```toml
+[agents]
+default = { provider = "groq", model = "llama-3.3-70b-versatile" }
+```
+
+Restart `synthadoc serve`. The banner will confirm `LLM: groq/llama-3.3-70b-versatile`.
 
 ---
 

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -95,7 +95,7 @@ plus a human-readable Markdown body for documentation.
 If you followed the README, you should already have:
 
 - **Demo wiki installed** — `synthadoc install history-of-computing --target ... --demo`
-- **LLM API key set** — `GROQ_API_KEY` (default, free) or `GEMINI_API_KEY` / `ANTHROPIC_API_KEY`
+- **LLM API key set** — `GEMINI_API_KEY` (default, free) or `GROQ_API_KEY` / `ANTHROPIC_API_KEY`
 - **Engine running** — `synthadoc serve -w history-of-computing`
 
 If any of these are missing, complete [README Steps 4–6](../README.md#step-4--set-your-api-keys) first, then come back here.
@@ -105,7 +105,7 @@ If any of these are missing, complete [README Steps 4–6](../README.md#step-4--
 > required when you ingest new sources or run lint. Web search (Step 9) additionally
 > requires `TAVILY_API_KEY` — see [Appendix — Tavily web search key](#appendix--tavily-web-search-key).
 >
-> Want to use a different LLM provider (e.g. free-tier Gemini Flash)? See
+> Want to use a different LLM provider (e.g. Groq or Anthropic)? See
 > [Appendix — Switching LLM providers](#appendix--switching-llm-providers) at the bottom
 > of this guide.
 
@@ -935,23 +935,22 @@ The directory and registry entry are both removed. There is no `--yes` flag — 
 
 ## Appendix — Switching LLM providers
 
-Synthadoc supports five LLM providers and defaults to **Groq** — free, no credit card,
-and fast. You can switch at any time by editing `<wiki-root>/.synthadoc/config.toml` and
-restarting the server. The wiki, cache, and audit trail are provider-agnostic — switching
-never requires re-ingesting anything.
+Synthadoc supports five LLM providers and defaults to **Gemini Flash** — free, no credit
+card, and 1 million tokens per day. You can switch at any time by editing
+`<wiki-root>/.synthadoc/config.toml` and restarting the server. The wiki, cache, and
+audit trail are provider-agnostic — switching never requires re-ingesting anything.
 
 | Provider    | Key env var         | Free tier                  |
 | ----------- | ------------------- | -------------------------- |
-| `groq`      | `GROQ_API_KEY`      | **Yes — default** · fast Llama models, 100K tokens/day      |
-| `gemini`    | `GEMINI_API_KEY`    | Yes — 15 RPM / 1M tokens per day                           |
+| `gemini`    | `GEMINI_API_KEY`    | **Yes — default** · 15 RPM / 1M tokens per day              |
+| `groq`      | `GROQ_API_KEY`      | Yes — fast Llama models, 100K tokens/day                    |
 | `ollama`    | _(none)_            | Yes — fully local, no rate limits                           |
 | `anthropic` | `ANTHROPIC_API_KEY` | No — pay-per-token, highest quality                         |
 | `openai`    | `OPENAI_API_KEY`    | No — pay-per-token                                          |
 
-> **Hit a quota limit?** Gemini free tier enforces a per-minute token cap that can be
+> **Hit a quota limit?** Gemini free tier enforces a 15 RPM per-minute cap that can be
 > exhausted during a long ingest session. If you see a `429 RateLimitError`, either wait
-> a few minutes and retry, or switch to Groq (Option C below) which has a larger daily
-> free quota and is faster.
+> a minute and retry, or switch to Groq (Option C below) as a fallback.
 
 ### Option A — Anthropic (Claude)
 
@@ -988,7 +987,7 @@ default = { provider = "anthropic", model = "claude-sonnet-4-6" }
 
 Restart `synthadoc serve`. The banner will confirm `LLM: anthropic/claude-sonnet-4-6`.
 
-### Option B — Google Gemini (free tier)
+### Option B — Google Gemini (free tier, default)
 
 1. Go to **aistudio.google.com/app/apikey** → create a key (free, no credit card)
 2. Set the key:
@@ -1017,13 +1016,13 @@ default = { provider = "gemini", model = "gemini-2.0-flash" }
 Restart `synthadoc serve` to pick up the change.
 
 > **Gemini free tier limits:** 15 requests per minute and 1 million input tokens per day.
-> A long batch ingest can exhaust the per-minute token cap — if you see a `429` error,
-> wait 60 seconds and retry, or switch to Groq (Option C) which has a higher burst limit.
+> A long batch ingest can exhaust the per-minute cap — if you see a `429` error, wait
+> 60 seconds and retry. For higher burst throughput, switch to Groq (Option C).
 
 ### Option C — Groq (free tier, fast inference)
 
-Groq offers free API access to Llama 3 models with generous daily quotas and very fast
-inference speeds — a good fallback when Gemini quotas are exhausted.
+Groq offers free API access to Llama 3 models with fast inference speeds — a good
+fallback when Gemini's per-minute rate limit is exhausted.
 
 1. Go to **console.groq.com** → sign up (no credit card needed) → **API Keys** → create a key
 2. Set the key:
@@ -1061,9 +1060,8 @@ Restart `synthadoc serve`. The banner will confirm `LLM: groq/llama-3.3-70b-vers
 
 > **Groq free tier limits:** 100,000 tokens per day for `llama-3.3-70b-versatile`. A
 > web search ingest fans out to ~20 URLs, each costing ~1,200 tokens — four web searches
-> can exhaust the daily quota. For heavier use, switch to Gemini (1M tokens/day) or add
-> a Groq billing method at console.groq.com. The server backs off automatically when the
-> quota is hit and resumes processing once the window resets.
+> can exhaust the daily quota. For heavier sustained use, switch back to Gemini (1M
+> tokens/day). The server backs off automatically when the quota is hit.
 
 ---
 

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -95,7 +95,7 @@ plus a human-readable Markdown body for documentation.
 If you followed the README, you should already have:
 
 - **Demo wiki installed** — `synthadoc install history-of-computing --target ... --demo`
-- **LLM API key set** — at least one of `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`
+- **LLM API key set** — `GROQ_API_KEY` (default, free) or `GEMINI_API_KEY` / `ANTHROPIC_API_KEY`
 - **Engine running** — `synthadoc serve -w history-of-computing`
 
 If any of these are missing, complete [README Steps 4–6](../README.md#step-4--set-your-api-keys) first, then come back here.
@@ -935,21 +935,18 @@ The directory and registry entry are both removed. There is no `--yes` flag — 
 
 ## Appendix — Switching LLM providers
 
-Synthadoc supports five LLM providers. The demo uses Anthropic by default, but
-**Gemini Flash is a great free-tier alternative** — 15 requests per minute and 1 million
-tokens per day at no cost, which is more than enough for demos and personal wikis.
-
-You can switch at any time by changing the `provider` line in
-`<wiki-root>/.synthadoc/config.toml` and restarting the server. The wiki, cache, and
-audit trail are provider-agnostic — switching does not require re-ingesting anything.
+Synthadoc supports five LLM providers and defaults to **Groq** — free, no credit card,
+and fast. You can switch at any time by editing `<wiki-root>/.synthadoc/config.toml` and
+restarting the server. The wiki, cache, and audit trail are provider-agnostic — switching
+never requires re-ingesting anything.
 
 | Provider    | Key env var         | Free tier                  |
 | ----------- | ------------------- | -------------------------- |
-| `anthropic` | `ANTHROPIC_API_KEY` | No — pay-per-token                            |
-| `openai`    | `OPENAI_API_KEY`    | No — pay-per-token                            |
-| `gemini`    | `GEMINI_API_KEY`    | Yes — 15 RPM / 1M tokens per day             |
-| `groq`      | `GROQ_API_KEY`      | Yes — fast Llama models, generous daily quota |
-| `ollama`    | _(none)_            | Yes — fully local, no rate limits             |
+| `groq`      | `GROQ_API_KEY`      | **Yes — default** · fast Llama models, generous daily quota |
+| `gemini`    | `GEMINI_API_KEY`    | Yes — 15 RPM / 1M tokens per day                           |
+| `ollama`    | _(none)_            | Yes — fully local, no rate limits                           |
+| `anthropic` | `ANTHROPIC_API_KEY` | No — pay-per-token, highest quality                         |
+| `openai`    | `OPENAI_API_KEY`    | No — pay-per-token                                          |
 
 > **Hit a quota limit?** Gemini free tier enforces a per-minute token cap that can be
 > exhausted during a long ingest session. If you see a `429 RateLimitError`, either wait

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -977,6 +977,17 @@ setx ANTHROPIC_API_KEY sk-ant-your-key-here
 export ANTHROPIC_API_KEY="sk-ant-your-key-here"
 ```
 
+3. Update the wiki config:
+
+Open `<wiki-root>/.synthadoc/config.toml` and set:
+
+```toml
+[agents]
+default = { provider = "anthropic", model = "claude-sonnet-4-6" }
+```
+
+Restart `synthadoc serve`. The banner will confirm `LLM: anthropic/claude-sonnet-4-6`.
+
 ### Option B — Google Gemini (free tier)
 
 1. Go to **aistudio.google.com/app/apikey** → create a key (free, no credit card)

--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -942,7 +942,7 @@ never requires re-ingesting anything.
 
 | Provider    | Key env var         | Free tier                  |
 | ----------- | ------------------- | -------------------------- |
-| `groq`      | `GROQ_API_KEY`      | **Yes — default** · fast Llama models, generous daily quota |
+| `groq`      | `GROQ_API_KEY`      | **Yes — default** · fast Llama models, 100K tokens/day      |
 | `gemini`    | `GEMINI_API_KEY`    | Yes — 15 RPM / 1M tokens per day                           |
 | `ollama`    | _(none)_            | Yes — fully local, no rate limits                           |
 | `anthropic` | `ANTHROPIC_API_KEY` | No — pay-per-token, highest quality                         |
@@ -1047,6 +1047,12 @@ default = { provider = "groq", model = "llama-3.3-70b-versatile" }
 ```
 
 Restart `synthadoc serve`. The banner will confirm `LLM: groq/llama-3.3-70b-versatile`.
+
+> **Groq free tier limits:** 100,000 tokens per day for `llama-3.3-70b-versatile`. A
+> web search ingest fans out to ~20 URLs, each costing ~1,200 tokens — four web searches
+> can exhaust the daily quota. For heavier use, switch to Gemini (1M tokens/day) or add
+> a Groq billing method at console.groq.com. The server backs off automatically when the
+> quota is hit and resumes processing once the window resets.
 
 ---
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -174,11 +174,18 @@ class QueryAgent:
             }
             _covered = {t: f for t, f in _term_doc_freq.items() if f > 0}
 
-            # Drop hyper-generic terms that appear in >60% of candidates.
+            # Drop hyper-generic terms that appear in >80% of candidates.
+            # Using 80% (not 60%) so moderately-common topic words like "partial"
+            # (present in ~60-70% of pages in a shade-focused wiki) are kept as
+            # discriminators rather than being wrongly discarded as generic.
             _n_cands = len(candidates)
-            _specific = {t: f for t, f in _covered.items() if f <= _n_cands * 0.6}
+            _specific = {t: f for t, f in _covered.items() if f <= _n_cands * 0.8}
             if not _specific:
                 _specific = _covered  # all terms are corpus-generic; use full covered set
+            # If every term in _specific appears in only one page it is too rare to
+            # discriminate topic coverage — expand to include all covered terms.
+            elif max(_specific.values()) <= 1:
+                _specific = _covered
 
             # Log the rarest specific term as a representative discriminator.
             if _specific:

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -147,17 +147,24 @@ class QueryAgent:
             if len(w) > 4 and w.lower().rstrip("s?!.,") not in _STOPWORDS
         }
 
-        # Signal 3: pick the RAREST key term among the retrieved pages as the
-        # discriminating signal.  Generic terms ("spring", "canadian") appear in
-        # almost every page of a topic-specific wiki and inflate the count; the
-        # rarest term (e.g. "vegetable" in a flower-heavy wiki) tells us whether
-        # the wiki actually has DEDICATED content on the question's main topic.
+        # Signal 3: check whether retrieved pages contain dedicated coverage of the
+        # query's specific topic words.
         #
-        # A page "covers" the topic if the discriminating term appears ≥ 3 times —
-        # a single mention in a bullet list is different from a dedicated section.
-        _MIN_TERM_FREQ = 3
+        # Generic corpus terms ("canadian", "spring", "plant") appear in nearly
+        # every page and would make every page look on-topic.  We filter them out
+        # by excluding terms whose document frequency exceeds 60% of the candidates.
+        # From the remaining "specific" terms we check whether at least 2 candidates
+        # contain ANY of them with meaningful frequency (≥ 2 occurrences).
+        #
+        # Using ANY rather than a single rarest term handles multi-aspect queries
+        # correctly: a page about "full shade" plants is on-topic for a query about
+        # "sun, partial shade, and full shade" even if it lacks the word "partial".
+        #
+        # Zero-freq terms (synonyms like "backyard" vs "garden") are excluded;
+        # they reflect vocabulary mismatch, not missing content.
+        _MIN_TERM_FREQ = 2
         if _key_terms and candidates:
-            # Count how many candidates contain each key term at all (doc frequency).
+            # Count how many candidates contain each key term (doc frequency).
             _term_doc_freq = {
                 t: sum(
                     1 for r in candidates
@@ -165,21 +172,27 @@ class QueryAgent:
                 )
                 for t in _key_terms
             }
-            # Prefer the rarest term that appears in at least one page.
-            # Zero-freq terms are often synonym mismatches (e.g. "backyard" vs "garden")
-            # rather than evidence of missing content.  Only fall back to a zero-freq
-            # term when ALL key terms are absent — that is an unambiguous content gap.
             _covered = {t: f for t, f in _term_doc_freq.items() if f > 0}
-            if _covered:
+
+            # Drop hyper-generic terms that appear in >60% of candidates.
+            _n_cands = len(candidates)
+            _specific = {t: f for t, f in _covered.items() if f <= _n_cands * 0.6}
+            if not _specific:
+                _specific = _covered  # all terms are corpus-generic; use full covered set
+
+            # Log the rarest specific term as a representative discriminator.
+            if _specific:
+                _discriminating_term = min(_specific, key=lambda t: _specific[t])
+            elif _covered:
                 _discriminating_term = min(_covered, key=lambda t: _covered[t])
             else:
                 _discriminating_term = min(_term_doc_freq, key=lambda t: _term_doc_freq[t])
 
-            # Count pages where the discriminating term appears with meaningful frequency.
+            # A page is on-topic if it mentions ANY specific term with sufficient freq.
             _pages_with_overlap = sum(
                 1 for r in candidates
                 if (p := self._store.read_page(r.slug)) and
-                   p.content.lower().count(_discriminating_term) >= _MIN_TERM_FREQ
+                   any(p.content.lower().count(t) >= _MIN_TERM_FREQ for t in _specific)
             )
         else:
             _discriminating_term = ""

--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -44,7 +44,7 @@ def get(wiki: str, path: str, **params) -> dict:
         )
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
-                    f"Server returned {e.response.status_code}: {e.response.text.strip()}")
+                    f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
 def post(wiki: str, path: str, body: dict) -> dict:
@@ -63,7 +63,7 @@ def post(wiki: str, path: str, body: dict) -> dict:
         )
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
-                    f"Server returned {e.response.status_code}: {e.response.text.strip()}")
+                    f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
 def delete(wiki: str, path: str) -> dict:
@@ -76,7 +76,15 @@ def delete(wiki: str, path: str) -> dict:
         _no_server(wiki)
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
-                    f"Server returned {e.response.status_code}: {e.response.text.strip()}")
+                    f"Server returned {e.response.status_code}: {_detail(e.response)}")
+
+
+def _detail(response: httpx.Response) -> str:
+    """Extract FastAPI's detail string from a JSON error response, or return raw text."""
+    try:
+        return response.json()["detail"]
+    except Exception:
+        return response.text.strip()
 
 
 def _no_server(wiki: str) -> None:

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -27,11 +27,11 @@ domain = "{domain}"
 port = {port}  # change this if running multiple wikis simultaneously
 
 [agents]
-default = {{ provider = "groq", model = "llama-3.3-70b-versatile" }}
+default = {{ provider = "gemini", model = "gemini-2.0-flash" }}
 # Alternatives (uncomment and restart to switch):
-# default = {{ provider = "gemini", model = "gemini-2.0-flash" }}   # free tier, 15 RPM
-# default = {{ provider = "anthropic", model = "claude-opus-4-6" }} # paid, highest quality
-# default = {{ provider = "ollama",    model = "llama3.2" }}        # fully local
+# default = {{ provider = "groq",      model = "llama-3.3-70b-versatile" }} # free tier, 100K tokens/day
+# default = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}       # paid, highest quality
+# default = {{ provider = "ollama",    model = "llama3.2" }}                 # fully local
 
 [ingest]
 max_pages_per_ingest = 15

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -27,8 +27,11 @@ domain = "{domain}"
 port = {port}  # change this if running multiple wikis simultaneously
 
 [agents]
-# default = {{ provider = "anthropic", model = "claude-opus-4-6" }}
-# lint    = {{ model = "claude-haiku-4-5" }}
+default = {{ provider = "groq", model = "llama-3.3-70b-versatile" }}
+# Alternatives (uncomment and restart to switch):
+# default = {{ provider = "gemini", model = "gemini-2.0-flash" }}   # free tier, 15 RPM
+# default = {{ provider = "anthropic", model = "claude-opus-4-6" }} # paid, highest quality
+# default = {{ provider = "ollama",    model = "llama3.2" }}        # fully local
 
 [ingest]
 max_pages_per_ingest = 15

--- a/synthadoc/cli/logo.py
+++ b/synthadoc/cli/logo.py
@@ -67,12 +67,15 @@ def print_banner(
     mode: str = "HTTP + MCP",
     provider: str = "",
     model: str = "",
+    llm_note: str = "",
 ) -> None:
     """Print the startup banner to stdout."""
     use_color = _color_supported()
 
     logo_lines = _LOGO.strip("\n").splitlines()
     llm_label = f"{provider}/{model}" if provider and model else provider or model or "unknown"
+    if llm_note:
+        llm_label = f"{llm_label} {llm_note}"
     info_lines = [
         _c(_BOLD + _WHITE,  f"  S Y N T H A D O C  {version}", use_color),
         _c(_DIM,            f"  {'-' * 32}", use_color),

--- a/synthadoc/cli/logo.py
+++ b/synthadoc/cli/logo.py
@@ -65,11 +65,14 @@ def print_banner(
     wiki: str,
     version: str = _VERSION,
     mode: str = "HTTP + MCP",
+    provider: str = "",
+    model: str = "",
 ) -> None:
     """Print the startup banner to stdout."""
     use_color = _color_supported()
 
     logo_lines = _LOGO.strip("\n").splitlines()
+    llm_label = f"{provider}/{model}" if provider and model else provider or model or "unknown"
     info_lines = [
         _c(_BOLD + _WHITE,  f"  S Y N T H A D O C  {version}", use_color),
         _c(_DIM,            f"  {'-' * 32}", use_color),
@@ -78,6 +81,7 @@ def print_banner(
         _c(_WHITE,          f"  Mode:  {mode}", use_color),
         _c(_WHITE,          f"  Port:  {port}", use_color),
         _c(_WHITE,          f"  Wiki:  {wiki}", use_color),
+        _c(_WHITE,          f"  LLM:   {llm_label}", use_color),
         _c(_WHITE,          f"  PID:   {os.getpid()}", use_color),
         "",
         _c(_DIM,            f"  http://127.0.0.1:{port}", use_color),

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -210,7 +210,9 @@ def serve_cmd(
     if not os.environ.get(_NO_BANNER_ENV):
         from synthadoc.cli.logo import print_banner
         mode = "MCP (stdio)" if mcp_only else "HTTP" if http_only else "HTTP + MCP"
-        print_banner(port=effective_port, wiki=str(root), mode=mode)
+        _agent_cfg = cfg.agents.resolve("default")
+        print_banner(port=effective_port, wiki=str(root), mode=mode,
+                     provider=_agent_cfg.provider, model=_agent_cfg.model)
 
     if background:
         log_path = root / ".synthadoc" / "logs" / "synthadoc.log"

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -213,8 +213,14 @@ def serve_cmd(
         from synthadoc.cli.logo import print_banner
         mode = "MCP (stdio)" if mcp_only else "HTTP" if http_only else "HTTP + MCP"
         _agent_cfg = cfg.agents.resolve("default")
+        _override_count = sum(
+            1 for slot in ("ingest", "query", "lint", "skill")
+            if getattr(cfg.agents, slot, None) is not None
+        )
+        _llm_note = f"(+ {_override_count} override{'s' if _override_count != 1 else ''})" if _override_count else ""
         print_banner(port=effective_port, wiki=str(root), mode=mode,
-                     provider=_agent_cfg.provider, model=_agent_cfg.model)
+                     provider=_agent_cfg.provider, model=_agent_cfg.model,
+                     llm_note=_llm_note)
 
     if background:
         log_path = root / ".synthadoc" / "logs" / "synthadoc.log"

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -22,6 +22,8 @@ _NO_BANNER_ENV = "_SYNTHADOC_NO_BANNER"
 _PROVIDER_HOSTS = {
     "anthropic": ("api.anthropic.com", 443),
     "openai":    ("api.openai.com", 443),
+    "gemini":    ("generativelanguage.googleapis.com", 443),
+    "groq":      ("api.groq.com", 443),
 }
 
 

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -376,7 +376,7 @@ def load_config(
     if not any_file_loaded:
         return Config(
             agents=AgentsConfig(
-                default=AgentConfig(provider="anthropic", model="claude-opus-4-6")
+                default=AgentConfig(provider="groq", model="llama-3.3-70b-versatile")
             ),
             web_search=WebSearchConfig(),
         )
@@ -393,8 +393,8 @@ def load_config(
     # inject built-in defaults so the rest of the build succeeds.
     if "agents" not in raw or "default" not in raw.get("agents", {}):
         raw.setdefault("agents", {})["default"] = {
-            "provider": "anthropic",
-            "model": "claude-opus-4-6",
+            "provider": "groq",
+            "model": "llama-3.3-70b-versatile",
         }
 
     return _raw_to_config(raw, source_has_agents=True)

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -376,7 +376,7 @@ def load_config(
     if not any_file_loaded:
         return Config(
             agents=AgentsConfig(
-                default=AgentConfig(provider="groq", model="llama-3.3-70b-versatile")
+                default=AgentConfig(provider="gemini", model="gemini-2.0-flash")
             ),
             web_search=WebSearchConfig(),
         )
@@ -393,8 +393,8 @@ def load_config(
     # inject built-in defaults so the rest of the build succeeds.
     if "agents" not in raw or "default" not in raw.get("agents", {}):
         raw.setdefault("agents", {})["default"] = {
-            "provider": "groq",
-            "model": "llama-3.3-70b-versatile",
+            "provider": "gemini",
+            "model": "gemini-2.0-flash",
         }
 
     return _raw_to_config(raw, source_has_agents=True)

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -6,6 +6,8 @@ import asyncio
 from pathlib import Path
 from typing import Optional
 
+import logging
+
 from synthadoc.config import Config, load_config
 from synthadoc.core.cache import CacheManager
 from synthadoc.core.cost_guard import CostGuard
@@ -18,6 +20,8 @@ from synthadoc.providers.pricing import estimate_cost
 from synthadoc.storage.log import AuditDB, LogWriter
 from synthadoc.storage.search import HybridSearch
 from synthadoc.storage.wiki import WikiStorage
+
+logger = logging.getLogger(__name__)
 
 
 class Orchestrator:
@@ -44,6 +48,21 @@ class Orchestrator:
         await self._queue.init()
         await self._audit.init()
         await self._cache.init()
+        self._log_agent_config()
+
+    def _log_agent_config(self) -> None:
+        """Log the effective provider/model for each named agent slot at startup."""
+        slots = ["default", "ingest", "query", "lint", "skill"]
+        parts = []
+        seen: dict[str, str] = {}
+        for slot in slots:
+            cfg = self._cfg.agents.resolve(slot)
+            label = f"{cfg.provider}/{cfg.model}"
+            raw = getattr(self._cfg.agents, slot, None)
+            if slot == "default" or raw is not None:
+                parts.append(f"{slot}={label}")
+                seen[slot] = label
+        logger.info("LLM agents — %s", " | ".join(parts))
 
     async def ingest(self, source: str, force: bool = False) -> str:
         """Enqueue an ingest job. The server worker loop executes it."""

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -29,22 +29,20 @@ def _classify_llm_error(exc: Exception) -> "HTTPException | None":
 
     if code == 429:
         msg = str(exc)
+        _SWITCH = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: groq, gemini, anthropic, openai, ollama)."
         if "generativelanguage.googleapis.com" in msg or "gemini" in msg.lower():
-            hint = "Gemini free-tier quota exhausted. Wait for the daily reset or switch to Groq."
+            hint = f"Gemini free-tier quota exhausted. Wait for the daily reset or switch providers. {_SWITCH}"
         elif "groq" in msg.lower():
-            hint = "Groq rate limit hit. Wait a moment and retry."
+            hint = f"Groq rate limit hit. Wait for the retry window or switch providers. {_SWITCH}"
         elif "anthropic" in msg.lower():
-            hint = "Anthropic rate limit hit. Wait a moment and retry."
+            hint = f"Anthropic rate limit hit. Wait a moment or switch providers. {_SWITCH}"
         elif "openai" in msg.lower():
-            hint = "OpenAI rate limit hit. Wait a moment and retry."
+            hint = f"OpenAI rate limit hit. Wait a moment or switch providers. {_SWITCH}"
         else:
-            hint = "LLM provider rate limit hit. Wait a moment and retry."
+            hint = f"LLM provider rate limit hit. Wait a moment or switch providers. {_SWITCH}"
         return HTTPException(
             status_code=429,
-            detail=(
-                f"LLM quota exceeded (429). {hint} "
-                "To switch providers, edit [agents] in .synthadoc/config.toml and restart the server."
-            ),
+            detail=f"LLM quota exceeded (429). {hint}",
         )
     if code == 529:
         return HTTPException(

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -20,7 +20,13 @@ _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MB
 
 def _classify_llm_error(exc: Exception) -> "HTTPException | None":
     """Return a meaningful HTTPException for known LLM API error codes, or None."""
+    # openai/anthropic SDKs set status_code directly on the exception;
+    # httpx.HTTPStatusError (used by OllamaProvider) stores it on exc.response.
     code = getattr(exc, "status_code", None)
+    if code is None:
+        resp = getattr(exc, "response", None)
+        code = getattr(resp, "status_code", None)
+
     if code == 429:
         msg = str(exc)
         if "generativelanguage.googleapis.com" in msg or "gemini" in msg.lower():
@@ -29,6 +35,8 @@ def _classify_llm_error(exc: Exception) -> "HTTPException | None":
             hint = "Groq rate limit hit. Wait a moment and retry."
         elif "anthropic" in msg.lower():
             hint = "Anthropic rate limit hit. Wait a moment and retry."
+        elif "openai" in msg.lower():
+            hint = "OpenAI rate limit hit. Wait a moment and retry."
         else:
             hint = "LLM provider rate limit hit. Wait a moment and retry."
         return HTTPException(

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -116,12 +116,22 @@ class AnalyseRequest(BaseModel):
         return v
 
 
+def _parse_retry_after(exc: Exception, default: float = 60.0) -> float:
+    """Parse 'Please try again in Xm Y.Zs' from a rate-limit error message."""
+    import re
+    m = re.search(r"Please try again in (?:(\d+)m\s*)?(\d+(?:\.\d+)?)s", str(exc))
+    if m:
+        return float(m.group(1) or 0) * 60 + float(m.group(2))
+    return default
+
+
 async def _worker_loop(orch) -> None:
     """Background task: poll jobs.db and execute pending jobs."""
-    from synthadoc.core.queue import JobStatus
+    sleep_secs = _WORKER_POLL_SECONDS
     while True:
         try:
             job = await orch.queue.dequeue()
+            sleep_secs = _WORKER_POLL_SECONDS  # reset after a successful dequeue
             if job:
                 if job.operation == "ingest":
                     source = job.payload.get("source", "")
@@ -134,10 +144,22 @@ async def _worker_loop(orch) -> None:
                 elif job.operation == "scaffold":
                     domain = job.payload.get("domain", "")
                     await orch._run_scaffold(job.id, domain=domain)
-        except Exception:
-            logger.exception("Worker loop error — job recorded in jobs.db; continuing")
+        except Exception as exc:
+            known = _classify_llm_error(exc)
+            if known and known.status_code == 429:
+                sleep_secs = _parse_retry_after(exc)
+                logger.warning(
+                    "Rate limit hit in worker — pausing %.0f s before next job. "
+                    "(%d pending jobs will wait.) %s",
+                    sleep_secs,
+                    len([j for j in asyncio.all_tasks() if not j.done()]),
+                    known.detail,
+                )
+            else:
+                logger.exception("Worker loop error — job recorded in jobs.db; continuing")
+                sleep_secs = _WORKER_POLL_SECONDS
 
-        await asyncio.sleep(_WORKER_POLL_SECONDS)
+        await asyncio.sleep(sleep_secs)
 
 
 def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAPI:

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -16,6 +16,34 @@ import re
 logger = logging.getLogger(__name__)
 
 _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _classify_llm_error(exc: Exception) -> "HTTPException | None":
+    """Return a meaningful HTTPException for known LLM API error codes, or None."""
+    code = getattr(exc, "status_code", None)
+    if code == 429:
+        msg = str(exc)
+        if "generativelanguage.googleapis.com" in msg or "gemini" in msg.lower():
+            hint = "Gemini free-tier quota exhausted. Wait for the daily reset or switch to Groq."
+        elif "groq" in msg.lower():
+            hint = "Groq rate limit hit. Wait a moment and retry."
+        elif "anthropic" in msg.lower():
+            hint = "Anthropic rate limit hit. Wait a moment and retry."
+        else:
+            hint = "LLM provider rate limit hit. Wait a moment and retry."
+        return HTTPException(
+            status_code=429,
+            detail=(
+                f"LLM quota exceeded (429). {hint} "
+                "To switch providers, edit [agents] in .synthadoc/config.toml and restart the server."
+            ),
+        )
+    if code == 529:
+        return HTTPException(
+            status_code=503,
+            detail="LLM provider temporarily overloaded (529). Retry in a moment.",
+        )
+    return None
 _WORKER_POLL_SECONDS = 2
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 _FM_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
@@ -177,6 +205,10 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
         try:
             result = await app.state.orch.query(q)
         except Exception as exc:
+            known = _classify_llm_error(exc)
+            if known:
+                logger.warning("LLM rate limit during query: %s", exc)
+                raise known from exc
             logger.exception("Query failed")
             raise HTTPException(status_code=502, detail="LLM provider unavailable") from exc
         return {
@@ -191,6 +223,10 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
         try:
             result = await app.state.orch.query(req.question)
         except Exception as exc:
+            known = _classify_llm_error(exc)
+            if known:
+                logger.warning("LLM rate limit during query: %s", exc)
+                raise known from exc
             logger.exception("Query failed")
             raise HTTPException(status_code=502, detail="LLM provider unavailable") from exc
         return {

--- a/synthadoc/providers/anthropic.py
+++ b/synthadoc/providers/anthropic.py
@@ -7,7 +7,10 @@ import anthropic as anthropic_lib
 from synthadoc.config import AgentConfig
 from synthadoc.providers.base import CompletionResponse, LLMProvider, Message
 
-_RETRYABLE = (anthropic_lib.RateLimitError, anthropic_lib.InternalServerError)
+# RateLimitError (429) is not retried — quota exhaustion needs a provider switch or wait.
+# InternalServerError covers transient 500/529 overload; retry with backoff.
+_RETRYABLE = (anthropic_lib.InternalServerError,)
+_RATE_LIMIT = (anthropic_lib.RateLimitError,)
 _MAX_RETRIES = 3
 
 
@@ -34,10 +37,12 @@ class AnthropicProvider(LLMProvider):
                 return CompletionResponse(text=text,
                                          input_tokens=resp.usage.input_tokens,
                                          output_tokens=resp.usage.output_tokens)
+            except _RATE_LIMIT:
+                raise  # quota exhaustion — propagate immediately, no retry
             except _RETRYABLE as exc:
                 last_exc = exc
                 if attempt < _MAX_RETRIES - 1:
-                    await asyncio.sleep(0)  # yield; real backoff added in orchestrator
+                    await asyncio.sleep(2 ** attempt)  # 0 s, 1 s, 2 s backoff
                 continue
             except Exception:
                 raise

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -886,6 +886,61 @@ async def test_gap_signal3_boundary_one_on_topic_page(tmp_wiki):
                        gap_score_threshold=0.01)
     with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
         result = await agent.query("What orchid plants grow well indoors?")
-    # "orchid" is the discriminating term; only 1 page has it ≥ 3 times → 1 < 2 → gap.
+    # "orchid" is the discriminating term; only 1 page has it ≥ 2 times → 1 < 2 → gap.
     assert result.knowledge_gap is True
     assert len(result.suggested_searches) >= 1
+
+
+@pytest.mark.asyncio
+async def test_no_gap_multi_aspect_query_with_generic_corpus_term(tmp_wiki):
+    """Signal 3 must not fire for a multi-aspect query when the wiki covers the topic
+    well but the corpus-dominant term ('shade') is filtered as hyper-generic.
+
+    Real-world regression: query asks about 'full sun, partial shade, and full shade'.
+    The wiki has many shade pages.  'shade' and 'plant' appear in every page (>60%
+    coverage) so they are filtered as generic.  'partial' is the rarest specific term.
+    Pages that mention 'partial' at least twice count as on-topic — if ≥ 2 pages pass,
+    no gap fires even though 'shade' was excluded from the specific-term check.
+
+    bm25_search is mocked to return the shade pages directly.
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+    # 4 pages cover partial shade explicitly; 2 are full-shade only.
+    for i in range(4):
+        store.write_page(f"partial-shade-{i}", WikiPage(
+            title=f"Partial Shade Plants {i}", tags=["shade"],
+            content=(
+                "Best plants for partial shade in Canadian gardens. "
+                "Partial shade perennials thrive under dappled light. "
+                "These shade-tolerant plants suit partial shade conditions. "
+                "Plant selection for partial shade and full shade areas."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+    for i in range(2):
+        store.write_page(f"full-shade-{i}", WikiPage(
+            title=f"Full Shade Plants {i}", tags=["shade"],
+            content=(
+                "Best plants for full shade. Hostas thrive in shade. "
+                "Shade plants for Canadian gardens. Deep shade perennials."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+    all_slugs = [f"partial-shade-{i}" for i in range(4)] + [f"full-shade-{i}" for i in range(2)]
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["best plants for full sun partial shade and full shade Canada"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text="Here are plants for each light level...",
+                           input_tokens=200, output_tokens=60),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)  # signal 2 disabled; only signal 3 can fire
+    with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
+        result = await agent.query(
+            "What are the best plants for full sun, partial shade, and full shade in a Canadian backyard?"
+        )
+    # 4 pages mention "partial" ≥ 2 times → on_topic_pages = 4 ≥ 2 → no gap.
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -29,7 +29,8 @@ async def test_anthropic_provider_complete():
 
 
 @pytest.mark.asyncio
-async def test_anthropic_provider_retries_on_rate_limit():
+async def test_anthropic_provider_propagates_rate_limit_immediately():
+    """RateLimitError must not be retried — it should propagate on the first attempt."""
     import anthropic
     cfg = AgentConfig(provider="anthropic", model="claude-haiku-4-5-20251001")
     provider = AnthropicProvider(api_key="test-key", config=cfg)
@@ -38,17 +39,12 @@ async def test_anthropic_provider_retries_on_rate_limit():
     async def flaky(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        if call_count < 3:
-            raise anthropic.RateLimitError(response=MagicMock(status_code=429), body={}, message="rate limit")
-        m = AsyncMock()
-        m.content = [AsyncMock(text="ok")]
-        m.usage = AsyncMock(input_tokens=5, output_tokens=2)
-        return m
+        raise anthropic.RateLimitError(response=MagicMock(status_code=429), body={}, message="rate limit")
 
     with patch.object(provider._client.messages, "create", side_effect=flaky):
-        result = await provider.complete(messages=[Message(role="user", content="hi")])
-    assert result.text == "ok"
-    assert call_count == 3
+        with pytest.raises(anthropic.RateLimitError):
+            await provider.complete(messages=[Message(role="user", content="hi")])
+    assert call_count == 1  # raised immediately, no retries
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
What

  Improves LLM provider resilience with meaningful rate-limit errors and worker backoff, switches the default provider to Gemini Flash, fixes two gap
  detection false positives, and adds per-agent LLM visibility at startup.

  Why

  Users hitting quota limits were getting opaque 502 errors with no guidance. The worker loop was hammering the API every 2 s after exhaustion. Gap
  detection was incorrectly flagging relevant multi-aspect queries as knowledge gaps. Gemini's 1M token/day free tier is a better default than Groq's
  100K. Operators had no way to see which LLM each agent component was using.

  Changes

  Rate limit handling
  - Return provider-specific 429 errors instead of generic 502 when LLM quota is exceeded
  - Worker loop now parses Retry-After from the error and sleeps the correct duration instead of retrying every 2 s
  - _classify_llm_error covers all five providers including Ollama (httpx.HTTPStatusError stores status_code on exc.response)
  - Anthropic RateLimitError now propagates immediately instead of being retried

  Default provider
  - Switched default from Groq → Gemini Flash (gemini-2.0-flash, 1M tokens/day)
  - Updated config.py, cli/_init.py, README.md, and docs/demo-guide.md; Groq listed as first commented alternative

  Gap detection fixes
  - Fixed false positive for multi-aspect queries (e.g. "full sun, partial shade, full shade") where the generic-term filter left only a rare corpus term
  (backyard, freq=1) as the discriminator - expanded back to all covered terms when only single-page terms survive the 80% threshold
  - Fixed false positive where zero-frequency synonyms were selected as the discriminating term

  Per-agent LLM visibility
  - orchestrator.init() logs LLM agents  - default=gemini/gemini-2.0-flash | lint=groq/... at startup
  - Banner now shows LLM: gemini/gemini-2.0-flash (+ 1 override) when any agent slot overrides the default; full detail remains in the log

  Docs
  - demo-guide.md: Gemini first in provider table, Option B marked as default, Groq reframed as burst-speed fallback; added Anthropic [agents] config
  snippet to Option A
  - README.md Step 4: GEMINI_API_KEY is now the primary key shown