### PR TITLE
fix: run PDF extraction in thread pool to prevent event loop blocking

### DIFF
--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -36,12 +36,7 @@ def get(wiki: str, path: str, timeout: int = 60, **params) -> dict:
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.ReadTimeout:
-        E.cli_error(
-            E.QUERY_TIMEOUT,
-            f"The query timed out waiting for the LLM to respond ({timeout} s).",
-            "The wiki server is still running. Try again — if the wiki is large, "
-            "reduce your question scope or pass --timeout 120 to allow more time.",
-        )
+        _timeout_error(path, timeout)
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
@@ -56,11 +51,7 @@ def post(wiki: str, path: str, body: dict, timeout: int = 60) -> dict:
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.ReadTimeout:
-        E.cli_error(
-            E.QUERY_TIMEOUT,
-            f"The request timed out waiting for the server to respond ({timeout} s).",
-            "The wiki server is still running. Try again.",
-        )
+        _timeout_error(path, timeout)
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
@@ -77,6 +68,29 @@ def delete(wiki: str, path: str) -> dict:
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
+
+
+def _timeout_error(path: str, timeout: int) -> None:
+    if "/query" in path:
+        E.cli_error(
+            E.QUERY_TIMEOUT,
+            f"The query timed out waiting for the LLM to respond ({timeout} s).",
+            "The wiki server is still running. Try again — if the wiki is large, "
+            "reduce your question scope or pass --timeout 120 to allow more time.",
+        )
+    elif "/jobs" in path:
+        E.cli_error(
+            E.QUERY_TIMEOUT,
+            f"The server did not respond to '{path}' within {timeout} s.",
+            "The server may be busy processing a large file (e.g. a PDF). "
+            "Wait a moment and try again.",
+        )
+    else:
+        E.cli_error(
+            E.QUERY_TIMEOUT,
+            f"The request timed out waiting for the server to respond ({timeout} s).",
+            "The wiki server is still running. Try again.",
+        )
 
 
 def _detail(response: httpx.Response) -> str:

--- a/synthadoc/cli/jobs.py
+++ b/synthadoc/cli/jobs.py
@@ -33,7 +33,7 @@ def jobs_list(
 ):
     """List all jobs for this wiki."""
     params = {"status": status} if status else {}
-    jobs = get(wiki, "/jobs", **params)
+    jobs = get(wiki, "/jobs", timeout=10, **params)
     if not jobs:
         typer.echo("No jobs found.")
         return

--- a/synthadoc/skills/pdf/scripts/main.py
+++ b/synthadoc/skills/pdf/scripts/main.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
+import asyncio
 import logging
 
 import pypdf
@@ -22,7 +23,11 @@ class PdfSkill(BaseSkill):
     meta = SkillMeta(name="pdf", description="Extract text from PDF files", extensions=[".pdf"])
 
     async def extract(self, source: str) -> ExtractedContent:
-        text, num_pages = self._extract_pypdf(source)
+        # pypdf and pdfminer are synchronous CPU-bound libraries; run them in a
+        # thread pool so they do not block the asyncio event loop and starve
+        # other coroutines (e.g. HTTP handlers, jobs list) while processing
+        # large PDFs.
+        text, num_pages = await asyncio.to_thread(self._extract_pypdf, source)
 
         # Low yield → likely CJK fonts that pypdf cannot decode; try pdfminer fallback
         if num_pages > 0 and len(text.strip()) < num_pages * _MIN_CHARS_PER_PAGE:
@@ -30,7 +35,7 @@ class PdfSkill(BaseSkill):
                 "pypdf yielded %d chars for %d page(s) in %s — trying pdfminer fallback",
                 len(text.strip()), num_pages, source,
             )
-            fallback = self._extract_pdfminer(source)
+            fallback = await asyncio.to_thread(self._extract_pdfminer, source)
             if len(fallback.strip()) > len(text.strip()):
                 text = fallback
 

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -62,7 +62,8 @@ class UrlSkill(BaseSkill):
         content_type = resp.headers.get("content-type", "")
         is_pdf = "application/pdf" in content_type or source.lower().endswith(".pdf")
         if is_pdf:
-            return self._extract_pdf_response(resp.content, source)
+            import asyncio
+            return await asyncio.to_thread(self._extract_pdf_response, resp.content, source)
         html = resp.text
 
         soup = BeautifulSoup(html, "html.parser")


### PR DESCRIPTION
pypdf and pdfminer are synchronous CPU-bound libraries. Calling them directly inside async def blocked the event loop during large PDF processing, causing jobs list and other HTTP handlers to time out with a misleading ERR-QUERY-001 error.

- skills/pdf: await asyncio.to_thread() for pypdf and pdfminer calls
- skills/url: await asyncio.to_thread() for _extract_pdf_response
- cli/jobs.py: 10s timeout on jobs list (DB read, never needs 60s)
- cli/_http.py: endpoint-aware timeout error messages