### PR TITLE
[bug] synthadoc ingestion retry failed in some cases

### DIFF
--- a/docs/badges.json
+++ b/docs/badges.json
@@ -2,6 +2,6 @@
   "cli_commands": 25,
   "obsidian_commands": 15,
   "skills": 8,
-  "coverage": 82,
+  "coverage": 83,
   "coverage_color": "brightgreen"
 }

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -101,6 +101,27 @@ _VISION_PROMPT = (
 )
 
 
+def _coerce_str_list(lst: object) -> list[str]:
+    """Ensure every item in an LLM-returned list is a plain string.
+
+    Some models return entities as dicts ({"name": "Canada", "type": "location"})
+    instead of strings.  Extract the most useful field or fall back to str().
+    """
+    if not isinstance(lst, list):
+        return []
+    result = []
+    for item in lst:
+        if isinstance(item, str):
+            result.append(item)
+        elif isinstance(item, dict):
+            value = item.get("name") or item.get("value") or item.get("label") or item.get("text") or ""
+            if value:
+                result.append(str(value))
+        else:
+            result.append(str(item))
+    return [s for s in result if s.strip()]
+
+
 def _parse_json_response(text: str) -> dict:
     """Parse a JSON object from an LLM response, handling markdown code fences."""
     text = text.strip()
@@ -169,8 +190,8 @@ class IngestAgent:
             temperature=0.0,
         )
         data = _parse_json_response(resp.text)
-        data.setdefault("entities", [])
-        data.setdefault("tags", [])
+        data["entities"] = _coerce_str_list(data.get("entities", []))
+        data["tags"] = _coerce_str_list(data.get("tags", []))
         data.setdefault("summary", text[:200])
         data.setdefault("relevant", True)
         data["_tokens"] = resp.total_tokens

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -352,8 +352,8 @@ class IngestAgent:
         result.tokens_used += analysis.pop("_tokens", 0)
         # input/output split not available for the analyse call (cached via _analyse)
 
-        entities = analysis.get("entities", [])
-        tags = analysis.get("tags", [])
+        entities = _coerce_str_list(analysis.get("entities", []))
+        tags = _coerce_str_list(analysis.get("tags", []))
         summary = analysis.get("summary", text[:1500])
 
         # Fallback: if LLM entity extraction returned nothing, extract key phrases

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -4,8 +4,24 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import re
 from pathlib import Path
 from typing import Optional
+
+_BACKSLASH_URL_RE = re.compile(r'^(https?:)[/\\]{1,2}', re.IGNORECASE)
+
+
+def _normalize_url(source: str) -> str:
+    """Reconstruct a proper URL from Windows-pasted forms with backslashes.
+
+    https:\\example.com\\path  →  https://example.com/path
+    https:\\example.com\\path  →  https://example.com/path
+    https://example.com/path   →  unchanged
+    """
+    m = _BACKSLASH_URL_RE.match(source)
+    if m:
+        return m.group(1) + "//" + source[m.end():].replace("\\", "/")
+    return source
 
 from synthadoc.skills.base import BaseSkill, ExtractedContent, SkillMeta
 from synthadoc.skills.registry import build_registry_cache, parse_skill_md, SkillManifestError
@@ -113,7 +129,7 @@ class SkillAgent:
         return list(self._registry.values())
 
     def detect_skill(self, source: str) -> SkillMeta:
-        s = source.replace("\\", "/").lower()
+        s = _normalize_url(source).lower()
         is_url = s.startswith("http://") or s.startswith("https://")
         # Pass 1: extension/prefix match — takes priority over intent matching.
         # For HTTP/HTTPS sources only startswith is checked so that the url skill
@@ -169,9 +185,9 @@ class SkillAgent:
         intent phrase (e.g. 'search for', '搜索', 'browse').  Adding new
         intents to a SKILL.md automatically applies here with no code changes.
         """
-        # Normalise backslashes before the URL check so that Windows-pasted
-        # URLs like "https:\example.com\path" are not mistakenly path-resolved.
-        s = source.replace("\\", "/").lower()
+        # Normalise backslash URLs so Windows-pasted forms (e.g. "https:\example.com\path")
+        # are not mistakenly resolved as local filesystem paths.
+        s = _normalize_url(source).lower()
         if s.startswith(("http://", "https://")):
             return False
         try:

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -113,7 +113,7 @@ class SkillAgent:
         return list(self._registry.values())
 
     def detect_skill(self, source: str) -> SkillMeta:
-        s = source.lower()
+        s = source.replace("\\", "/").lower()
         is_url = s.startswith("http://") or s.startswith("https://")
         # Pass 1: extension/prefix match — takes priority over intent matching.
         # For HTTP/HTTPS sources only startswith is checked so that the url skill
@@ -169,7 +169,9 @@ class SkillAgent:
         intent phrase (e.g. 'search for', '搜索', 'browse').  Adding new
         intents to a SKILL.md automatically applies here with no code changes.
         """
-        s = source.lower()
+        # Normalise backslashes before the URL check so that Windows-pasted
+        # URLs like "https:\example.com\path" are not mistakenly path-resolved.
+        s = source.replace("\\", "/").lower()
         if s.startswith(("http://", "https://")):
             return False
         try:

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -122,8 +122,8 @@ class Orchestrator:
                 "tokens_used": result.tokens_used,
                 "cost_usd": result.cost_usd,
             })
-        except NotImplementedError as e:
-            # Skill is a known stub — fail immediately, no retry
+        except (NotImplementedError, FileNotFoundError) as e:
+            # Permanent failures — source is invalid, retry can never help
             await self._queue.fail_permanent(job_id, str(e))
         except Exception as e:
             import httpx

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -291,6 +291,11 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
         from pathlib import Path as _Path
         from synthadoc.agents.skill_agent import SkillAgent
         source = req.source
+        # Normalise backslashes so Windows-pasted URLs (e.g. "https:\example.com\path")
+        # are stored as proper URLs and are not mistakenly path-resolved.
+        _normalised = source.replace("\\", "/")
+        if _normalised.lower().startswith(("http://", "https://")):
+            source = _normalised
         if SkillAgent().needs_path_resolution(source):
             p = _Path(source)
             if not p.is_absolute():

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -291,9 +291,10 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
         from pathlib import Path as _Path
         from synthadoc.agents.skill_agent import SkillAgent
         source = req.source
-        # Normalise backslashes so Windows-pasted URLs (e.g. "https:\example.com\path")
+        # Normalise backslash URLs so Windows-pasted forms (e.g. "https:\example.com\path")
         # are stored as proper URLs and are not mistakenly path-resolved.
-        _normalised = source.replace("\\", "/")
+        from synthadoc.agents.skill_agent import _normalize_url
+        _normalised = _normalize_url(source)
         if _normalised.lower().startswith(("http://", "https://")):
             source = _normalised
         if SkillAgent().needs_path_resolution(source):

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -4,7 +4,7 @@ import hashlib
 import pytest
 import aiosqlite
 from unittest.mock import AsyncMock
-from synthadoc.agents.ingest_agent import IngestAgent, IngestResult, _slugify
+from synthadoc.agents.ingest_agent import IngestAgent, IngestResult, _slugify, _coerce_str_list
 from synthadoc.providers.base import CompletionResponse
 from synthadoc.storage.wiki import WikiStorage
 from synthadoc.storage.search import HybridSearch
@@ -609,3 +609,70 @@ async def test_ingest_preserves_wikilinks_in_update_content(tmp_wiki):
     page = store.read_page("alan-turing")
     assert "[[enigma]]" in page.content
     assert "[[bletchley-park]]" in page.content
+
+
+# ── _coerce_str_list ──────────────────────────────────────────────────────────
+
+def test_coerce_str_list_plain_strings_unchanged():
+    assert _coerce_str_list(["AI", "Canada"]) == ["AI", "Canada"]
+
+
+def test_coerce_str_list_dict_entities_extracted():
+    """Some LLMs return entities as dicts with a 'name' field."""
+    result = _coerce_str_list([
+        {"name": "Canada", "type": "location"},
+        {"name": "Llama 3", "type": "model"},
+    ])
+    assert result == ["Canada", "Llama 3"]
+
+
+def test_coerce_str_list_mixed_str_and_dict():
+    result = _coerce_str_list(["AI", {"name": "OpenAI", "type": "org"}, "safety"])
+    assert result == ["AI", "OpenAI", "safety"]
+
+
+def test_coerce_str_list_fallback_fields():
+    """Falls back to 'value', 'label', 'text' if 'name' is absent."""
+    assert _coerce_str_list([{"value": "machine learning"}]) == ["machine learning"]
+    assert _coerce_str_list([{"label": "NLP"}]) == ["NLP"]
+    assert _coerce_str_list([{"text": "deep learning"}]) == ["deep learning"]
+
+
+def test_coerce_str_list_drops_empty_strings():
+    assert _coerce_str_list(["", "AI", "  "]) == ["AI"]
+
+
+def test_coerce_str_list_non_list_input_returns_empty():
+    assert _coerce_str_list(None) == []
+    assert _coerce_str_list("not a list") == []
+    assert _coerce_str_list(42) == []
+
+
+@pytest.mark.asyncio
+async def test_analyse_coerces_dict_entities_to_strings(tmp_wiki):
+    """_analyse() must return entities as strings even if the LLM returns dicts."""
+    provider = AsyncMock()
+    provider.complete = AsyncMock(return_value=CompletionResponse(
+        text='{"entities":[{"name":"Canada","type":"location"},{"name":"Gardening"}],'
+             '"tags":[{"name":"plants"}],"summary":"Canadian gardening.","relevant":true}',
+        input_tokens=40, output_tokens=15))
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+    cache = CacheManager(tmp_wiki / ".synthadoc" / "cache.db")
+    await cache.init()
+
+    agent = IngestAgent(provider=provider, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache,
+                        max_pages=15, wiki_root=tmp_wiki)
+    result = await agent._analyse("Canadian gardening content", bust_cache=True)
+
+    assert all(isinstance(e, str) for e in result["entities"]), \
+        f"entities must all be strings, got: {result['entities']}"
+    assert all(isinstance(t, str) for t in result["tags"]), \
+        f"tags must all be strings, got: {result['tags']}"
+    assert "Canada" in result["entities"]
+    assert "plants" in result["tags"]

--- a/tests/core/test_orchestrator_cost.py
+++ b/tests/core/test_orchestrator_cost.py
@@ -176,3 +176,49 @@ async def test_orchestrator_ingest_unknown_model_uses_fallback_nonzero(tmp_wiki)
     cost = await _run_and_capture_ingest_cost(orch, input_tokens=1000, output_tokens=500)
     assert cost is not None
     assert cost > 0.0, "Unknown model must use fallback rate, not $0.00"
+
+
+# ── Permanent failure handling ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_run_ingest_file_not_found_marks_job_permanently_failed(tmp_wiki):
+    """FileNotFoundError must mark a job dead immediately with no retry.
+
+    A missing or corrupted source path can never succeed — retrying wastes
+    quota and fills logs.  fail_permanent() must be called instead of fail().
+    """
+    cfg = _cfg()
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+    await orch.init()
+
+    mock_provider = MagicMock()
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=mock_provider):
+        with patch("synthadoc.agents.ingest_agent.IngestAgent.ingest",
+                   new=AsyncMock(side_effect=FileNotFoundError("Source not found: /bad/path"))):
+            with patch.object(orch._queue, "fail_permanent", new=AsyncMock()) as mock_perm:
+                with patch.object(orch._queue, "fail", new=AsyncMock()) as mock_fail:
+                    await orch._run_ingest("job-1", "/bad/path", auto_confirm=True)
+
+    mock_perm.assert_awaited_once()
+    mock_fail.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_transient_error_uses_retryable_fail(tmp_wiki):
+    """Network timeouts must use fail() (retryable), not fail_permanent()."""
+    import httpx
+    cfg = _cfg()
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+    await orch.init()
+
+    mock_provider = MagicMock()
+    timeout_exc = httpx.ReadTimeout("timed out", request=MagicMock())
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=mock_provider):
+        with patch("synthadoc.agents.ingest_agent.IngestAgent.ingest",
+                   new=AsyncMock(side_effect=timeout_exc)):
+            with patch.object(orch._queue, "fail_permanent", new=AsyncMock()) as mock_perm:
+                with patch.object(orch._queue, "fail", new=AsyncMock()) as mock_fail:
+                    await orch._run_ingest("job-2", "https://example.com", auto_confirm=True)
+
+    mock_perm.assert_not_awaited()
+    mock_fail.assert_awaited_once()

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -85,6 +85,25 @@ def test_ingest_url_not_mangled_to_file_path(tmp_wiki):
     assert str(tmp_wiki) not in queued_source
 
 
+def test_ingest_backslash_url_is_normalised_not_path_resolved(tmp_wiki):
+    """POST /jobs/ingest with a Windows backslash URL must store a clean https:// URL.
+
+    Users sometimes paste URLs as https:\\example.com\\path (backslashes).
+    The endpoint must normalise these to forward slashes and NOT prepend the
+    wiki root — otherwise the stored source becomes an unresolvable local path.
+    """
+    from synthadoc.integration.http_server import create_app
+    backslash_url = r"https:\example.com\collections\page"
+    with patch("synthadoc.core.queue.JobQueue.enqueue",
+               new=AsyncMock(return_value="job-bs")) as mock_enqueue:
+        with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+            resp = client.post("/jobs/ingest", json={"source": backslash_url})
+    assert resp.status_code == 200
+    queued_source = mock_enqueue.call_args[0][1]["source"]
+    assert queued_source == "https://example.com/collections/page"
+    assert str(tmp_wiki) not in queued_source
+
+
 def test_retry_job_endpoint(tmp_wiki):
     """POST /jobs/{id}/retry resets the job to pending."""
     from synthadoc.integration.http_server import create_app

--- a/tests/skills/test_skill_agent.py
+++ b/tests/skills/test_skill_agent.py
@@ -123,3 +123,34 @@ def test_pip_entry_point_skill_loaded(tmp_wiki):
                return_value=[skill_dir]):
         agent = SkillAgent(wiki_root=tmp_wiki)
     assert "_pip_skill_standalone" in [s.name for s in agent.list_skills()]
+
+
+# ── Backslash URL handling ────────────────────────────────────────────────────
+# Windows users sometimes paste URLs with backslashes (https:\example.com\path).
+# Both detect_skill and needs_path_resolution must handle these correctly so the
+# source is routed to the URL skill, not mistakenly treated as a local file path.
+
+def test_detect_skill_handles_backslash_urls(tmp_wiki):
+    """URLs with backslashes must be routed to the url skill, not treated as files."""
+    from synthadoc.agents.skill_agent import SkillAgent
+    agent = SkillAgent(wiki_root=tmp_wiki)
+    assert agent.detect_skill(r"https:\example.com\page").name == "url"
+    assert agent.detect_skill(r"http:\example.com\page").name == "url"
+    assert agent.detect_skill(r"https:\example.com\path\to\article").name == "url"
+
+
+def test_needs_path_resolution_returns_false_for_backslash_urls(tmp_wiki):
+    """URLs with backslashes must not be resolved as local filesystem paths."""
+    from synthadoc.agents.skill_agent import SkillAgent
+    agent = SkillAgent(wiki_root=tmp_wiki)
+    assert agent.needs_path_resolution(r"https:\example.com\page") is False
+    assert agent.needs_path_resolution(r"http:\example.com\path") is False
+
+
+def test_needs_path_resolution_returns_true_for_relative_paths(tmp_wiki):
+    """Relative paths with no URL prefix must be flagged for path resolution."""
+    from synthadoc.agents.skill_agent import SkillAgent
+    agent = SkillAgent(wiki_root=tmp_wiki)
+    # Use paths with no extension and no skill intent keywords in the string.
+    assert agent.needs_path_resolution("raw_sources/my-transcript") is True
+    assert agent.needs_path_resolution("uploads/batch-001") is True


### PR DESCRIPTION
1. When retrying a dead job and the job status was changed to pending, but it cannot be re-run, here is the error:

22:45:17 ERROR  integration.http_server — Worker loop error — job recorded in jobs.db; continuing

Traceback (most recent call last):

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\integration\http_[server.py](http://server.py/)", line 137, in workerloop

    await orch._run_ingest([job.id](http://job.id/), source, auto_confirm=True, force=force)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\core\[orchestrator.py](http://orchestrator.py/)", line 93, in runingest

    result = await agent.ingest(source, force=force, bust_cache=force)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\agents\ingest_[agent.py](http://agent.py/)", line 246, in ingest

    raise FileNotFoundError(f"Source not found: {source}")

FileNotFoundError: Source not found: C:\Users\ladmin\wikis\yard-gardening-in-canada\https:\[wickerpark.ca](http://wickerpark.ca/)\collections\home-decor-accents-accessories-canada

22:45:19 ERROR  integration.http_server — Worker loop error — job recorded in jobs.db; continuing

Traceback (most recent call last):

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\integration\http_[server.py](http://server.py/)", line 137, in workerloop

    await orch._run_ingest([job.id](http://job.id/), source, auto_confirm=True, force=force)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\core\[orchestrator.py](http://orchestrator.py/)", line 93, in runingest

    result = await agent.ingest(source, force=force, bust_cache=force)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\agents\ingest_[agent.py](http://agent.py/)", line 246, in ingest

    raise FileNotFoundError(f"Source not found: {source}")

FileNotFoundError: Source not found: C:\Users\ladmin\wikis\yard-gardening-in-canada\https:\[wickerpark.ca](http://wickerpark.ca/)\collections\home-decor-accents-accessories-canada

22:45:22 ERROR  integration.http_server — Worker loop error — job recorded in jobs.db; continuing

Traceback (most recent call last):

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\integration\http_[server.py](http://server.py/)", line 137, in workerloop

    await orch._run_ingest([job.id](http://job.id/), source, auto_confirm=True, force=force)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\core\[orchestrator.py](http://orchestrator.py/)", line 93, in runingest

    result = await agent.ingest(source, force=force, bust_cache=force)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\agents\ingest_[agent.py](http://agent.py/)", line 246, in ingest

    raise FileNotFoundError(f"Source not found: {source}")

FileNotFoundError: Source not found: C:\Users\ladmin\wikis\yard-gardening-in-canada\https:\[wickerpark.ca](http://wickerpark.ca/)\collections\home-decor-accents-accessories-canada


2. Tried another previously dead job, and re-ran it for ingestion, and i see the different error:

23:03:57 ERROR  integration.http_server — Worker loop error — job recorded in jobs.db; continuing
Traceback (most recent call last):
  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\integration\http_[server.py](http://server.py/)", line 137, in workerloop
  await orch._run_ingest([job.id](http://job.id/), source, auto_confirm=True, force=force)
  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\core\[orchestrator.py](http://orchestrator.py/)", line 93, in runingest
    result = await agent.ingest(source, force=force, bust_cache=force)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\agents\ingest_[agent.py](http://agent.py/)", line 352, in ingest

    candidates = self._[search.bm](http://search.bm/)25_search(entities + tags, top_n=self._max_pages)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\storage\[search.py](http://search.py/)", line 60, in bm25_search

    scores = bm25.get_scores(self._tokenize(" ".join(query_terms)))

                                            ~~~~~~~~^^^^^^^^^^^^^

TypeError: sequence item 0: expected str instance, dict found

23:04:00 ERROR  integration.http_server — Worker loop error — job recorded in jobs.db; continuing

Traceback (most recent call last):

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\integration\http_[server.py](http://server.py/)", line 137, in workerloop

    await orch._run_ingest([job.id](http://job.id/), source, auto_confirm=True, force=force)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\core\[orchestrator.py](http://orchestrator.py/)", line 93, in runingest

    result = await agent.ingest(source, force=force, bust_cache=force)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\agents\ingest_[agent.py](http://agent.py/)", line 352, in ingest

    candidates = self._[search.bm](http://search.bm/)25_search(entities + tags, top_n=self._max_pages)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\storage\[search.py](http://search.py/)", line 60, in bm25_search

    scores = bm25.get_scores(self._tokenize(" ".join(query_terms)))

                                            ~~~~~~~~^^^^^^^^^^^^^

TypeError: sequence item 0: expected str instance, dict found

23:04:04 ERROR  integration.http_server — Worker loop error — job recorded in jobs.db; continuing

Traceback (most recent call last):

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\integration\http_[server.py](http://server.py/)", line 137, in workerloop

    await orch._run_ingest([job.id](http://job.id/), source, auto_confirm=True, force=force)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\core\[orchestrator.py](http://orchestrator.py/)", line 93, in runingest

    result = await agent.ingest(source, force=force, bust_cache=force)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\agents\ingest_[agent.py](http://agent.py/)", line 352, in ingest

    candidates = self._[search.bm](http://search.bm/)25_search(entities + tags, top_n=self._max_pages)

  File "C:\Users\ladmin\Documents\my_workspace\synthadoc\synthadoc\storage\[search.py](http://search.py/)", line 60, in bm25_search

    scores = bm25.get_scores(self._tokenize(" ".join(query_terms)))

                                            ~~~~~~~~^^^^^^^^^^^^^

TypeError: sequence item 0: expected str instance, dict found