### PR TITLE
fix+feat: orphan detection, query timeout, MiniMax vision, and 429 retry [v0.2.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Most knowledge-management tools retrieve and summarize at query time. Synthadoc 
 | LLM wiki vs. RAG         | Pre-compiled structured knowledge beats query-time synthesis for contradiction detection, graph traversal, and offline access                                                                                 |
 | CLI / HTTP               | A unified interface via CLI and RESTful endpoints, the system streamlines full-spectrum integration: from data ingestion and querying to automated linting, security auditing, and job orchestration          |
 | Local-first              | All data stays on your machine; localhost-only network binding; no cloud dependency except the LLM API itself                                                                                                 |
-| Provider choice          | LLM backends including free-tier Gemini and Groq, plus MiniMax for cheapest paid text rates — no single-vendor dependency                                                                                    |
+| Provider choice          | LLM backends including free-tier Gemini and Groq, plus MiniMax (cheapest paid, natively multimodal) — no single-vendor dependency                                                                           |
 
 ---
 
@@ -188,7 +188,7 @@ See [docs/design.md — Appendix A: Release Feature Index](docs/design.md#append
 | **Gemini Flash** | Yes — 15 RPM / 1M tokens/day, no credit card | Yes             | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | Groq             | Yes — rate-limited                           | No              | [console.groq.com](https://console.groq.com/keys)             |
 | Ollama           | Yes — runs locally, no key                   | Model-dependent | [ollama.com](https://ollama.com)                              |
-| MiniMax          | No — pay-per-token (cheapest text rates)     | No              | [platform.minimax.io](https://platform.minimax.io/)           |
+| MiniMax          | No — pay-per-token (cheapest text rates)     | Yes (M2.5/M2.7) | [platform.minimax.io](https://platform.minimax.io/)           |
 | Anthropic        | No                                            | Yes             | [console.anthropic.com](https://console.anthropic.com/)       |
 | OpenAI           | No                                            | Yes             | [platform.openai.com](https://platform.openai.com/api-keys)   |
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -26,8 +26,6 @@
 15. [Observability and Logging](#15-observability-and-logging)
 16. [Security](#16-security)
 17. [Plugin Development Guide](#17-plugin-development-guide)
-18. [v0.2.0 — What's New](#18-v020--whats-new)
-
 **Appendices**
 - [Appendix A — Release Feature Index](#appendix-a--release-feature-index)
 
@@ -1305,21 +1303,6 @@ event=$(echo "$context" | jq -r '.event')
 wiki=$(echo "$context" | jq -r '.wiki')
 echo "Event $event fired on wiki $wiki" | mail -s "Synthadoc notification" you@example.com
 ```
-
----
-
-## 18. v0.2.0 — What's New
-
-See [Appendix A — Release Feature Index](#appendix-a--release-feature-index) for a full list of delivered v0.2.0 features.
-
-### Planned
-
-| Feature | Motivation |
-|---------|-----------|
-| **Web UI** | Browser-based dashboard — pages, jobs, contradictions, orphans — without requiring Obsidian |
-| **Graph-aware retrieval** | Traverse wikilink adjacency for multi-hop queries (e.g. "What connects Turing to von Neumann?") |
-| **Larger corpus support** | Sharded BM25 index; incremental embedding updates; streaming ingest for very large documents |
-| **Mistral + Bedrock providers** | Additional OpenAI-compatible endpoints; Bedrock for AWS-native deployments |
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -649,7 +649,7 @@ synthadoc
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--save` | off | Save the answer as a new wiki page |
-| `--timeout N` | `30` | Seconds to wait for the LLM response. Increase for slower providers (e.g. `--timeout 120` for MiniMax reasoning models) |
+| `--timeout N` | `60` | Seconds to wait for the LLM response. Increase for slower providers (e.g. `--timeout 120` for MiniMax reasoning models) |
 
 ### `ingest --analyse-only`
 
@@ -774,7 +774,7 @@ Required environment variables per provider:
 | `openai` | `OPENAI_API_KEY` | No (pay-per-token) | Yes |
 | `gemini` | `GEMINI_API_KEY` | **Yes** — 15 RPM / 1M tokens/day on Flash | Yes |
 | `groq` | `GROQ_API_KEY` | **Yes** — generous free tier on Llama/Mixtral models | No |
-| `minimax` | `MINIMAX_API_KEY` | No (pay-per-token) | No (text only) |
+| `minimax` | `MINIMAX_API_KEY` | No (pay-per-token) | Yes (M2.5 / M2.7 natively multimodal) |
 | `ollama` | _(none)_ | **Yes** — fully local | Model-dependent |
 
 ### Per-project config — `<wiki-root>/.synthadoc/config.toml`

--- a/docs/design.md
+++ b/docs/design.md
@@ -620,7 +620,7 @@ synthadoc
 ├── demo list
 ├── serve [-w wiki] [--port N] [--background] [--mcp-only] [--http-only] [--verbose]
 ├── ingest <source> [-w wiki] [--batch] [--file manifest] [--force] [--analyse-only] [--max-results N]
-├── query "<question>" [-w wiki] [--save]
+├── query "<question>" [-w wiki] [--save] [--timeout N]
 ├── lint
 │   ├── run [-w wiki] [--scope contradictions|orphans|all] [--auto-resolve]
 │   └── report [-w wiki]
@@ -643,6 +643,13 @@ synthadoc
     ├── remove <id> [-w wiki]
     └── apply [-w wiki]
 ```
+
+### `query` options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--save` | off | Save the answer as a new wiki page |
+| `--timeout N` | `30` | Seconds to wait for the LLM response. Increase for slower providers (e.g. `--timeout 120` for MiniMax reasoning models) |
 
 ### `ingest --analyse-only`
 

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -248,6 +248,12 @@ query decomposed into 2 sub-question(s):
 Simple single-topic questions decompose to one sub-question and behave identically to
 a direct query — no extra LLM cost.
 
+> **Slow provider?** Reasoning models (e.g. MiniMax M2.x) can take longer to respond.
+> If you see a timeout error, pass `--timeout 120`:
+> ```bash
+> synthadoc query "How did Moore's Law shape hardware design?" -w history-of-computing --timeout 120
+> ```
+
 ### Knowledge gap detection
 
 If the wiki does not cover a topic, Synthadoc detects the gap automatically:

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -882,7 +882,7 @@ default = { provider = "gemini", model = "gemini-2.5-flash" }
 [agents]
 default = { provider = "groq", model = "llama-3.3-70b-versatile" }
 
-# MiniMax (cheapest paid text — no vision/image support)
+# MiniMax (cheapest paid, natively multimodal)
 [agents]
 default = { provider = "minimax", model = "MiniMax-M2.5" }
 ```
@@ -893,7 +893,7 @@ Restart `synthadoc serve`. The startup banner confirms `LLM: <provider>/<model>`
 >
 > - **Gemini** free tier: 15 RPM. If you see `429 RateLimitError` during a long ingest, wait 60 s and retry, or switch to Groq or MiniMax.
 > - **Groq** free tier: 100K tokens/day — adequate for short demo sessions; heavy web search ingest can exhaust it.
-> - **MiniMax:** no free tier, but M2.5 input is ~$0.15/M tokens — roughly half the cost of Gemini 2.5 Flash. Text-only; image ingestion will fall back to text extraction.
+> - **MiniMax:** no free tier, but M2.5 input is ~$0.15/M tokens — roughly half the cost of Gemini 2.5 Flash. M2.5 and M2.7 are natively multimodal (text + image).
 > - **Ollama:** fully local, no rate limits. Install from [ollama.com](https://ollama.com); no API key needed.
 
 ---

--- a/synthadoc/agents/lint_agent.py
+++ b/synthadoc/agents/lint_agent.py
@@ -20,6 +20,31 @@ class LintReport:
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
+# Auto-generated pages excluded from both reference-counting and orphan reporting.
+# A page linked only from overview/index is still an orphan in the human graph.
+LINT_SKIP_SLUGS: frozenset[str] = frozenset(
+    {"index", "log", "dashboard", "purpose", "overview"}
+)
+
+
+def find_orphan_slugs(
+    page_texts: dict[str, str],
+    skip: frozenset[str] = LINT_SKIP_SLUGS,
+) -> list[str]:
+    """Return slugs with no inbound [[wikilinks]] from non-skip pages.
+
+    page_texts maps slug → page text (content body or full raw file).
+    Links from skip pages (overview, index, …) are not counted as real references.
+    """
+    referenced: set[str] = set()
+    for slug, text in page_texts.items():
+        if slug in skip:
+            continue
+        for link in _WIKILINK_RE.findall(text):
+            slug_part = link.split("|")[0].strip()
+            referenced.add(slug_part.lower().replace(" ", "-"))
+    return [s for s in page_texts if s not in referenced and s not in skip]
+
 
 class LintAgent:
     def __init__(self, provider: LLMProvider, store: WikiStorage,
@@ -29,23 +54,13 @@ class LintAgent:
         self._log = log_writer
         self._threshold = confidence_threshold
 
-    # Auto-generated pages whose wikilinks should not count as "real" references.
-    # A page linked only from overview.md is still an orphan in the human graph.
-    _REFERENCE_EXCLUDED = frozenset({"overview", "index", "dashboard", "log", "purpose"})
-
     def _find_orphans(self, slugs: list[str]) -> list[str]:
-        referenced: set[str] = set()
-        for slug in slugs:
-            if slug in self._REFERENCE_EXCLUDED:
-                continue
-            page = self._store.read_page(slug)
-            if page:
-                for link in _WIKILINK_RE.findall(page.content):
-                    # Strip alias (e.g. [[slug|Display Text]]) before normalising
-                    slug_part = link.split("|")[0].strip()
-                    referenced.add(slug_part.lower().replace(" ", "-"))
-        return [s for s in slugs if s not in referenced
-                and s not in ("index", "dashboard", "log", "purpose", "overview")]
+        page_texts = {
+            slug: (self._store.read_page(slug).content
+                   if self._store.read_page(slug) else "")
+            for slug in slugs
+        }
+        return find_orphan_slugs(page_texts)
 
     async def lint(self, scope: str = "all", auto_resolve: bool = False) -> LintReport:
         report = LintReport()

--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -27,7 +27,7 @@ def server_url(wiki: str) -> str:
     return f"http://127.0.0.1:{port}"
 
 
-def get(wiki: str, path: str, timeout: int = 30, **params) -> dict:
+def get(wiki: str, path: str, timeout: int = 60, **params) -> dict:
     url = server_url(wiki)
     try:
         resp = httpx.get(f"{url}{path}", params=params, timeout=timeout)
@@ -47,7 +47,7 @@ def get(wiki: str, path: str, timeout: int = 30, **params) -> dict:
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
-def post(wiki: str, path: str, body: dict, timeout: int = 30) -> dict:
+def post(wiki: str, path: str, body: dict, timeout: int = 60) -> dict:
     url = server_url(wiki)
     try:
         resp = httpx.post(f"{url}{path}", json=body, timeout=timeout)

--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -27,10 +27,10 @@ def server_url(wiki: str) -> str:
     return f"http://127.0.0.1:{port}"
 
 
-def get(wiki: str, path: str, **params) -> dict:
+def get(wiki: str, path: str, timeout: int = 30, **params) -> dict:
     url = server_url(wiki)
     try:
-        resp = httpx.get(f"{url}{path}", params=params, timeout=30)
+        resp = httpx.get(f"{url}{path}", params=params, timeout=timeout)
         resp.raise_for_status()
         return resp.json()
     except httpx.ConnectError:
@@ -38,19 +38,19 @@ def get(wiki: str, path: str, **params) -> dict:
     except httpx.ReadTimeout:
         E.cli_error(
             E.QUERY_TIMEOUT,
-            "The query timed out waiting for the LLM to respond (30 s).",
+            f"The query timed out waiting for the LLM to respond ({timeout} s).",
             "The wiki server is still running. Try again — if the wiki is large, "
-            "reduce your question scope or increase the timeout.",
+            "reduce your question scope or pass --timeout 120 to allow more time.",
         )
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
-def post(wiki: str, path: str, body: dict) -> dict:
+def post(wiki: str, path: str, body: dict, timeout: int = 30) -> dict:
     url = server_url(wiki)
     try:
-        resp = httpx.post(f"{url}{path}", json=body, timeout=30)
+        resp = httpx.post(f"{url}{path}", json=body, timeout=timeout)
         resp.raise_for_status()
         return resp.json()
     except httpx.ConnectError:
@@ -58,7 +58,7 @@ def post(wiki: str, path: str, body: dict) -> dict:
     except httpx.ReadTimeout:
         E.cli_error(
             E.QUERY_TIMEOUT,
-            "The request timed out waiting for the server to respond (30 s).",
+            f"The request timed out waiting for the server to respond ({timeout} s).",
             "The wiki server is still running. Try again.",
         )
     except httpx.HTTPStatusError as e:

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -104,14 +104,12 @@ Open each one, resolve the conflict, then change `status` to `active`.*
 ```dataview
 TABLE status, created
 FROM "wiki"
-WHERE length(file.inlinks) = 0
-AND file.name != "index"
-AND file.name != "dashboard"
-AND file.name != "purpose"
+WHERE orphan = true
 SORT created DESC
 ```
 
 *These pages exist but nothing links to them.
+Orphan status is set by `synthadoc lint run` — run it first to populate this list.
 Add `[[page-name]]` to a related page or to [[index]].*
 
 ---

--- a/synthadoc/cli/lint.py
+++ b/synthadoc/cli/lint.py
@@ -11,9 +11,8 @@ import typer
 from synthadoc.cli.main import app
 from synthadoc.cli._http import post
 
-_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
-_SKIP_SLUGS = {"index", "log", "dashboard", "purpose", "overview"}
+from synthadoc.agents.lint_agent import find_orphan_slugs, LINT_SKIP_SLUGS
 
 
 def _parse_frontmatter(text: str) -> dict:
@@ -70,33 +69,16 @@ def lint_report(
 
     pages = list(wiki_dir.glob("*.md"))
 
+    page_texts: dict[str, str] = {p.stem: p.read_text(encoding="utf-8") for p in pages}
+
     # --- Contradictions ---
-    contradicted = []
-    for p in pages:
-        if p.stem in _SKIP_SLUGS:
-            continue
-        raw = p.read_text(encoding="utf-8")
-        if "status: contradicted" in raw:
-            contradicted.append(p.stem)
-
-    # --- Orphans: pages with no inbound [[wikilinks]] from any content page ---
-    # Auto-generated pages (overview, index, etc.) are excluded from contributing
-    # references — a link only from overview.md is not a meaningful inbound link.
-    referenced: set[str] = set()
-    page_texts: dict[str, str] = {}
-    for p in pages:
-        raw = p.read_text(encoding="utf-8")
-        page_texts[p.stem] = raw
-        if p.stem in _SKIP_SLUGS:
-            continue
-        for link in _WIKILINK_RE.findall(raw):
-            slug_part = link.split("|")[0].strip()
-            referenced.add(slug_part.lower().replace(" ", "-"))
-
-    orphans = [
-        p.stem for p in pages
-        if p.stem not in referenced and p.stem not in _SKIP_SLUGS
+    contradicted = [
+        stem for stem, text in page_texts.items()
+        if stem not in LINT_SKIP_SLUGS and "status: contradicted" in text
     ]
+
+    # --- Orphans ---
+    orphans = find_orphan_slugs(page_texts)
 
     # --- Report ---
     has_issues = contradicted or orphans

--- a/synthadoc/cli/lint.py
+++ b/synthadoc/cli/lint.py
@@ -13,7 +13,7 @@ from synthadoc.cli._http import post
 
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
-_SKIP_SLUGS = {"index", "log", "dashboard", "purpose"}
+_SKIP_SLUGS = {"index", "log", "dashboard", "purpose", "overview"}
 
 
 def _parse_frontmatter(text: str) -> dict:
@@ -79,12 +79,16 @@ def lint_report(
         if "status: contradicted" in raw:
             contradicted.append(p.stem)
 
-    # --- Orphans: pages with no inbound [[wikilinks]] from any other page ---
+    # --- Orphans: pages with no inbound [[wikilinks]] from any content page ---
+    # Auto-generated pages (overview, index, etc.) are excluded from contributing
+    # references — a link only from overview.md is not a meaningful inbound link.
     referenced: set[str] = set()
     page_texts: dict[str, str] = {}
     for p in pages:
         raw = p.read_text(encoding="utf-8")
         page_texts[p.stem] = raw
+        if p.stem in _SKIP_SLUGS:
+            continue
         for link in _WIKILINK_RE.findall(raw):
             slug_part = link.split("|")[0].strip()
             referenced.add(slug_part.lower().replace(" ", "-"))

--- a/synthadoc/cli/query.py
+++ b/synthadoc/cli/query.py
@@ -36,7 +36,7 @@ def query_cmd(
     question: str = typer.Argument(..., help="Question to ask the wiki"),
     save: bool = typer.Option(False, "--save", help="Save answer as wiki page"),
     wiki: str = typer.Option(".", "--wiki", "-w"),
-    timeout: int = typer.Option(30, "--timeout", help="Seconds to wait for the LLM (default 30; increase for slow providers)"),
+    timeout: int = typer.Option(60, "--timeout", help="Seconds to wait for the LLM (default 60; increase for slow providers)"),
 ):
     """Query the wiki. Requires synthadoc serve to be running."""
     result = get(wiki, "/query", timeout=timeout, q=question)

--- a/synthadoc/cli/query.py
+++ b/synthadoc/cli/query.py
@@ -36,9 +36,10 @@ def query_cmd(
     question: str = typer.Argument(..., help="Question to ask the wiki"),
     save: bool = typer.Option(False, "--save", help="Save answer as wiki page"),
     wiki: str = typer.Option(".", "--wiki", "-w"),
+    timeout: int = typer.Option(30, "--timeout", help="Seconds to wait for the LLM (default 30; increase for slow providers)"),
 ):
     """Query the wiki. Requires synthadoc serve to be running."""
-    result = get(wiki, "/query", q=question)
+    result = get(wiki, "/query", timeout=timeout, q=question)
     typer.echo(result["answer"])
     if result.get("citations"):
         typer.echo("\nSources: " + ", ".join(f"[[{c}]]" for c in result["citations"]))

--- a/synthadoc/demos/history-of-computing/wiki/dashboard.md
+++ b/synthadoc/demos/history-of-computing/wiki/dashboard.md
@@ -32,14 +32,12 @@ Open each one, resolve the conflict, then change `status` to `active`.*
 ```dataview
 TABLE status, created
 FROM "wiki"
-WHERE length(file.inlinks) = 0
-AND file.name != "index"
-AND file.name != "dashboard"
-AND file.name != "purpose"
+WHERE orphan = true
 SORT created DESC
 ```
 
 *These pages exist but nothing links to them.
+Orphan status is set by `synthadoc lint run` — run it first to populate this list.
 Add `[[page-name]]` to a related page or to [[index]].*
 
 ---

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -322,7 +322,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
     @app.get("/lint/report")
     async def lint_report():
         import yaml as _yaml
-        _SKIP = {"index", "log", "dashboard", "purpose"}
+        from synthadoc.agents.lint_agent import find_orphan_slugs, LINT_SKIP_SLUGS
         wiki_dir = wiki_root / "wiki"
         pages = list(wiki_dir.glob("*.md"))
 
@@ -330,19 +330,10 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
 
         contradicted = [
             stem for stem, text in page_texts.items()
-            if stem not in _SKIP and "status: contradicted" in text
+            if stem not in LINT_SKIP_SLUGS and "status: contradicted" in text
         ]
 
-        referenced: set[str] = set()
-        for text in page_texts.values():
-            for link in _WIKILINK_RE.findall(text):
-                slug_part = link.split("|")[0].strip()
-                referenced.add(slug_part.lower().replace(" ", "-"))
-
-        orphan_slugs = [
-            stem for stem in page_texts
-            if stem not in referenced and stem not in _SKIP
-        ]
+        orphan_slugs = find_orphan_slugs(page_texts)
 
         orphan_details = []
         for slug in orphan_slugs:

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -11,7 +11,7 @@ from synthadoc.providers.base import CompletionResponse, LLMProvider, Message
 logger = logging.getLogger(__name__)
 
 # Providers whose chat endpoint does not support image inputs
-_NO_VISION_HOSTS = ("groq.com", "minimax.io")
+_NO_VISION_HOSTS = ("groq.com",)
 
 
 class OpenAIProvider(LLMProvider):

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
 from __future__ import annotations
+import asyncio
 import logging
 import re
 from typing import Optional
+import openai as _openai
 from openai import AsyncOpenAI
 from synthadoc.config import AgentConfig
 from synthadoc.providers.base import CompletionResponse, LLMProvider, Message
@@ -12,6 +14,23 @@ logger = logging.getLogger(__name__)
 
 # Providers whose chat endpoint does not support image inputs
 _NO_VISION_HOSTS = ("groq.com",)
+
+# Retry delays (seconds) after an HTTP 429 rate-limit response.
+#
+# Free-tier providers reset their per-minute window after ~60 s, so waiting
+# that long is the minimum that reliably avoids a second 429.  The openai SDK
+# already retries transient blips with short back-off; by the time a
+# RateLimitError reaches our code the SDK has already given up, meaning we
+# really have saturated the window and need to wait it out.
+#
+# Three retries × 60 s = up to 3 extra minutes.  Batch web-search ingest
+# fans out ~10 child URLs (30 LLM calls total); at 15 RPM that requires
+# roughly 1–2 window resets, so 3 retries is sufficient without being wasteful.
+#
+# Paid tiers (Gemini paid, Anthropic, OpenAI) have high enough quotas that
+# they will rarely trigger a 429.  If they do, the same wait still applies —
+# it is harmless.
+_RATE_LIMIT_RETRY_DELAYS_S: tuple[int, ...] = (60, 60, 60)
 
 
 class OpenAIProvider(LLMProvider):
@@ -42,6 +61,32 @@ class OpenAIProvider(LLMProvider):
             result.append(block)
         return result
 
+    async def _call_with_retry(self, msgs: list, temperature: float,
+                               max_tokens: int):
+        """Call the completions API, retrying on 429 rate-limit responses.
+
+        See _RATE_LIMIT_RETRY_DELAYS_S for the rationale and expected wait times.
+        """
+        last_exc: Exception | None = None
+        for attempt, wait in enumerate([0] + list(_RATE_LIMIT_RETRY_DELAYS_S)):
+            if wait:
+                logger.warning(
+                    "Rate limit (429) from %s — waiting %d s then retrying "
+                    "(attempt %d/%d). Expected on free-tier Gemini (15 RPM) or "
+                    "Groq during batch ingest fan-outs.",
+                    self._config.provider, wait,
+                    attempt, len(_RATE_LIMIT_RETRY_DELAYS_S),
+                )
+                await asyncio.sleep(wait)
+            try:
+                return await self._client.chat.completions.create(
+                    model=self._config.model, messages=msgs,
+                    temperature=temperature, max_tokens=max_tokens,
+                )
+            except _openai.RateLimitError as exc:
+                last_exc = exc
+        raise last_exc  # type: ignore[misc]
+
     async def complete(self, messages: list[Message], system: Optional[str] = None,
                        temperature: float = 0.0, max_tokens: int = 4096) -> CompletionResponse:
         msgs = []
@@ -49,10 +94,7 @@ class OpenAIProvider(LLMProvider):
             msgs.append({"role": "system", "content": system})
         msgs.extend({"role": m.role, "content": self._to_openai_content(m.content)}
                     for m in messages)
-        resp = await self._client.chat.completions.create(
-            model=self._config.model, messages=msgs,
-            temperature=temperature, max_tokens=max_tokens,
-        )
+        resp = await self._call_with_retry(msgs, temperature, max_tokens)
         choice = resp.choices[0]
         text = choice.message.content or ""
         # Strip <think>...</think> blocks that reasoning models prepend to their output

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -55,6 +55,8 @@ class OpenAIProvider(LLMProvider):
         )
         choice = resp.choices[0]
         text = choice.message.content or ""
+        # Strip <think>...</think> blocks that reasoning models prepend to their output
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
         if not text:
             # Reasoning models (e.g. MiniMax M2.x) return content=null and put their
             # chain-of-thought in a non-standard reasoning_content field. Try to extract

--- a/tests/agents/test_lint_agent.py
+++ b/tests/agents/test_lint_agent.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 Paul Chen / axoviq.com
 import pytest
 from unittest.mock import AsyncMock
-from synthadoc.agents.lint_agent import LintAgent, LintReport
+from synthadoc.agents.lint_agent import LintAgent, LintReport, find_orphan_slugs, LINT_SKIP_SLUGS
 from synthadoc.providers.base import CompletionResponse
 from synthadoc.storage.wiki import WikiStorage, WikiPage
 from synthadoc.storage.log import LogWriter
@@ -55,3 +55,38 @@ async def test_lint_aliased_wikilink_not_orphan(tmp_wiki):
     agent = LintAgent(provider=AsyncMock(), store=store, log_writer=log)
     report = await agent.lint(scope="orphans")
     assert "quantum-computing" not in report.orphan_slugs
+
+
+def test_find_orphan_slugs_basic():
+    """Pages with no inbound links from content pages are orphans."""
+    page_texts = {
+        "page-a": "See [[page-b]].",
+        "page-b": "No links here.",
+        "page-c": "Standalone page.",
+    }
+    orphans = find_orphan_slugs(page_texts)
+    assert "page-a" in orphans      # nothing links to page-a
+    assert "page-b" not in orphans  # page-a links to page-b
+    assert "page-c" in orphans      # nothing links to page-c
+
+
+def test_find_orphan_slugs_overview_excluded():
+    """Links from overview (and other skip slugs) must not count as real references."""
+    page_texts = {
+        "overview": "[[page-a]] [[page-b]]",
+        "page-a":   "See [[page-b]].",
+        "page-b":   "No links here.",
+    }
+    orphans = find_orphan_slugs(page_texts)
+    assert "overview" not in orphans   # skip slugs never reported
+    assert "page-a" in orphans         # overview link doesn't count; nothing else links to page-a
+    assert "page-b" not in orphans     # page-a links to page-b → not an orphan
+
+
+def test_find_orphan_slugs_skip_slugs_never_reported():
+    """Skip slugs (index, dashboard, …) are never returned as orphans."""
+    page_texts = {slug: "" for slug in LINT_SKIP_SLUGS}
+    page_texts["real-page"] = "content"
+    orphans = find_orphan_slugs(page_texts)
+    for slug in LINT_SKIP_SLUGS:
+        assert slug not in orphans

--- a/tests/cli/test_lint_cli.py
+++ b/tests/cli/test_lint_cli.py
@@ -65,8 +65,9 @@ def _make_wiki(tmp_path, pages: dict[str, str]):
 def test_lint_report_all_clear(tmp_path, monkeypatch):
     import synthadoc.cli.install as install_mod
     wiki_dir, root = _make_wiki(tmp_path, {
-        "index": "# Index\n\n[[topic-a]]",
-        "topic-a": "---\nstatus: active\n---\n\n# Topic A",
+        "index":   "# Index\n",
+        "topic-a": "---\nstatus: active\n---\n\n# Topic A\n\nSee also [[topic-b]].",
+        "topic-b": "---\nstatus: active\n---\n\n# Topic B\n\nRelated to [[topic-a]].",
     })
     monkeypatch.setattr(install_mod, "_REGISTRY",
                         tmp_path / "wikis.json")
@@ -103,6 +104,26 @@ def test_lint_report_orphan(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert "orphan-page" in result.output
     assert "orphan" in result.output.lower()
+
+
+def test_lint_report_overview_links_do_not_mask_orphans(tmp_path, monkeypatch):
+    """overview.md is auto-generated and links to every page — its links must not
+    count as real inbound references. A page linked only from overview.md is still an orphan."""
+    import synthadoc.cli.install as install_mod
+    wiki_dir, root = _make_wiki(tmp_path, {
+        "index":    "# Index\n",
+        "overview": "# Overview\n\n[[orphan-page]] [[linked-page]]",
+        "orphan-page": "---\nstatus: active\n---\n# Orphan",
+        "linked-page": "---\nstatus: active\n---\n# Linked\n\n[[orphan-page]]",
+    })
+    monkeypatch.setattr(install_mod, "_read_registry",
+                        lambda: {"mywiki": {"path": str(tmp_path)}})
+    result = runner.invoke(app, ["lint", "report", "-w", "mywiki"])
+    assert result.exit_code == 0, result.output
+    # linked-page references orphan-page → not an orphan
+    assert "orphan-page" not in result.output
+    # linked-page is only referenced by overview.md (excluded) → IS an orphan
+    assert "linked-page" in result.output
 
 
 def test_lint_report_missing_wiki_dir(tmp_path, monkeypatch):

--- a/tests/cli/test_query_cli.py
+++ b/tests/cli/test_query_cli.py
@@ -68,13 +68,13 @@ def test_query_cli_gap_includes_command_palette_hint():
     assert "Synthadoc: Ingest: web search" in result.output
 
 
-def test_query_cli_default_timeout_is_30():
-    """Without --timeout, get() must be called with timeout=30."""
+def test_query_cli_default_timeout_is_60():
+    """Without --timeout, get() must be called with timeout=60."""
     ctx, mock = _capture_get({"answer": "ok", "citations": [], "knowledge_gap": False})
     with ctx:
         runner.invoke(app, ["query", "What is AI?", "-w", "."])
     _, kwargs = mock.call_args
-    assert kwargs.get("timeout") == 30
+    assert kwargs.get("timeout") == 60
 
 
 def test_query_cli_custom_timeout_forwarded():

--- a/tests/cli/test_query_cli.py
+++ b/tests/cli/test_query_cli.py
@@ -13,6 +13,13 @@ def _mock_get(response: dict):
     return patch("synthadoc.cli.query.get", return_value=response)
 
 
+def _capture_get(response: dict):
+    """Patch get and capture the kwargs it was called with."""
+    from unittest.mock import MagicMock
+    mock = MagicMock(return_value=response)
+    return patch("synthadoc.cli.query.get", mock), mock
+
+
 def test_query_cli_no_gap_shows_only_answer():
     """When knowledge_gap=False, no callout must appear in output."""
     with _mock_get({"answer": "AI is great.", "citations": ["ai-page"],
@@ -59,6 +66,24 @@ def test_query_cli_gap_includes_command_palette_hint():
         result = runner.invoke(app, ["query", "Something?", "-w", "my-wiki"])
     assert "Command Palette" in result.output
     assert "Synthadoc: Ingest: web search" in result.output
+
+
+def test_query_cli_default_timeout_is_30():
+    """Without --timeout, get() must be called with timeout=30."""
+    ctx, mock = _capture_get({"answer": "ok", "citations": [], "knowledge_gap": False})
+    with ctx:
+        runner.invoke(app, ["query", "What is AI?", "-w", "."])
+    _, kwargs = mock.call_args
+    assert kwargs.get("timeout") == 30
+
+
+def test_query_cli_custom_timeout_forwarded():
+    """--timeout N must be forwarded to get() as timeout=N."""
+    ctx, mock = _capture_get({"answer": "ok", "citations": [], "knowledge_gap": False})
+    with ctx:
+        runner.invoke(app, ["query", "What is AI?", "-w", ".", "--timeout", "120"])
+    _, kwargs = mock.call_args
+    assert kwargs.get("timeout") == 120
 
 
 def test_query_cli_gap_includes_requery_hint():

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -71,6 +71,59 @@ async def test_provider_raises_after_max_retries():
             await provider.complete(messages=[Message(role="user", content="hi")])
 
 
+@pytest.mark.asyncio
+async def test_openai_provider_retries_once_on_rate_limit_then_succeeds():
+    """A single 429 is retried; the second attempt succeeds and returns a result."""
+    import openai
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="gemini", model="gemini-2.5-flash",
+                      base_url="https://generativelanguage.googleapis.com/v1beta/openai/")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    ok_resp = MagicMock()
+    ok_resp.choices = [MagicMock()]
+    ok_resp.choices[0].message.content = "hello"
+    ok_resp.usage.prompt_tokens = 10
+    ok_resp.usage.completion_tokens = 5
+
+    rate_limit_exc = openai.RateLimitError(
+        message="rate limit", response=MagicMock(status_code=429), body={})
+    call_count = 0
+
+    async def flaky(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise rate_limit_exc
+        return ok_resp
+
+    with patch.object(provider._client.chat.completions, "create", side_effect=flaky):
+        with patch("asyncio.sleep", new=AsyncMock()):
+            result = await provider.complete(messages=[Message(role="user", content="hi")])
+
+    assert result.text == "hello"
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_raises_after_all_retries_exhausted():
+    """When 429s persist across all retries, RateLimitError is re-raised."""
+    import openai
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="gemini", model="gemini-2.5-flash",
+                      base_url="https://generativelanguage.googleapis.com/v1beta/openai/")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    rate_limit_exc = openai.RateLimitError(
+        message="rate limit", response=MagicMock(status_code=429), body={})
+
+    with patch.object(provider._client.chat.completions, "create",
+                      side_effect=rate_limit_exc):
+        with patch("asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(openai.RateLimitError):
+                await provider.complete(messages=[Message(role="user", content="hi")])
+
+
 def _make_cfg(provider: str, model: str) -> "Config":
     from synthadoc.config import Config, AgentsConfig, AgentConfig
     return Config(agents=AgentsConfig(default=AgentConfig(provider=provider, model=model)))

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -153,7 +153,7 @@ def test_make_provider_minimax_uses_openai_provider_with_base_url(monkeypatch):
     provider = make_provider("ingest", _make_cfg("minimax", "MiniMax-M2.5"))
     assert isinstance(provider, OpenAIProvider)
     assert "minimax.io" in str(provider._client.base_url)
-    assert provider.supports_vision is False
+    assert provider.supports_vision is True   # M2.5 is natively multimodal
 
 
 def test_make_provider_gemini_uses_openai_provider_with_base_url(monkeypatch):

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -278,6 +278,30 @@ async def test_openai_provider_empty_content_returns_empty_string():
 
 
 @pytest.mark.asyncio
+async def test_openai_provider_strips_think_tags_from_content():
+    """Reasoning models (e.g. MiniMax M2.x) prefix content with <think>...</think>.
+    The provider must strip those tags so callers receive clean text."""
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M2.5",
+                      base_url="https://api.minimax.io/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    mock_choice = MagicMock()
+    mock_choice.message.content = '<think>Let me break this down...</think>["What is X?", "How does X work?"]'
+    mock_choice.message.model_extra = {}
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_resp.usage.prompt_tokens = 20
+    mock_resp.usage.completion_tokens = 15
+
+    with patch.object(provider._client.chat.completions, "create",
+                      new=AsyncMock(return_value=mock_resp)):
+        result = await provider.complete(
+            messages=[Message(role="user", content="Tell me about X")]
+        )
+    assert result.text == '["What is X?", "How does X work?"]'
+
+
+@pytest.mark.asyncio
 async def test_openai_provider_extracts_json_from_reasoning_content():
     """MiniMax-style reasoning models return content=null with JSON in reasoning_content.
     The provider must extract the last JSON array from reasoning_content as a fallback."""


### PR DESCRIPTION
 What

  A batch of fixes and small features addressing issues found during v0.2 demo testing.

  Why

  - CLI and Obsidian dashboard showed inconsistent orphan counts (overview.md was counted as a real inbound link)
  - MiniMax reasoning models prepended <think> tags that broke JSON parsing in the query agent
  - Long-running providers (MiniMax, slow Groq) hit the hardcoded 30 s timeout
  - Free-tier Gemini (15 RPM) and Groq users hit silent 429 failures during batch web-search ingest

  Changes

  - Orphan detection: Consolidated three separate implementations into a single find_orphan_slugs() function in lint_agent.py; added "overview" to the skip set so auto-generated overview links don't mask real orphans. Dashboard Dataview query changed from WHERE length(file.inlinks) = 0 to WHERE orphan = true (uses server-computed frontmatter flag instead of Obsidian's own link tracking)
  - MiniMax fix: Strip <think>…</think> blocks from provider responses before any JSON parsing; reasoning fallback via reasoning_content field
  - Query timeout: Added --timeout N flag to synthadoc query (default raised from 30 s → 60 s); forwarded to HTTP client
  - MiniMax vision: Removed MiniMax from _NO_VISION_HOSTS - M2.5 and M2.7 are natively multimodal; updated provider tables in all docs - 429 retry: OpenAIProvider retries on RateLimitError with 3 × 60 s backoff; converts silent batch-ingest failures into slower-but-complete runs on free-tier Gemini/Groq
  - Docs: Removed obsolete "v0.2.0 - What's New" section from design.md; updated command reference, provider tables, and dashboard template