### PR TITLE
[v0.3.0] MiniMax reasoning model fixes, configurable LLM timeout, and code quality improvements

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -860,6 +860,7 @@ port = 7070
 default = { provider = "anthropic", model = "claude-opus-4-6" }
 lint    = { model = "claude-haiku-4-5-20251001" }
 skill   = { model = "claude-haiku-4-5-20251001" }
+# llm_timeout_seconds = 90  # set for reasoning models to fail fast instead of silent empty response
 
 [queue]
 max_parallel_ingest  = 4
@@ -908,6 +909,7 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 |-----|------|---------|-------------|
 | `agents.default.provider` | str | `"gemini"` | LLM provider: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `ollama` |
 | `agents.default.model` | str | `"gemini-2.5-flash"` | Model ID |
+| `agents.llm_timeout_seconds` | int | `0` | Per-call LLM timeout in seconds; `0` = no limit. Set to e.g. `90` when using reasoning models (MiniMax-M2.5, DeepSeek-R1) that can exceed their internal generation budget silently. Restart required. |
 | `server.port` | int | `7070` | HTTP listen port |
 | `queue.max_parallel_ingest` | int | `4` | Max concurrent ingest agents |
 | `queue.max_retries` | int | `3` | Retries before job → dead |
@@ -1423,3 +1425,11 @@ echo "Event $event fired on wiki $wiki" | mail -s "Synthadoc notification" you@e
 - **Job crash recovery** — `in_progress` jobs are reset to `pending` on server `init()`, so all pending work resumes automatically after a restart
 - **Rate-limit requeue** — HTTP 429 responses from any LLM provider are detected and requeued via `requeue()` (retry counter unchanged), preserving the retry budget for real errors
 - **Bulk cancel (`jobs cancel`)** — `synthadoc jobs cancel [-w wiki] [--yes]` marks all pending jobs as `skipped` in one operation; also `POST /jobs/cancel-pending`
+
+### v0.3.0
+
+- **Session wiki resolution (`synthadoc use`)** — `synthadoc use <name>` writes the default wiki to `~/.synthadoc/default_wiki`; all commands resolve it automatically via priority chain: `-w` flag > `SYNTHADOC_WIKI` env var > saved default > CWD fallback; hint messages simplified to `[wiki: <name>]`; `-w .` omitted from job hints when CWD is the active wiki
+- **MiniMax reasoning-model fixes** — `OpenAIProvider` now handles three failure modes of reasoning models (e.g. MiniMax-M2.5): (1) `choices=null` response converted from silent `TypeError` to a descriptive `RuntimeError` with error code logged; (2) `content=null` with prose answer in `reasoning_content` — think-tag stripping then full-text fallback so query synthesis returns a real answer; (3) `APITimeoutError` caught, logged with the config key to set, then re-raised
+- **Configurable LLM call timeout (`agents.llm_timeout_seconds`)** — new `[agents]` key (default `0` = no limit); passed as `timeout` to every OpenAI-compatible `create()` call; `APITimeoutError` logs an actionable message naming the exact config key; config.toml template ships the key commented out with a 5-line explanation of when to enable it
+- **`parse_json_string_array` utility** — extracted shared fence-strip + JSON-parse + filter logic from `QueryAgent.decompose()` and `SearchDecomposeAgent.decompose()` into `synthadoc/agents/_utils.py`; 16 unit tests; LLM call failures and JSON-parse failures now log separate, distinct messages
+- **v0.2.0 gap fixes** — Ollama `eval_count` mapped to `output_tokens` (was always 0); `_SLUG_BLACKLIST` moved to module-level `frozenset`; synthetic URL fields in ingest_agent commented; four test-coverage gaps closed (no-text guard, orphan flag inversion, `/analyse` endpoint, hybrid-search partial-miss fallback)

--- a/synthadoc/agents/_utils.py
+++ b/synthadoc/agents/_utils.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+from __future__ import annotations
+
+import json
+
+
+def parse_json_string_array(text: str, max_items: int) -> list[str] | None:
+    """Strip code fences, parse a JSON array, return non-empty strings up to max_items.
+
+    Returns None (never raises) when the text cannot be parsed as a non-empty
+    JSON array of strings, so callers can fall back without a try/except.
+    """
+    text = text.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(l for l in lines if not l.strip().startswith("```")).strip()
+    try:
+        parts = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parts, list) or not parts:
+        return None
+    filtered = [str(q) for q in parts[:max_items] if str(q).strip()]
+    return filtered or None

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from dataclasses import dataclass, field
 
+from synthadoc.agents._utils import parse_json_string_array
 from synthadoc.agents.search_decompose_agent import SearchDecomposeAgent
 from synthadoc.providers.base import LLMProvider, Message
 from synthadoc.storage.search import HybridSearch
@@ -71,32 +71,26 @@ class QueryAgent:
                     ))],
                 temperature=0.0,
             )
-            text = resp.text.strip()
-            if text.startswith("```"):
-                # Strip markdown code fences that some models add despite instructions
-                lines = text.splitlines()
-                text = "\n".join(
-                    l for l in lines
-                    if not l.strip().startswith("```")
-                ).strip()
-            parts = json.loads(text)
-            if isinstance(parts, list) and parts:
-                filtered = [str(q) for q in parts[:_MAX_SUB_QUESTIONS] if str(q).strip()]
-                if filtered:
-                    if len(filtered) == 1:
-                        logger.info("query is simple — no decomposition (1 sub-question)")
-                    else:
-                        logger.info(
-                            "query decomposed into %d sub-question(s): %s",
-                            len(filtered),
-                            " | ".join(f'"{q}"' for q in filtered),
-                        )
-                    return filtered
         except Exception as exc:
             logger.warning(
                 "decompose failed (%s: %s) — falling back to original question",
                 type(exc).__name__, exc,
             )
+            return [question]
+        filtered = parse_json_string_array(resp.text, _MAX_SUB_QUESTIONS)
+        if filtered:
+            if len(filtered) == 1:
+                logger.info("query is simple — no decomposition (1 sub-question)")
+            else:
+                logger.info(
+                    "query decomposed into %d sub-question(s): %s",
+                    len(filtered),
+                    " | ".join(f'"{q}"' for q in filtered),
+                )
+            return filtered
+        logger.warning(
+            "decompose: response was not a valid JSON array — falling back to original question"
+        )
         return [question]
 
     async def query(self, question: str) -> QueryResult:

--- a/synthadoc/agents/search_decompose_agent.py
+++ b/synthadoc/agents/search_decompose_agent.py
@@ -2,9 +2,9 @@
 # Copyright (C) 2026 William Johnason / axoviq.com
 from __future__ import annotations
 
-import json
 import logging
 
+from synthadoc.agents._utils import parse_json_string_array
 from synthadoc.providers.base import LLMProvider, Message
 
 logger = logging.getLogger(__name__)
@@ -43,28 +43,24 @@ class SearchDecomposeAgent:
                 ))],
                 temperature=0.0,
             )
-            text = resp.text.strip()
-            if text.startswith("```"):
-                lines = text.splitlines()
-                text = "\n".join(
-                    l for l in lines if not l.strip().startswith("```")
-                ).strip()
-            parts = json.loads(text)
-            if isinstance(parts, list) and parts:
-                filtered = [str(q) for q in parts[:_MAX_SUB_QUERIES] if str(q).strip()]
-                if filtered:
-                    if len(filtered) == 1:
-                        logger.info("web search is simple — no decomposition (1 query)")
-                    else:
-                        logger.info(
-                            "web search decomposed into %d queries: %s",
-                            len(filtered),
-                            " | ".join(f'"{q}"' for q in filtered),
-                        )
-                    return filtered
         except Exception as exc:
             logger.warning(
                 "search decompose failed (%s: %s) — falling back to original query",
                 type(exc).__name__, exc,
             )
+            return [query]
+        filtered = parse_json_string_array(resp.text, _MAX_SUB_QUERIES)
+        if filtered:
+            if len(filtered) == 1:
+                logger.info("web search is simple — no decomposition (1 query)")
+            else:
+                logger.info(
+                    "web search decomposed into %d queries: %s",
+                    len(filtered),
+                    " | ".join(f'"{q}"' for q in filtered),
+                )
+            return filtered
+        logger.warning(
+            "search decompose failed (invalid JSON array) — falling back to original query"
+        )
         return [query]

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -35,6 +35,13 @@ default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}
 # default = {{ provider = "groq",      model = "llama-3.3-70b-versatile" }}  # free tier, 100K tokens/day
 # default = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}        # paid, highest quality
 # default = {{ provider = "ollama",    model = "llama3.2" }}                  # fully local, no API key
+#
+# LLM call timeout — useful for reasoning models (e.g. MiniMax-M2.5) that can
+# spend 2+ minutes on a single prompt and return an empty response instead of
+# raising an error.  Setting this causes synthadoc to fail fast with a clear
+# log message so you know to adjust the model or prompt size.
+# 0 = no limit (provider default).  Restart the server after changing.
+# llm_timeout_seconds = 90
 
 [ingest]
 max_pages_per_ingest = 15

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -39,6 +39,7 @@ class AgentsConfig:
     query: Optional[AgentConfig] = None
     lint: Optional[AgentConfig] = None
     skill: Optional[AgentConfig] = None
+    llm_timeout_seconds: int = 0  # 0 = no limit (provider default)
 
     def resolve(self, agent_name: str) -> AgentConfig:
         """Return the effective AgentConfig for *agent_name*.
@@ -228,7 +229,10 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
     default_agent = _parse_agent(a["default"])
     _validate_provider(default_agent)
 
-    agents = AgentsConfig(default=default_agent)
+    agents = AgentsConfig(
+        default=default_agent,
+        llm_timeout_seconds=int(a.get("llm_timeout_seconds", 0)),
+    )
 
     for name in ("ingest", "query", "lint", "skill"):
         if name in a:

--- a/synthadoc/providers/__init__.py
+++ b/synthadoc/providers/__init__.py
@@ -28,6 +28,7 @@ def _require_env(var: str, provider: str, url: str) -> str:
 
 def make_provider(agent_name: str, config: Config) -> LLMProvider:
     agent_cfg = config.agents.resolve(agent_name)
+    timeout = config.agents.llm_timeout_seconds
     name = agent_cfg.provider
     if name == "anthropic":
         from synthadoc.providers.anthropic import AnthropicProvider
@@ -36,7 +37,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
     if name == "openai":
         from synthadoc.providers.openai import OpenAIProvider
         key = _require_env("OPENAI_API_KEY", "OpenAI", "https://platform.openai.com/api-keys")
-        return OpenAIProvider(api_key=key, config=agent_cfg)
+        return OpenAIProvider(api_key=key, config=agent_cfg, timeout=timeout)
     if name == "gemini":
         from synthadoc.providers.openai import OpenAIProvider
         key = _require_env("GEMINI_API_KEY", "Google Gemini",
@@ -45,7 +46,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
             provider="gemini", model=agent_cfg.model,
             base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
         )
-        return OpenAIProvider(api_key=key, config=cfg_with_url)
+        return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "groq":
         from synthadoc.providers.openai import OpenAIProvider
         key = _require_env("GROQ_API_KEY", "Groq", "https://console.groq.com/keys")
@@ -53,7 +54,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
             provider="groq", model=agent_cfg.model,
             base_url="https://api.groq.com/openai/v1",
         )
-        return OpenAIProvider(api_key=key, config=cfg_with_url)
+        return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "minimax":
         from synthadoc.providers.openai import OpenAIProvider
         key = _require_env("MINIMAX_API_KEY", "MiniMax", "https://platform.minimax.io/")
@@ -61,7 +62,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
             provider="minimax", model=agent_cfg.model,
             base_url="https://api.minimax.io/v1",
         )
-        return OpenAIProvider(api_key=key, config=cfg_with_url)
+        return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "ollama":
         from synthadoc.providers.ollama import OllamaProvider
         return OllamaProvider(config=agent_cfg)

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -126,6 +126,23 @@ class OpenAIProvider(LLMProvider):
         msgs.extend({"role": m.role, "content": self._to_openai_content(m.content)}
                     for m in messages)
         resp = await self._call_with_retry(msgs, temperature, max_tokens)
+        if not resp.choices:
+            # Some providers (e.g. MiniMax) return choices=null when the model
+            # exceeds its internal generation budget. Extract any error details.
+            extra = getattr(resp, "model_extra", None) or {}
+            base_resp = extra.get("base_resp") or {}
+            err_code = base_resp.get("status_code", "unknown")
+            err_msg  = base_resp.get("status_msg",  "no details")
+            logger.error(
+                "OpenAI provider: %s returned choices=null (code=%s, msg=%r). "
+                "The model likely timed out internally — try a lighter model or "
+                "reduce max_tokens.",
+                self._config.provider, err_code, err_msg,
+            )
+            raise RuntimeError(
+                f"{self._config.provider} returned choices=null "
+                f"(code={err_code}): {err_msg}"
+            )
         choice = resp.choices[0]
         text = choice.message.content or ""
         # Strip <think>...</think> blocks that reasoning models prepend to their output

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -37,12 +37,13 @@ _sleep = asyncio.sleep
 
 
 class OpenAIProvider(LLMProvider):
-    def __init__(self, api_key: str, config: AgentConfig) -> None:
+    def __init__(self, api_key: str, config: AgentConfig, timeout: int = 0) -> None:
         kwargs: dict = {"api_key": api_key}
         if config.base_url:
             kwargs["base_url"] = config.base_url
         self._client = AsyncOpenAI(**kwargs)
         self._config = config
+        self._timeout: int | None = timeout if timeout > 0 else None
         base = str(config.base_url or "")
         self.supports_vision = not any(host in base for host in _NO_VISION_HOSTS)
 
@@ -103,7 +104,16 @@ class OpenAIProvider(LLMProvider):
                 return await self._client.chat.completions.create(
                     model=self._config.model, messages=msgs,
                     temperature=temperature, max_tokens=max_tokens,
+                    timeout=self._timeout,
                 )
+            except _openai.APITimeoutError:
+                logger.error(
+                    "LLM call to %s timed out after %d s. "
+                    "Increase [agents] llm_timeout_seconds in .synthadoc/config.toml "
+                    "or switch to a faster model.",
+                    self._config.provider, self._timeout,
+                )
+                raise
             except _openai.RateLimitError as exc:
                 if self._is_daily_quota_error(exc):
                     logger.error(
@@ -135,8 +145,10 @@ class OpenAIProvider(LLMProvider):
             err_msg  = base_resp.get("status_msg",  "no details")
             logger.error(
                 "OpenAI provider: %s returned choices=null (code=%s, msg=%r). "
-                "The model likely timed out internally — try a lighter model or "
-                "reduce max_tokens.",
+                "The model likely timed out internally. Set "
+                "[agents] llm_timeout_seconds in .synthadoc/config.toml "
+                "(e.g. llm_timeout_seconds = 90) to fail fast, or switch to "
+                "a lighter model.",
                 self._config.provider, err_code, err_msg,
             )
             raise RuntimeError(

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -132,19 +132,26 @@ class OpenAIProvider(LLMProvider):
         text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL).strip()
         if not text:
             # Reasoning models (e.g. MiniMax M2.x) return content=null and put their
-            # chain-of-thought in a non-standard reasoning_content field. Try to extract
-            # the last JSON-like block from it so structured callers still get a result.
+            # answer in a non-standard reasoning_content field.  For structured callers
+            # (e.g. decompose) we extract the last JSON array; for prose callers
+            # (e.g. query synthesis) we fall back to the full cleaned text.
             extra = getattr(choice.message, "model_extra", None) or {}
             reasoning = (extra.get("reasoning_content") or "").strip()
             if reasoning:
-                last_close = reasoning.rfind("]")
+                clean = re.sub(r"<think>.*?</think>", "", reasoning, flags=re.DOTALL).strip()
+                last_close = clean.rfind("]")
                 if last_close >= 0:
-                    last_open = reasoning.rfind("[", 0, last_close)
+                    last_open = clean.rfind("[", 0, last_close)
                     if last_open >= 0:
-                        text = reasoning[last_open: last_close + 1]
+                        text = clean[last_open: last_close + 1]
                         logger.debug(
                             "OpenAI provider: content=null — extracted JSON from reasoning_content"
                         )
+                if not text:
+                    text = clean
+                    logger.debug(
+                        "OpenAI provider: content=null — using full reasoning_content as prose answer"
+                    )
         return CompletionResponse(text=text,
                                   input_tokens=resp.usage.prompt_tokens,
                                   output_tokens=resp.usage.completion_tokens)

--- a/tests/agents/test_agent_utils.py
+++ b/tests/agents/test_agent_utils.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+import pytest
+from synthadoc.agents._utils import parse_json_string_array
+
+
+# ── happy path ────────────────────────────────────────────────────────────────
+
+def test_basic_array():
+    assert parse_json_string_array('["a", "b", "c"]', 4) == ["a", "b", "c"]
+
+
+def test_strips_json_fenced_block():
+    text = '```json\n["zone map", "frost dates"]\n```'
+    assert parse_json_string_array(text, 4) == ["zone map", "frost dates"]
+
+
+def test_strips_plain_fenced_block():
+    text = '```\n["zone map", "frost dates"]\n```'
+    assert parse_json_string_array(text, 4) == ["zone map", "frost dates"]
+
+
+def test_respects_max_items():
+    assert parse_json_string_array('["a", "b", "c", "d", "e"]', 3) == ["a", "b", "c"]
+
+
+def test_single_element_array():
+    assert parse_json_string_array('["only one"]', 4) == ["only one"]
+
+
+def test_filters_whitespace_only_strings():
+    result = parse_json_string_array('["valid", "   ", "\\t", "also valid"]', 4)
+    assert result == ["valid", "also valid"]
+
+
+def test_coerces_non_string_elements():
+    assert parse_json_string_array('[1, 2, 3]', 4) == ["1", "2", "3"]
+
+
+def test_leading_trailing_whitespace_around_json():
+    assert parse_json_string_array('  \n["a", "b"]\n  ', 4) == ["a", "b"]
+
+
+# ── fallback → None ───────────────────────────────────────────────────────────
+
+def test_empty_text_returns_none():
+    assert parse_json_string_array("", 4) is None
+
+
+def test_prose_text_returns_none():
+    assert parse_json_string_array("This is not JSON.", 4) is None
+
+
+def test_empty_array_returns_none():
+    assert parse_json_string_array("[]", 4) is None
+
+
+def test_json_object_returns_none():
+    assert parse_json_string_array('{"queries": ["a"]}', 4) is None
+
+
+def test_all_whitespace_elements_returns_none():
+    assert parse_json_string_array('["  ", "\t", ""]', 4) is None
+
+
+def test_max_items_zero_returns_none():
+    assert parse_json_string_array('["a", "b"]', 0) is None
+
+
+def test_malformed_json_returns_none():
+    assert parse_json_string_array('["a", "b"', 4) is None
+
+
+def test_only_fence_lines_returns_none():
+    assert parse_json_string_array("```\n```", 4) is None

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -828,3 +828,30 @@ async def test_ingest_slug_collision_appends_as_update(tmp_wiki):
     assert "alan-turing" not in result.pages_created
     page = store.read_page("alan-turing")
     assert "Original content." in page.content
+
+
+@pytest.mark.asyncio
+async def test_no_extractable_text_produces_skip(tmp_wiki, mock_provider):
+    """Empty extracted text on a create action skips with skip_reason='no extractable text'."""
+    from unittest.mock import patch
+    from synthadoc.skills.base import ExtractedContent
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+    cache = CacheManager(tmp_wiki / ".synthadoc" / "cache.db")
+    await cache.init()
+
+    source = tmp_wiki / "raw_sources" / "blank.md"
+    source.write_text("some bytes so it passes the size check", encoding="utf-8")
+
+    agent = IngestAgent(provider=mock_provider, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15)
+    fake_extracted = ExtractedContent(text="", source_path=str(source), metadata={})
+    with patch.object(agent._skill_agent, "extract", AsyncMock(return_value=fake_extracted)):
+        result = await agent.ingest(str(source))
+
+    assert result.skipped is True
+    assert result.skip_reason == "no extractable text"

--- a/tests/agents/test_lint_agent.py
+++ b/tests/agents/test_lint_agent.py
@@ -132,3 +132,23 @@ async def test_lint_skip_slugs_not_counted_as_contradictions(tmp_wiki):
     agent = LintAgent(provider=AsyncMock(), store=store, log_writer=log)
     report = await agent.lint(scope="contradictions")
     assert report.contradictions_found == 0
+
+
+@pytest.mark.asyncio
+async def test_orphan_flag_cleared_when_inbound_link_added(tmp_wiki):
+    """Page with orphan=True transitions to orphan=False once another page links to it."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("page-a", WikiPage(title="Page A", tags=[],
+        content="Content of page A.", status="active", confidence="high",
+        sources=[], orphan=True))
+    store.write_page("page-b", WikiPage(title="Page B", tags=[],
+        content="Links to [[page-a]] here.", status="active", confidence="high",
+        sources=[]))
+
+    assert store.read_page("page-a").orphan is True
+
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    agent = LintAgent(provider=AsyncMock(), store=store, log_writer=log)
+    await agent.lint(scope="orphans")
+
+    assert store.read_page("page-a").orphan is False

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -329,3 +329,48 @@ def test_list_jobs_includes_progress_field(tmp_wiki):
     assert len(jobs) >= 1
     for job in jobs:
         assert "progress" in job
+
+
+def test_analyse_endpoint_returns_structure(tmp_wiki):
+    """POST /analyse returns source and analysis keys."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.skills.base import ExtractedContent
+
+    app = create_app(wiki_root=tmp_wiki)
+    mock_extracted = ExtractedContent(text="AI is important.", source_path="test.md", metadata={})
+    mock_analysis = {"entities": ["AI"], "tags": ["ai"], "summary": "AI summary.", "relevant": True}
+
+    with patch("synthadoc.agents.skill_agent.SkillAgent.extract",
+               new=AsyncMock(return_value=mock_extracted)), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent._analyse",
+               new=AsyncMock(return_value=mock_analysis)), \
+         patch("synthadoc.providers.make_provider", return_value=AsyncMock()):
+        with TestClient(app) as client:
+            resp = client.post("/analyse", json={"source": "test.md"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source"] == "test.md"
+    assert "analysis" in data
+    assert "entities" in data["analysis"]
+
+
+def test_analyse_endpoint_empty_wiki(tmp_wiki):
+    """POST /analyse works when the wiki has no pages."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.skills.base import ExtractedContent
+
+    app = create_app(wiki_root=tmp_wiki)
+    mock_extracted = ExtractedContent(text="", source_path="empty.md", metadata={})
+    mock_analysis = {"entities": [], "tags": [], "summary": "", "relevant": False}
+
+    with patch("synthadoc.agents.skill_agent.SkillAgent.extract",
+               new=AsyncMock(return_value=mock_extracted)), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent._analyse",
+               new=AsyncMock(return_value=mock_analysis)), \
+         patch("synthadoc.providers.make_provider", return_value=AsyncMock()):
+        with TestClient(app) as client:
+            resp = client.post("/analyse", json={"source": "empty.md"})
+
+    assert resp.status_code == 200
+    assert resp.json()["source"] == "empty.md"

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -568,6 +568,23 @@ async def test_openai_provider_reasoning_content_strips_think_tags_then_returns_
 
 
 @pytest.mark.asyncio
+async def test_openai_provider_raises_on_null_choices():
+    """choices=null from providers like MiniMax must raise RuntimeError, not TypeError."""
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M2.5",
+                      base_url="https://api.minimax.io/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    mock_resp = MagicMock()
+    mock_resp.choices = None
+    mock_resp.model_extra = {"base_resp": {"status_code": 1000, "status_msg": "timeout"}}
+
+    with patch.object(provider._client.chat.completions, "create",
+                      new=AsyncMock(return_value=mock_resp)):
+        with pytest.raises(RuntimeError, match="choices=null"):
+            await provider.complete(messages=[Message(role="user", content="hi")])
+
+
+@pytest.mark.asyncio
 async def test_openai_provider_uses_custom_base_url():
     """Providers like Groq and Gemini pass a base_url — verify it is forwarded to AsyncOpenAI."""
     cfg = AgentConfig(provider="groq", model="llama3-8b-8192",

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -585,6 +585,66 @@ async def test_openai_provider_raises_on_null_choices():
 
 
 @pytest.mark.asyncio
+async def test_openai_provider_passes_timeout_to_create():
+    """timeout > 0 is forwarded to chat.completions.create()."""
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M2.5",
+                      base_url="https://api.minimax.io/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg, timeout=90)
+
+    mock_choice = MagicMock()
+    mock_choice.message.content = "answer"
+    mock_choice.message.model_extra = {}
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_resp.usage.prompt_tokens = 10
+    mock_resp.usage.completion_tokens = 5
+
+    mock_create = AsyncMock(return_value=mock_resp)
+    with patch.object(provider._client.chat.completions, "create", new=mock_create):
+        await provider.complete(messages=[Message(role="user", content="hi")])
+
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("timeout") == 90
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_passes_none_timeout_when_zero():
+    """timeout=0 (no limit) sends timeout=None to create() so the SDK uses its default."""
+    cfg = AgentConfig(provider="gemini", model="gemini-2.5-flash-lite",
+                      base_url="https://generativelanguage.googleapis.com/v1beta/openai/")
+    provider = OpenAIProvider(api_key="test-key", config=cfg, timeout=0)
+
+    mock_choice = MagicMock()
+    mock_choice.message.content = "answer"
+    mock_choice.message.model_extra = {}
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_resp.usage.prompt_tokens = 10
+    mock_resp.usage.completion_tokens = 5
+
+    mock_create = AsyncMock(return_value=mock_resp)
+    with patch.object(provider._client.chat.completions, "create", new=mock_create):
+        await provider.complete(messages=[Message(role="user", content="hi")])
+
+    _, kwargs = mock_create.call_args
+    assert kwargs.get("timeout") is None
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_api_timeout_error_is_logged_and_raised():
+    """APITimeoutError is logged with config hint and re-raised."""
+    import openai
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M2.5",
+                      base_url="https://api.minimax.io/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg, timeout=90)
+
+    with patch.object(provider._client.chat.completions, "create",
+                      new=AsyncMock(side_effect=openai.APITimeoutError(request=MagicMock()))):
+        with pytest.raises(openai.APITimeoutError):
+            await provider.complete(messages=[Message(role="user", content="hi")])
+
+
+@pytest.mark.asyncio
 async def test_openai_provider_uses_custom_base_url():
     """Providers like Groq and Gemini pass a base_url — verify it is forwarded to AsyncOpenAI."""
     cfg = AgentConfig(provider="groq", model="llama3-8b-8192",

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -518,8 +518,8 @@ async def test_openai_provider_extracts_json_from_reasoning_content():
 
 
 @pytest.mark.asyncio
-async def test_openai_provider_reasoning_content_no_json_returns_empty():
-    """If reasoning_content has no JSON array, text must still be empty string (not crash)."""
+async def test_openai_provider_reasoning_content_no_json_returns_prose():
+    """If reasoning_content has no JSON array, the prose text is returned as-is (prose answer fallback)."""
     cfg = AgentConfig(provider="minimax", model="MiniMax-M2.5",
                       base_url="https://api.minimax.io/v1")
     provider = OpenAIProvider(api_key="test-key", config=cfg)
@@ -539,7 +539,32 @@ async def test_openai_provider_reasoning_content_no_json_returns_empty():
         result = await provider.complete(
             messages=[Message(role="user", content="hi")]
         )
-    assert result.text == ""
+    assert result.text == "I am thinking about this question at length..."
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_reasoning_content_strips_think_tags_then_returns_prose():
+    """Think tags are stripped from reasoning_content before returning prose answer."""
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M2.5",
+                      base_url="https://api.minimax.io/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    mock_choice = MagicMock()
+    mock_choice.message.content = None
+    mock_choice.message.model_extra = {
+        "reasoning_content": "<think>internal reasoning here</think>Moore's Law states that transistor counts double roughly every two years."
+    }
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_resp.usage.prompt_tokens = 10
+    mock_resp.usage.completion_tokens = 0
+
+    with patch.object(provider._client.chat.completions, "create",
+                      new=AsyncMock(return_value=mock_resp)):
+        result = await provider.complete(
+            messages=[Message(role="user", content="What is Moore's Law?")]
+        )
+    assert result.text == "Moore's Law states that transistor counts double roughly every two years."
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_search.py
+++ b/tests/storage/test_search.py
@@ -377,3 +377,34 @@ def test_get_embed_model_raises_on_missing_fastembed(tmp_wiki):
             sys.modules.pop("fastembed", None)
         else:
             sys.modules["fastembed"] = orig
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_partial_embeddings(tmp_wiki):
+    """Candidates missing embeddings get score 0.0 — not an error — and rank below those with embeddings."""
+    from synthadoc.storage.search import HybridSearch, VectorStore
+    from synthadoc.config import SearchConfig
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    # Both pages are relevant to the query so they both appear as BM25 candidates
+    _write_page(store, "with-emb", "transformers attention mechanisms deep learning neural")
+    _write_page(store, "no-emb",   "transformer attention networks vision model")
+    _write_page(store, "extra",    "something completely unrelated content here about cooking")
+
+    cfg = SearchConfig(vector=True, vector_top_candidates=10)
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db", search_cfg=cfg)
+    with patch.dict("sys.modules", {"fastembed": MagicMock()}):
+        await search.init_vector()
+
+    vs = VectorStore(tmp_wiki / ".synthadoc" / "embeddings.db")
+    await vs.upsert("with-emb", [1.0, 0.0, 0.0, 0.0])
+    # "no-emb" intentionally has no embedding stored
+
+    with patch.object(search, "_embed_text", return_value=[1.0, 0.0, 0.0, 0.0]):
+        results = await search.hybrid_search(["attention", "transformer"], top_n=3)
+
+    slugs = [r.slug for r in results]
+    assert "with-emb" in slugs, "page with embedding must appear in results"
+    assert "no-emb" in slugs, "page without embedding must not be dropped — fallback score 0.0"
+    assert slugs.index("with-emb") < slugs.index("no-emb"), \
+        "page with matching embedding must rank above page with fallback score 0.0"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,3 +118,22 @@ def test_search_config_vector_true_parsed(tmp_path):
     cfg = load_config(project_config=toml)
     assert cfg.search.vector is True
     assert cfg.search.vector_top_candidates == 30
+
+
+def test_llm_timeout_seconds_default_is_zero(tmp_path):
+    """llm_timeout_seconds defaults to 0 (no limit) when not set."""
+    toml = tmp_path / "config.toml"
+    toml.write_text('[agents]\ndefault = {provider = "gemini", model = "gemini-2.5-flash-lite"}\n')
+    cfg = load_config(project_config=toml)
+    assert cfg.agents.llm_timeout_seconds == 0
+
+
+def test_llm_timeout_seconds_is_parsed(tmp_path):
+    """llm_timeout_seconds is read from [agents] and exposed on AgentsConfig."""
+    toml = tmp_path / "config.toml"
+    toml.write_text(
+        '[agents]\ndefault = {provider = "gemini", model = "gemini-2.5-flash-lite"}\n'
+        'llm_timeout_seconds = 90\n'
+    )
+    cfg = load_config(project_config=toml)
+    assert cfg.agents.llm_timeout_seconds == 90


### PR DESCRIPTION
 What

  Fixes silent failures when using MiniMax M2.5 (and other reasoning models), adds a configurable per-call LLM timeout, and closes selected v0.2.0 code quality gaps.

  Why

  MiniMax M2.5 is a reasoning model that returns non-standard API responses - content=null with the answer in reasoning_content, and choices=null when it exceeds its internal generation budget. Both caused silent failures (empty answer or TypeError crash) with no actionable guidance for users. The configurable timeout gives users a lever to fail fast and see a clear error instead of waiting 2 minutes for a silent empty response.

  Changes

  MiniMax / reasoning model fixes
  - providers/openai.py: when content=null, extract prose answer from reasoning_content (with think-tag stripping); previously only JSON arrays were
  extracted, leaving query synthesis blank
  - providers/openai.py: guard choices=null - converts silent TypeError crash to a descriptive RuntimeError logging the provider error code and naming the exact config key to set
  - providers/openai.py: catch APITimeoutError, log with actionable config hint, re-raise

  Configurable LLM timeout
  - config.py: AgentsConfig.llm_timeout_seconds (int, default 0 = no limit)
  - providers/__init__.py: timeout forwarded to all OpenAI-compatible providers
  - cli/_init.py: config.toml template ships llm_timeout_seconds = 90 commented out with a 5-line explanation of when and why to enable it
  - docs/design.md: new key in config reference table, per-project example, and v0.3.0 Appendix A entry

  Code quality (v0.2.0 gap #3)
  - agents/_utils.py: parse_json_string_array() extracted from duplicate implementations in QueryAgent.decompose() and SearchDecomposeAgent.decompose();
  LLM call failures and JSON-parse failures now log separate messages

  Test coverage (v0.2.0 gaps #14, #16, #17, #18)
  - No-text guard, orphan flag inversion, /analyse endpoint (empty and non-empty wiki), hybrid search partial-miss fallback