### PR TITLE
[bug] Server console throws http status errors when running Web search (MacOS, MiniMax model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ As the wiki accumulates pages the `index.md` table of contents, domain scope (`p
 | Offline browsable artifact   | **Yes**                                             | No          | No         | No        |
 | Multi-wiki isolation         | **Yes**                                             | No          | No         | No        |
 | Web search → wiki pages     | **Yes**                                             | No          | No         | No        |
-| Multiple LLMs support       | **Yes** (MiniMax, Gemini, Groq, Anthropic, Ollama) | No          | No         | No        |
+| Multiple LLMs support       | **Yes** (MiniMax, Gemini, Groq, Anthropic, OpenAI, Ollama) | No          | No         | No        |
 | Auto wiki overview page      | **Yes**                                             | No          | No         | No        |
 | Resumable job queue + retry  | **Yes**                                             | No          | No         | No        |
 | Query decomposition          | **Yes** (parallel sub-queries)                      | No          | No         | No        |

--- a/docs/design.md
+++ b/docs/design.md
@@ -854,9 +854,10 @@ hard_gate_usd                     = 2.00
 auto_resolve_confidence_threshold = 0.85
 
 [ingest]
-max_pages_per_ingest = 15
-chunk_size           = 1500
-chunk_overlap        = 150
+max_pages_per_ingest  = 15
+chunk_size            = 1500
+chunk_overlap         = 150
+fetch_timeout_seconds = 30   # seconds to wait for a URL response before retrying
 
 [logs]
 level        = "INFO"
@@ -900,6 +901,7 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 | `ingest.max_pages_per_ingest` | int | `15` | Max pages one ingest may update |
 | `ingest.chunk_size` | int | `1500` | Text chunk size (characters) |
 | `ingest.chunk_overlap` | int | `150` | Overlap between chunks |
+| `ingest.fetch_timeout_seconds` | int | `30` | Seconds to wait for a URL response before retrying |
 | `logs.level` | str | `"INFO"` | Console log level |
 | `logs.max_file_mb` | int | `5` | Rotate `synthadoc.log` at this size |
 | `logs.backup_count` | int | `5` | Rotated files to keep |

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -976,6 +976,9 @@ port = 7071          # required if running more than one wiki simultaneously
 soft_warn_usd = 0.50
 hard_gate_usd = 2.00
 
+[ingest]
+fetch_timeout_seconds = 60   # increase if slow sites time out during web search
+
 [web_search]
 provider    = "tavily"
 max_results = 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "anthropic>=0.30",
     "openai>=1.40",
     "httpx>=0.27",
+    "certifi>=2024.0",
     "beautifulsoup4>=4.12",
     "pypdf>=4.0",
     "pdfminer.six>=20221105",

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -164,7 +164,8 @@ class IngestAgent:
     def __init__(self, provider: LLMProvider, store: WikiStorage, search: HybridSearch,
                  log_writer: LogWriter, audit_db: AuditDB, cache: CacheManager,
                  max_pages: int = 15, wiki_root: Optional[Path] = None,
-                 cache_version: str = CACHE_VERSION) -> None:
+                 cache_version: str = CACHE_VERSION,
+                 fetch_timeout: int = 30) -> None:
         self._provider = provider
         self._store = store
         self._search = search
@@ -174,7 +175,7 @@ class IngestAgent:
         self._max_pages = max_pages
         self._wiki_root = Path(wiki_root) if wiki_root is not None else None
         self._cache_version = cache_version
-        self._skill_agent = SkillAgent()
+        self._skill_agent = SkillAgent(skill_kwargs={"url": {"fetch_timeout": fetch_timeout}})
         self._purpose = self._load_purpose()
 
     async def _analyse(self, text: str, bust_cache: bool = False) -> dict:

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -84,9 +84,11 @@ class SkillAgent:
         self,
         wiki_root: Optional[Path] = None,
         extra_dirs: Optional[list[Path]] = None,
+        skill_kwargs: Optional[dict[str, dict]] = None,
     ) -> None:
         self._registry: dict[str, SkillMeta] = {}
         self._loaded: dict[str, type[BaseSkill]] = {}
+        self._skill_kwargs: dict[str, dict] = skill_kwargs or {}
         self._build_registry(wiki_root, extra_dirs or [])
 
     def _build_registry(self, wiki_root: Optional[Path], extra_dirs: list[Path]) -> None:
@@ -159,7 +161,8 @@ class SkillAgent:
             self._check_requires(meta)
             cls = _import_class(meta.skill_dir / meta.entry_script, meta.entry_class)
             self._loaded[name] = cls
-        instance = self._loaded[name]()
+        kwargs = self._skill_kwargs.get(name, {})
+        instance = self._loaded[name](**kwargs)
         instance.skill_dir = self._registry[name].skill_dir
         return instance
 

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -75,6 +75,7 @@ class IngestConfig:
     max_pages_per_ingest: int = 15
     chunk_size: int = 1500
     chunk_overlap: int = 150
+    fetch_timeout_seconds: int = 30
 
 
 @dataclass
@@ -255,6 +256,7 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
         max_pages_per_ingest=ig.get("max_pages_per_ingest", 15),
         chunk_size=ig.get("chunk_size", 1500),
         chunk_overlap=ig.get("chunk_overlap", 150),
+        fetch_timeout_seconds=ig.get("fetch_timeout_seconds", 30),
     )
 
     # --- query ---

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -206,12 +206,14 @@ class Orchestrator:
             elif isinstance(e, DomainBlockedException):
                 await self._auto_block_domain(e)
                 await self._queue.skip(job_id, str(e))
-            elif isinstance(e, (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout)):
-                # Transient network timeout — retry with backoff, no traceback.
+            elif isinstance(e, (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout,
+                                   httpx.ConnectError, httpx.ReadError)):
+                # Transient network error (timeout, connection refused, dropped) — retry with backoff.
                 logging.getLogger(__name__).warning(
-                    "URL fetch timed out for job %s (%s) — will retry", job_id, source
+                    "URL fetch failed for job %s (%s: %s) — will retry", job_id, source,
+                    type(e).__name__
                 )
-                await self._queue.fail(job_id, f"ReadTimeout: {source}")
+                await self._queue.fail(job_id, f"{type(e).__name__}: {source}")
             elif isinstance(e, httpx.HTTPStatusError):
                 status = e.response.status_code
                 if 400 <= status < 500:

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -136,6 +136,7 @@ class Orchestrator:
                 log_writer=self._log, audit_db=self._audit,
                 cache=self._cache, max_pages=self._cfg.ingest.max_pages_per_ingest,
                 cache_version=self._cfg.cache.version,
+                fetch_timeout=self._cfg.ingest.fetch_timeout_seconds,
             )
             result = await agent.ingest(source, force=force, bust_cache=force)
             _agent_cfg = self._cfg.agents.resolve("ingest")

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -270,6 +270,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
             cache=orch._cache, max_pages=orch._cfg.ingest.max_pages_per_ingest,
             wiki_root=orch._root,
             cache_version=orch._cfg.cache.version,
+            fetch_timeout=orch._cfg.ingest.fetch_timeout_seconds,
         )
         skill = SkillAgent()
         extracted = await skill.extract(req.source)

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -25,19 +25,24 @@ class UrlSkill(BaseSkill):
                      extensions=["https://", "http://"])
 
     async def extract(self, source: str) -> ExtractedContent:
-        async with httpx.AsyncClient(follow_redirects=True, timeout=30, headers=_HEADERS) as client:
-            resp = await client.get(source)
-            if resp.status_code in _BLOCKED_STATUSES:
-                domain = urlparse(source).hostname or source
-                raise DomainBlockedException(
-                    domain=domain, url=source, status_code=resp.status_code
-                )
-            resp.raise_for_status()
-            content_type = resp.headers.get("content-type", "")
-            is_pdf = "application/pdf" in content_type or source.lower().endswith(".pdf")
-            if is_pdf:
-                return self._extract_pdf_response(resp.content, source)
-            html = resp.text
+        try:
+            async with httpx.AsyncClient(follow_redirects=True, timeout=30, headers=_HEADERS) as client:
+                resp = await client.get(source)
+        except httpx.TransportError as exc:
+            # ReadError, ConnectError, TimeoutException, etc. — treat as transient;
+            # raise so the job fails cleanly and enters the normal retry queue.
+            raise RuntimeError(f"Network error fetching {source}: {exc}") from exc
+        if resp.status_code in _BLOCKED_STATUSES:
+            domain = urlparse(source).hostname or source
+            raise DomainBlockedException(
+                domain=domain, url=source, status_code=resp.status_code
+            )
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "")
+        is_pdf = "application/pdf" in content_type or source.lower().endswith(".pdf")
+        if is_pdf:
+            return self._extract_pdf_response(resp.content, source)
+        html = resp.text
 
         soup = BeautifulSoup(html, "html.parser")
         for tag in soup(["script", "style", "nav", "footer"]):

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -35,10 +35,14 @@ class UrlSkill(BaseSkill):
     meta = SkillMeta(name="url", description="Fetch and extract text from web URLs",
                      extensions=["https://", "http://"])
 
+    def __init__(self, fetch_timeout: int = 30) -> None:
+        super().__init__()
+        self._fetch_timeout = fetch_timeout
+
     async def extract(self, source: str) -> ExtractedContent:
         try:
             async with httpx.AsyncClient(
-                follow_redirects=True, timeout=30, headers=_HEADERS, verify=_SSL_CONTEXT
+                follow_redirects=True, timeout=self._fetch_timeout, headers=_HEADERS, verify=_SSL_CONTEXT
             ) as client:
                 resp = await client.get(source)
         except httpx.ConnectError as exc:

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
+import logging
 import tempfile
 import httpx
 from bs4 import BeautifulSoup
@@ -7,6 +8,7 @@ from urllib.parse import urlparse
 from synthadoc.skills.base import BaseSkill, ExtractedContent, SkillMeta
 from synthadoc.errors import DomainBlockedException
 
+logger = logging.getLogger(__name__)
 
 _HEADERS = {
     "User-Agent": (
@@ -19,6 +21,15 @@ _HEADERS = {
 # HTTP status codes that indicate bot/access blocking (not transient errors)
 _BLOCKED_STATUSES = {403, 401, 429}
 
+# macOS Python (python.org installer) doesn't use the system keychain.
+# certifi ships its own CA bundle that covers the vast majority of public sites.
+import ssl as _ssl
+try:
+    import certifi as _certifi
+    _SSL_CONTEXT = _ssl.create_default_context(cafile=_certifi.where())
+except ImportError:
+    _SSL_CONTEXT = _ssl.create_default_context()  # fall back to system certs
+
 
 class UrlSkill(BaseSkill):
     meta = SkillMeta(name="url", description="Fetch and extract text from web URLs",
@@ -26,12 +37,18 @@ class UrlSkill(BaseSkill):
 
     async def extract(self, source: str) -> ExtractedContent:
         try:
-            async with httpx.AsyncClient(follow_redirects=True, timeout=30, headers=_HEADERS) as client:
+            async with httpx.AsyncClient(
+                follow_redirects=True, timeout=30, headers=_HEADERS, verify=_SSL_CONTEXT
+            ) as client:
                 resp = await client.get(source)
-        except httpx.TransportError as exc:
-            # ReadError, ConnectError, TimeoutException, etc. — treat as transient;
-            # raise so the job fails cleanly and enters the normal retry queue.
-            raise RuntimeError(f"Network error fetching {source}: {exc}") from exc
+        except httpx.ConnectError as exc:
+            err_str = str(exc)
+            if "CERTIFICATE_VERIFY_FAILED" in err_str or "SSL" in err_str.upper():
+                # SSL errors won't resolve on retry — skip gracefully
+                logger.warning("SSL verification failed for %s — skipping", source)
+                return ExtractedContent(text="", source_path=source,
+                                        metadata={"url": source, "ssl_error": True})
+            raise  # non-SSL ConnectError — let orchestrator handle (retry with backoff)
         if resp.status_code in _BLOCKED_STATUSES:
             domain = urlparse(source).hostname or source
             raise DomainBlockedException(
@@ -58,12 +75,10 @@ class UrlSkill(BaseSkill):
         an empty ExtractedContent is returned so the job completes as 'skipped'
         rather than dying after 3 retries.
         """
-        import logging
         import os
         import pypdf
 
         logging.getLogger("pypdf").setLevel(logging.ERROR)
-        logger = logging.getLogger(__name__)
 
         with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp:
             tmp.write(content)

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -102,6 +102,42 @@ async def test_url_skill_raises_domain_blocked_on_403():
 
 
 @pytest.mark.asyncio
+async def test_url_skill_ssl_error_skips_gracefully():
+    """SSL ConnectError returns empty ExtractedContent instead of raising."""
+    import respx, httpx
+    from synthadoc.skills.url.scripts.main import UrlSkill
+    with respx.mock:
+        respx.get("https://badssl.example/").mock(
+            side_effect=httpx.ConnectError("[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed")
+        )
+        result = await UrlSkill().extract("https://badssl.example/")
+    assert result.text == ""
+    assert result.metadata.get("ssl_error") is True
+
+
+@pytest.mark.asyncio
+async def test_url_skill_connect_timeout_propagates():
+    """ConnectTimeout propagates so the orchestrator can retry with backoff."""
+    import respx, httpx
+    from synthadoc.skills.url.scripts.main import UrlSkill
+    with respx.mock:
+        respx.get("https://slow.example/").mock(side_effect=httpx.ConnectTimeout("timed out"))
+        with pytest.raises(httpx.ConnectTimeout):
+            await UrlSkill().extract("https://slow.example/")
+
+
+@pytest.mark.asyncio
+async def test_url_skill_read_error_propagates():
+    """ReadError propagates so the orchestrator can retry with backoff."""
+    import respx, httpx
+    from synthadoc.skills.url.scripts.main import UrlSkill
+    with respx.mock:
+        respx.get("https://drops.example/").mock(side_effect=httpx.ReadError("connection dropped"))
+        with pytest.raises(httpx.ReadError):
+            await UrlSkill().extract("https://drops.example/")
+
+
+@pytest.mark.asyncio
 async def test_url_skill_extracts_pdf_via_content_type():
     """URLs served with application/pdf content-type route to PDF extraction."""
     import respx, httpx


### PR DESCRIPTION
The extract method catches DomainBlockedException and HTTP status errors, but httpx.ReadError (connection interrupted mid-response) is uncaught — it escapes into the worker loop, which logs it as an unhandled error.

Identified 3 problems:

Four problems here:

1. macOS Python SSL: Python from python.org on macOS doesn't use the system keychain - it needs certifi's CA bundle. Using verify=certifi.where() fixes this for the vast majority of URLs.
2. SSL errors should not retry: Unlike network timeouts, an SSL failure won't resolve on retry - the job should skip gracefully rather than burning retries and becoming dead.

3. The extract method catches DomainBlockedException and HTTP status errors, but httpx.ReadError (connection interrupted mid-response) is uncaught - it escapes into the worker loop, which logs it as an unhandled error. The server isn't truly stuck; it's draining a backlog of retrying URL jobs, but the ReadError path needs to be handled cleanly.

4. the URL skill wraps all httpx.TransportError in a RuntimeError, which hits the generic except Exception branch at line 229 and re-raises - so the worker loop logs it at ERROR with a full traceback.


Here's what are fixed:

- verify=_SSL_VERIFY - httpx now uses certifi's CA bundle (cacert.pem) instead of macOS's system keychain, which Python 3.13 from python.org doesn't access by default. This fixes the CERTIFICATE_VERIFY_FAILED errors for the vast majority of public URLs.
- SSL errors skip gracefully - if a URL still fails SSL verification (e.g. a site with a genuinely expired or self-signed cert), the job returns empty content and completes as skipped rather than burning 3 retries and dying.
- Other transport errors still retry - ReadError, ConnectError, timeout remain retryable as before.
- certifi>=2024.0 added to pyproject.toml dependencies.
- url/scripts/main.py: verify=_SSL_CONTEXT fix (was _SSL_VERIFY, a stale name)
- orchestrator.py: httpx.ConnectError + httpx.ReadError handled at WARNING level with retry
- pyproject.toml: certifi>=2024.0 dependency
- test_skills.py: 3 new tests covering SSL graceful skip, ConnectTimeout propagation, ReadError propagation

