### PR TITLE
Testing hung [v0.2.0]

### DIFF
--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -496,11 +496,20 @@ synthadoc ingest "search for: Dennis Ritchie C programming language Bell Labs hi
 synthadoc ingest "search for: ENIAC first general purpose electronic computer history" -w history-of-computing
 ```
 
-Each command fans out to up to 20 URL ingest jobs. Watch them:
+Each command fans out to up to 20 URL ingest jobs. The commands return immediately —
+all processing happens in the background. Watch progress with:
 
 ```bash
 synthadoc jobs list -w history-of-computing
 ```
+
+> **How long does it take?**
+> - **Free-tier Gemini (15 RPM) or Groq:** Two searches produce ~20–40 LLM calls. The
+>   server retries automatically when the rate limit is hit (you will see
+>   `Rate limit (429) — waiting 60 s` in the server log — this is normal). Expect
+>   **3–8 minutes** for both searches to fully complete.
+> - **Paid tier (Gemini paid, MiniMax, Anthropic, OpenAI):** No rate-limit retries.
+>   Both searches typically finish in **under 2 minutes**.
 
 Pages such as `dennis-ritchie`, `eniac-history`, and related topics will be created or
 enriched. The `wiki/overview.md` page is regenerated automatically after each batch

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -32,6 +32,10 @@ _NO_VISION_HOSTS = ("groq.com",)
 # it is harmless.
 _RATE_LIMIT_RETRY_DELAYS_S: tuple[int, ...] = (60, 60, 60)
 
+# Module-level alias so tests can patch precisely:
+#   patch("synthadoc.providers.openai._sleep", new=AsyncMock())
+_sleep = asyncio.sleep
+
 
 class OpenAIProvider(LLMProvider):
     def __init__(self, api_key: str, config: AgentConfig) -> None:
@@ -77,7 +81,7 @@ class OpenAIProvider(LLMProvider):
                     self._config.provider, wait,
                     attempt, len(_RATE_LIMIT_RETRY_DELAYS_S),
                 )
-                await asyncio.sleep(wait)
+                await _sleep(wait)
             try:
                 return await self._client.chat.completions.create(
                     model=self._config.model, messages=msgs,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -30,6 +30,9 @@ def test_install_creates_fresh_wiki(tmp_path, monkeypatch):
     import synthadoc.cli.install as install_mod
     monkeypatch.setattr(install_mod, "_REGISTRY", tmp_path / "wikis.json")
     monkeypatch.setattr(install_mod, "_find_free_port", lambda start=7070, max_scan=20: 7070)
+    # Prevent a real LLM call: _run_scaffold checks for API keys in the environment
+    # and will call the provider if one is set (e.g. GEMINI_API_KEY on a dev machine).
+    monkeypatch.setattr(install_mod, "_run_scaffold", lambda dest, domain: None)
 
     result = runner.invoke(app, ["install", "my-wiki", "--target", str(tmp_path)])
     assert result.exit_code == 0, result.output
@@ -107,6 +110,7 @@ def test_install_output_instructs_parent_dir(tmp_path, monkeypatch):
     import synthadoc.cli.install as install_mod
     monkeypatch.setattr(install_mod, "_REGISTRY", tmp_path / "wikis.json")
     monkeypatch.setattr(install_mod, "_find_free_port", lambda start=7070, max_scan=20: 7070)
+    monkeypatch.setattr(install_mod, "_run_scaffold", lambda dest, domain: None)
 
     result = runner.invoke(app, ["install", "my-research", "--target", str(tmp_path)])
     # No absolute paths in output

--- a/tests/cli/test_install_port.py
+++ b/tests/cli/test_install_port.py
@@ -5,29 +5,57 @@ import pytest
 from synthadoc.cli._port import find_free_port as _find_free_port
 
 
+def _find_bindable_base(count: int) -> int:
+    """Return the first port in a run of `count` consecutively bindable ports.
+
+    Hardcoded port numbers fail on Windows when Hyper-V or other system
+    components exclude specific ranges (WinError 10013). Starting from a
+    high ephemeral range and scanning avoids those exclusions.
+    """
+    for base in range(40000, 41000):
+        socks: list[socket.socket] = []
+        try:
+            for i in range(count):
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind(("127.0.0.1", base + i))
+                socks.append(s)
+            return base
+        except OSError:
+            pass
+        finally:
+            for s in socks:
+                try:
+                    s.close()
+                except OSError:
+                    pass
+    pytest.skip("No block of consecutive bindable ports found")
+
+
 def test_find_free_port_returns_start_when_available():
     """Returns the start port if it is not bound."""
-    # Pick a port above common use range — unlikely to be bound in CI
-    port = _find_free_port(start=19700)
-    assert port == 19700
+    base = _find_bindable_base(1)
+    assert _find_free_port(start=base) == base
 
 
 def test_find_free_port_skips_bound_port():
     """Skips a port that is already bound and returns the next free one."""
+    base = _find_bindable_base(2)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s.bind(("127.0.0.1", 19800))
-        port = _find_free_port(start=19800)
-    assert port == 19801
+        s.bind(("127.0.0.1", base))
+        port = _find_free_port(start=base)
+    assert port == base + 1
 
 
 def test_find_free_port_scans_multiple():
     """Scans past multiple bound ports."""
+    base = _find_bindable_base(3)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1, \
          socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2:
         s1.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         s2.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        s1.bind(("127.0.0.1", 19900))
-        s2.bind(("127.0.0.1", 19901))
-        port = _find_free_port(start=19900)
-    assert port == 19902
+        s1.bind(("127.0.0.1", base))
+        s2.bind(("127.0.0.1", base + 1))
+        port = _find_free_port(start=base)
+    assert port == base + 2

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -98,7 +98,7 @@ async def test_openai_provider_retries_once_on_rate_limit_then_succeeds():
         return ok_resp
 
     with patch.object(provider._client.chat.completions, "create", side_effect=flaky):
-        with patch("asyncio.sleep", new=AsyncMock()):
+        with patch("synthadoc.providers.openai._sleep", new=AsyncMock()):
             result = await provider.complete(messages=[Message(role="user", content="hi")])
 
     assert result.text == "hello"
@@ -119,7 +119,7 @@ async def test_openai_provider_raises_after_all_retries_exhausted():
 
     with patch.object(provider._client.chat.completions, "create",
                       side_effect=rate_limit_exc):
-        with patch("asyncio.sleep", new=AsyncMock()):
+        with patch("synthadoc.providers.openai._sleep", new=AsyncMock()):
             with pytest.raises(openai.RateLimitError):
                 await provider.complete(messages=[Message(role="user", content="hi")])
 


### PR DESCRIPTION
 1. test_install_creates_fresh_wiki hang:  _run_scaffold was making a real Gemini API call when GEMINI_API_KEY was set. Mocked it out in the two affected install tests.

 2. test_find_free_port_scans_multiple failure : port 19900 is inside a Windows Hyper-V excluded range on your machine. Replaced all three port tests with a _find_bindable_base() helper that scans from port 40000 upward for a consecutive bindable block.