### PR TITLE
[v0.3.0] feat: add DeepSeek provider + fix 401/402 HTTP error classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Normalize line endings: text files use LF in the repo
+* text=auto eol=lf
+
+# Binaries — no conversion
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.eot binary
+*.pdf binary

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ As the wiki accumulates pages the `index.md` table of contents, domain scope (`p
 | Offline browsable artifact   | **Yes**                                                        | No          | No         | No        |
 | Multi-wiki isolation         | **Yes**                                                        | No          | No         | No        |
 | Web search → wiki pages     | **Yes**                                                        | No          | No         | No        |
-| Multiple LLMs support       | **Yes** (MiniMax, Gemini, Groq, Anthropic, DeepSeek, Ollama) | No          | No         | No        |
+| Multiple LLMs support       | **Yes** (Gemini, Groq, MiniMax, DeepSeek, Anthropic, OpenAI, Ollama) | No          | No         | No        |
 | Auto wiki overview page      | **Yes**                                                        | No          | No         | No        |
 | Resumable job queue + retry  | **Yes**                                                        | No          | No         | No        |
 | Query decomposition          | **Yes** (parallel sub-queries)                                 | No          | No         | No        |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Most knowledge-management tools retrieve and summarize at query time. Synthadoc 
 | LLM wiki vs. RAG         | Pre-compiled structured knowledge beats query-time synthesis for contradiction detection, graph traversal, and offline access                                                                                 |
 | CLI / HTTP               | A unified interface via CLI and RESTful endpoints, the system streamlines full-spectrum integration: from data ingestion and querying to automated linting, security auditing, and job orchestration          |
 | Local-first              | All data stays on your machine; localhost-only network binding; no cloud dependency except the LLM API itself                                                                                                 |
-| Provider choice          | LLM backends including free-tier Gemini and Groq, plus MiniMax for cheapest paid text rates — no single-vendor dependency                                                                                    |
+| Provider choice          | LLM backends including free-tier Gemini and Groq, plus DeepSeek and MiniMax for cheapest paid text rates — no single-vendor dependency                                                                                    |
 
 ---
 
@@ -188,7 +188,8 @@ See [docs/design.md — Appendix A: Release Feature Index](docs/design.md#append
 | **Gemini Flash** | Yes — 15 RPM / 1M tokens/day, no credit card | Yes             | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | Groq             | Yes — rate-limited                           | No              | [console.groq.com](https://console.groq.com/keys)             |
 | Ollama           | Yes — runs locally, no key                   | Model-dependent | [ollama.com](https://ollama.com)                              |
-| MiniMax          | No — pay-per-token (cheapest text rates)     | No              | [platform.minimax.io](https://platform.minimax.io/)           |
+| MiniMax          | No — pay-per-token                           | Yes             | [platform.minimax.io](https://platform.minimax.io/)           |
+| DeepSeek         | No — pay-per-token (very cheap text rates)   | No              | [platform.deepseek.com](https://platform.deepseek.com/api_keys) |
 | Anthropic        | No                                            | Yes             | [console.anthropic.com](https://console.anthropic.com/)       |
 | OpenAI           | No                                            | Yes             | [platform.openai.com](https://platform.openai.com/api-keys)   |
 
@@ -260,9 +261,10 @@ set TAVILY_API_KEY=tvly-…
 
 # Windows cmd — permanent (open a new cmd window after running)
 setx GEMINI_API_KEY AIza…
-setx GROQ_API_KEY=gsk_…
-setx ANTHROPIC_API_KEY=sk-ant-…
+setx GROQ_API_KEY gsk_…
+setx ANTHROPIC_API_KEY sk-ant-…
 setx MINIMAX_API_KEY …
+setx DEEPSEEK_API_KEY sk-…
 setx TAVILY_API_KEY tvly-…
 ```
 

--- a/README.md
+++ b/README.md
@@ -118,28 +118,28 @@ As the wiki accumulates pages the `index.md` table of contents, domain scope (`p
 ### Competitive advantages
 
 
-| Capability                   | Synthadoc                                           | Typical RAG | NotebookLM | Notion AI |
-| ---------------------------- | --------------------------------------------------- | ----------- | ---------- | --------- |
-| Ingest-time synthesis        | **Yes**                                             | No          | Partial    | No        |
-| Contradiction detection      | **Yes**                                             | No          | No         | No        |
-| Orphan page detection        | **Yes**                                             | No          | No         | No        |
-| Persistent wikilink graph    | **Yes**                                             | No          | No         | No        |
-| Local-first (no cloud data)  | **Yes**                                             | Varies      | No         | No        |
-| Custom skill plugins         | **Yes**                                             | Limited     | No         | No        |
-| Obsidian integration         | **Yes**                                             | No          | No         | No        |
-| Cost guard + audit trail     | **Yes**                                             | No          | No         | No        |
-| Hook / CI integration        | **Yes** (2 events)                                  | No          | No         | No        |
-| Offline browsable artifact   | **Yes**                                             | No          | No         | No        |
-| Multi-wiki isolation         | **Yes**                                             | No          | No         | No        |
-| Web search → wiki pages     | **Yes**                                             | No          | No         | No        |
-| Multiple LLMs support       | **Yes** (MiniMax, Gemini, Groq, Anthropic, OpenAI, Ollama) | No          | No         | No        |
-| Auto wiki overview page      | **Yes**                                             | No          | No         | No        |
-| Resumable job queue + retry  | **Yes**                                             | No          | No         | No        |
-| Query decomposition          | **Yes** (parallel sub-queries)                      | No          | No         | No        |
-| Knowledge gap detection      | **Yes**                                             | No          | No         | No        |
-| Web search decomposition     | **Yes** (parallel Tavily)                           | No          | No         | No        |
-| Semantic re-ranking (vector) | **Yes** (optional fastembed)                        | Varies      | No         | No        |
-| Scaffold automation          | **Yes**                                             | No          | No         | No        |
+| Capability                   | Synthadoc                                                      | Typical RAG | NotebookLM | Notion AI |
+| ---------------------------- | -------------------------------------------------------------- | ----------- | ---------- | --------- |
+| Ingest-time synthesis        | **Yes**                                                        | No          | Partial    | No        |
+| Contradiction detection      | **Yes**                                                        | No          | No         | No        |
+| Orphan page detection        | **Yes**                                                        | No          | No         | No        |
+| Persistent wikilink graph    | **Yes**                                                        | No          | No         | No        |
+| Local-first (no cloud data)  | **Yes**                                                        | Varies      | No         | No        |
+| Custom skill plugins         | **Yes**                                                        | Limited     | No         | No        |
+| Obsidian integration         | **Yes**                                                        | No          | No         | No        |
+| Cost guard + audit trail     | **Yes**                                                        | No          | No         | No        |
+| Hook / CI integration        | **Yes** (2 events)                                             | No          | No         | No        |
+| Offline browsable artifact   | **Yes**                                                        | No          | No         | No        |
+| Multi-wiki isolation         | **Yes**                                                        | No          | No         | No        |
+| Web search → wiki pages     | **Yes**                                                        | No          | No         | No        |
+| Multiple LLMs support       | **Yes** (MiniMax, Gemini, Groq, Anthropic, DeepSeek, Ollama) | No          | No         | No        |
+| Auto wiki overview page      | **Yes**                                                        | No          | No         | No        |
+| Resumable job queue + retry  | **Yes**                                                        | No          | No         | No        |
+| Query decomposition          | **Yes** (parallel sub-queries)                                 | No          | No         | No        |
+| Knowledge gap detection      | **Yes**                                                        | No          | No         | No        |
+| Web search decomposition     | **Yes** (parallel Tavily)                                      | No          | No         | No        |
+| Semantic re-ranking (vector) | **Yes** (optional fastembed)                                   | Varies      | No         | No        |
+| Scaffold automation          | **Yes**                                                        | No          | No         | No        |
 
 ### Key differentiators vs. RAG
 
@@ -246,7 +246,8 @@ Web search uses **Tavily** (`TAVILY_API_KEY`) — optional, only needed for
 export GEMINI_API_KEY=AIza…          # default — free tier, 1M tokens/day
 export GROQ_API_KEY=gsk_…            # alternative free tier — 100K tokens/day
 export ANTHROPIC_API_KEY=sk-ant-…    # paid — highest quality
-export MINIMAX_API_KEY=…             # paid — cheapest text rates (no image support)
+export MINIMAX_API_KEY=…             # paid — text rates (image support)
+export DEEPSEEK_API_KEY=…            # paid — text rates (no image support)
 export TAVILY_API_KEY=tvly-…         # web search (optional)
 
 # Windows cmd — current session only
@@ -254,6 +255,7 @@ set GEMINI_API_KEY=AIza…
 set GROQ_API_KEY=gsk_…
 set ANTHROPIC_API_KEY=sk-ant-…
 set MINIMAX_API_KEY=…
+set DEEPSEEK_API_KEY=…
 set TAVILY_API_KEY=tvly-…
 
 # Windows cmd — permanent (open a new cmd window after running)
@@ -301,29 +303,6 @@ synthadoc serve -w history-of-computing --background
 
 The server binds to `http://127.0.0.1:7070` by default (port is set in `<wiki-root>/.synthadoc/config.toml`). Leave it running while you work — the Obsidian plugin, CLI ingest commands, and query commands all talk to it.
 
-### Skip typing -w on every command
-
-Set the demo wiki as your active context once — you won't need `-w` for the rest of the walkthrough:
-
-```bash
-synthadoc use history-of-computing
-```
-
-All subsequent commands in any terminal run against `history-of-computing` by default.
-
-### Working with multiple wikis
-
-| Goal | How |
-|------|-----|
-| Set a persistent default | `synthadoc use wiki1` |
-| One-off command against wiki2 | `synthadoc query "..." -w wiki2` |
-| Dedicate a terminal session to wiki2 | `export SYNTHADOC_WIKI=wiki2` in that window |
-
-`synthadoc use wiki1` saves to `~/.synthadoc/default_wiki` — persistent across all terminal windows. For occasional cross-wiki commands, pass `-w wiki2` directly without switching your default. To work with two wikis in parallel across separate windows, set `SYNTHADOC_WIKI` as an environment variable in each window — it takes priority over the saved default.
-
-**Automation / pipelines:** all wiki-context messages go to stderr; stdout is always
-machine-readable so `synthadoc jobs list | jq` works without filtering.
-
 To stop a background server:
 
 ```bash
@@ -367,11 +346,8 @@ Unlike the demo (which ships with pre-built pages), your own wiki starts from a 
 
 ```bash
 synthadoc install market-condition-canada --target ~/wikis --domain "Market conditions and trends in Canada"
-synthadoc use market-condition-canada
-synthadoc serve
+synthadoc serve -w market-condition-canada
 ```
-
-Set the wiki as your active context right after install — all subsequent commands skip the `-w` flag.
 
 `--domain` is a free-text description of the subject area — the LLM uses it to generate four domain-aware starter files via scaffold:
 
@@ -390,9 +366,9 @@ Open the wiki folder in Obsidian as a new vault and install both the Dataview an
 **1. Seed with web searches** — pull in real content for the topics you care about:
 
 ```bash
-synthadoc ingest "search for: Economy, employment and labour market analysis in Toronto GTA"
-synthadoc ingest "search for: Bank of Canada interest rate outlook 2025"
-synthadoc jobs list   # watch progress
+synthadoc ingest "search for: Economy, employment and labour market analysis in Toronto GTA" -w market-condition-canada
+synthadoc ingest "search for: Bank of Canada interest rate outlook 2025" -w market-condition-canada
+synthadoc jobs list -w market-condition-canada   # watch progress
 ```
 
 Each search fans out into up to 20 parallel URL ingest jobs. Query decomposition and web search decomposition (see below) make broad topics yield much richer results than a single search.
@@ -400,22 +376,22 @@ Each search fans out into up to 20 parallel URL ingest jobs. Query decomposition
 **2. Lint and query** — check for contradictions and verify the wiki answers your questions:
 
 ```bash
-synthadoc lint run
-synthadoc lint report
-synthadoc query "What are the current employment trends in the Toronto GTA?"
+synthadoc lint run -w market-condition-canada
+synthadoc lint report -w market-condition-canada
+synthadoc query "What are the current employment trends in the Toronto GTA?" -w market-condition-canada
 ```
 
 **3. Re-run scaffold** — after pages accumulate, scaffold regenerates a richer index that reflects actual content. Pages already linked in `index.md` are never overwritten:
 
 ```bash
-synthadoc scaffold
+synthadoc scaffold -w market-condition-canada
 ```
 
 **4. Schedule recurring updates** — keep the wiki fresh automatically:
 
 ```bash
-synthadoc schedule add --op "ingest" --source "search for: Toronto GTA economic indicators latest" --cron "0 2 * * *"
-synthadoc schedule add --op "scaffold" --cron "0 4 * * 0"
+synthadoc schedule add --op "ingest" --source "search for: Toronto GTA economic indicators latest" --cron "0 2 * * *" -w market-condition-canada
+synthadoc schedule add --op "scaffold" --cron "0 4 * * 0" -w market-condition-canada
 ```
 
 ### How decomposition works
@@ -426,18 +402,7 @@ See [docs/design.md — Query decomposition and web search decomposition](docs/d
 
 ### Semantic re-ranking (vector search)
 
-BM25 keyword search is the default. Optional vector re-ranking (`BAAI/bge-small-en-v1.5` cosine similarity) improves recall on conceptually related queries. The ~130 MB model is downloaded once on first enable; BM25 stays active as fallback.
-
-```bash
-pip install fastembed
-```
-
-Then enable in your wiki's `.synthadoc/config.toml`:
-
-```toml
-[search]
-vector = true
-```
+BM25 keyword search is the default. Optional vector re-ranking (`BAAI/bge-small-en-v1.5` cosine similarity) improves recall on conceptually related queries — enable it by installing `fastembed` and setting `[search] vector = true` in config. The ~130 MB model is downloaded once; BM25 stays active as fallback.
 
 See [docs/design.md — Semantic re-ranking](docs/design.md#semantic-re-ranking) for configuration options and performance notes.
 

--- a/README.md
+++ b/README.md
@@ -344,11 +344,12 @@ The guide covers:
 
 ## Creating Your Own Wiki
 
-Unlike the demo (which ships with pre-built pages), your own wiki starts from a domain description and grows as you feed it sources. Two commands are all you need to get started:
+Unlike the demo (which ships with pre-built pages), your own wiki starts from a domain description and grows as you feed it sources. Three commands are all you need to get started:
 
 ```bash
 synthadoc install market-condition-canada --target ~/wikis --domain "Market conditions and trends in Canada"
-synthadoc serve -w market-condition-canada
+synthadoc use market-condition-canada   # set as the default wiki — no -w needed from here on
+synthadoc serve
 ```
 
 `--domain` is a free-text description of the subject area — the LLM uses it to generate four domain-aware starter files via scaffold:
@@ -368,9 +369,9 @@ Open the wiki folder in Obsidian as a new vault and install both the Dataview an
 **1. Seed with web searches** — pull in real content for the topics you care about:
 
 ```bash
-synthadoc ingest "search for: Economy, employment and labour market analysis in Toronto GTA" -w market-condition-canada
-synthadoc ingest "search for: Bank of Canada interest rate outlook 2025" -w market-condition-canada
-synthadoc jobs list -w market-condition-canada   # watch progress
+synthadoc ingest "search for: Economy, employment and labour market analysis in Toronto GTA"
+synthadoc ingest "search for: Bank of Canada interest rate outlook 2025"
+synthadoc jobs list   # watch progress
 ```
 
 Each search fans out into up to 20 parallel URL ingest jobs. Query decomposition and web search decomposition (see below) make broad topics yield much richer results than a single search.
@@ -378,22 +379,22 @@ Each search fans out into up to 20 parallel URL ingest jobs. Query decomposition
 **2. Lint and query** — check for contradictions and verify the wiki answers your questions:
 
 ```bash
-synthadoc lint run -w market-condition-canada
-synthadoc lint report -w market-condition-canada
-synthadoc query "What are the current employment trends in the Toronto GTA?" -w market-condition-canada
+synthadoc lint run
+synthadoc lint report
+synthadoc query "What are the current employment trends in the Toronto GTA?"
 ```
 
 **3. Re-run scaffold** — after pages accumulate, scaffold regenerates a richer index that reflects actual content. Pages already linked in `index.md` are never overwritten:
 
 ```bash
-synthadoc scaffold -w market-condition-canada
+synthadoc scaffold
 ```
 
 **4. Schedule recurring updates** — keep the wiki fresh automatically:
 
 ```bash
-synthadoc schedule add --op "ingest" --source "search for: Toronto GTA economic indicators latest" --cron "0 2 * * *" -w market-condition-canada
-synthadoc schedule add --op "scaffold" --cron "0 4 * * 0" -w market-condition-canada
+synthadoc schedule add --op "ingest" --source "search for: Toronto GTA economic indicators latest" --cron "0 2 * * *"
+synthadoc schedule add --op "scaffold" --cron "0 4 * * 0"
 ```
 
 ### How decomposition works

--- a/docs/design.md
+++ b/docs/design.md
@@ -831,7 +831,7 @@ otlp_endpoint = "http://localhost:4317"   # used when exporter = "otlp"
 
 ### Provider switching
 
-All six supported providers (`anthropic`, `openai`, `gemini`, `groq`, `minimax`, `ollama`) share the same config key. Gemini, Groq, and MiniMax use OpenAI-compatible endpoints internally, so no custom provider class is needed — just set the provider name and supply the corresponding API key:
+All seven supported providers (`anthropic`, `openai`, `gemini`, `groq`, `minimax`, `deepseek`, `ollama`) share the same config key. Gemini, Groq, MiniMax, and DeepSeek use OpenAI-compatible endpoints internally, so no custom provider class is needed — just set the provider name and supply the corresponding API key:
 
 ```toml
 # Switch from Claude to Gemini Flash (free tier available)
@@ -848,6 +848,7 @@ Required environment variables per provider:
 | `gemini` | `GEMINI_API_KEY` | **Yes** — 15 RPM / 1M tokens/day on Flash | Yes |
 | `groq` | `GROQ_API_KEY` | **Yes** — generous free tier on Llama/Mixtral models | No |
 | `minimax` | `MINIMAX_API_KEY` | No (pay-per-token) | Yes (M2.5 / M2.7 natively multimodal) |
+| `deepseek` | `DEEPSEEK_API_KEY` | No (pay-per-token, very cheap) | No (text-only) |
 | `ollama` | _(none)_ | **Yes** — fully local | Model-dependent |
 
 ### Per-project config — `<wiki-root>/.synthadoc/config.toml`
@@ -907,7 +908,7 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `agents.default.provider` | str | `"gemini"` | LLM provider: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `ollama` |
+| `agents.default.provider` | str | `"gemini"` | LLM provider: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `deepseek`, `ollama` |
 | `agents.default.model` | str | `"gemini-2.5-flash"` | Model ID |
 | `agents.llm_timeout_seconds` | int | `0` | Per-call LLM timeout in seconds; `0` = no limit. Set to e.g. `90` when using reasoning models (MiniMax-M2.5, DeepSeek-R1) that can exceed their internal generation budget silently. Restart required. |
 | `server.port` | int | `7070` | HTTP listen port |
@@ -1338,7 +1339,7 @@ class SlackExportSkill(BaseSkill):
 
 ### Writing a provider
 
-Built-in providers: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `ollama`. For any provider that exposes an OpenAI-compatible API, no custom class is needed — the built-in `openai` provider with a custom `base_url` is sufficient.
+Built-in providers: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `deepseek`, `ollama`. For any provider that exposes an OpenAI-compatible API, no custom class is needed — the built-in `openai` provider with a custom `base_url` is sufficient.
 
 For a fully proprietary API, subclass `LLMProvider`:
 
@@ -1394,7 +1395,7 @@ echo "Event $event fired on wiki $wiki" | mail -s "Synthadoc notification" you@e
 - **Folder-based skill system** — each skill is a self-contained folder with a `SKILL.md` manifest; intent-based dispatch alongside extension matching; drop a folder in `skills/` to add a new format without touching core code
 - **2 access surfaces** — CLI (thin HTTP client), HTTP REST API
 - **Obsidian plugin** — ingest (file picker, URL, all sources, web search), query modal, lint report, jobs list — all from the command palette; ribbon shows engine health + page count
-- **6 LLM providers** — Anthropic, OpenAI, Gemini (free tier), Groq (free tier), MiniMax (paid, cheapest text), Ollama (local); switch with one config line
+- **7 LLM providers** — Anthropic, OpenAI, Gemini (free tier), Groq (free tier), MiniMax (paid, multimodal), DeepSeek (paid, very cheap text-only), Ollama (local); switch with one config line
 - **Two-step ingest** — `_analyse()` caches entity extraction + summary; decision prompt uses summary instead of full text; reduces cost on large documents
 - **purpose.md scope filtering** — define what belongs in your wiki; the LLM skips out-of-scope sources cleanly
 - **overview.md auto-summary** — 2-paragraph wiki overview regenerated automatically after every ingest
@@ -1432,4 +1433,5 @@ echo "Event $event fired on wiki $wiki" | mail -s "Synthadoc notification" you@e
 - **MiniMax reasoning-model fixes** — `OpenAIProvider` now handles three failure modes of reasoning models (e.g. MiniMax-M2.5): (1) `choices=null` response converted from silent `TypeError` to a descriptive `RuntimeError` with error code logged; (2) `content=null` with prose answer in `reasoning_content` — think-tag stripping then full-text fallback so query synthesis returns a real answer; (3) `APITimeoutError` caught, logged with the config key to set, then re-raised
 - **Configurable LLM call timeout (`agents.llm_timeout_seconds`)** — new `[agents]` key (default `0` = no limit); passed as `timeout` to every OpenAI-compatible `create()` call; `APITimeoutError` logs an actionable message naming the exact config key; config.toml template ships the key commented out with a 5-line explanation of when to enable it
 - **`parse_json_string_array` utility** — extracted shared fence-strip + JSON-parse + filter logic from `QueryAgent.decompose()` and `SearchDecomposeAgent.decompose()` into `synthadoc/agents/_utils.py`; 16 unit tests; LLM call failures and JSON-parse failures now log separate, distinct messages
+- **DeepSeek provider** — `deepseek` added as an eighth provider; routes through `OpenAIProvider` with `base_url="https://api.deepseek.com/v1"` and `DEEPSEEK_API_KEY`; vision disabled (`_NO_VISION_HOSTS`); DeepSeek-R1 `<think>` tags in the `content` field are stripped by the existing regex; config.toml template ships a commented-out example for `deepseek-chat`
 - **v0.2.0 gap fixes** — Ollama `eval_count` mapped to `output_tokens` (was always 0); `_SLUG_BLACKLIST` moved to module-level `frozenset`; synthetic URL fields in ingest_agent commented; four test-coverage gaps closed (no-text guard, orphan flag inversion, `/analyse` endpoint, hybrid-search partial-miss fallback)

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -34,6 +34,7 @@ default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}
 # default = {{ provider = "minimax",   model = "MiniMax-M2.5" }}             # paid, cheapest text-only ($0.15/M in)
 # default = {{ provider = "groq",      model = "llama-3.3-70b-versatile" }}  # free tier, 100K tokens/day
 # default = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}        # paid, highest quality
+# default = {{ provider = "deepseek",  model = "deepseek-chat" }}             # paid, very cheap ($0.14/M in); text-only, no vision
 # default = {{ provider = "ollama",    model = "llama3.2" }}                  # fully local, no API key
 #
 # LLM call timeout — useful for reasoning models (e.g. MiniMax-M2.5) that can

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -17,7 +17,7 @@ from typing import Optional
 # Known providers
 # ---------------------------------------------------------------------------
 
-KNOWN_PROVIDERS = {"anthropic", "openai", "ollama", "gemini", "groq", "minimax"}
+KNOWN_PROVIDERS = {"anthropic", "openai", "ollama", "gemini", "groq", "minimax", "deepseek"}
 
 
 # ---------------------------------------------------------------------------

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -21,7 +21,7 @@ _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MB
 def _classify_llm_error(exc: Exception) -> "HTTPException | None":
     """Return a meaningful HTTPException for known LLM API error codes, or None."""
     from synthadoc.errors import DailyQuotaExhaustedException
-    _SWITCH = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: groq, gemini, anthropic, openai, ollama)."
+    _SWITCH = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: anthropic, openai, gemini, groq, minimax, deepseek, ollama)."
     if isinstance(exc, DailyQuotaExhaustedException):
         return HTTPException(
             status_code=503,
@@ -35,19 +35,39 @@ def _classify_llm_error(exc: Exception) -> "HTTPException | None":
         resp = getattr(exc, "response", None)
         code = getattr(resp, "status_code", None)
 
+    if code == 401:
+        msg = str(exc)
+        if "deepseek" in msg.lower() or "api.deepseek.com" in msg.lower():
+            var = "DEEPSEEK_API_KEY"
+        elif "minimax" in msg.lower():
+            var = "MINIMAX_API_KEY"
+        elif "groq" in msg.lower():
+            var = "GROQ_API_KEY"
+        elif "generativelanguage" in msg.lower() or "gemini" in msg.lower():
+            var = "GEMINI_API_KEY"
+        elif "anthropic" in msg.lower():
+            var = "ANTHROPIC_API_KEY"
+        elif "openai" in msg.lower():
+            var = "OPENAI_API_KEY"
+        else:
+            var = "your provider's API key env var"
+        return HTTPException(
+            status_code=401,
+            detail=f"LLM provider rejected the API key (401). Check that {var} is set correctly and restart the server.",
+        )
     if code == 429:
         msg = str(exc)
-        _SWITCH = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: groq, gemini, anthropic, openai, ollama)."
+        _SWITCH_429 = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: anthropic, openai, gemini, groq, minimax, deepseek, ollama)."
         if "generativelanguage.googleapis.com" in msg or "gemini" in msg.lower():
-            hint = f"Gemini free-tier quota exhausted. Wait for the daily reset or switch providers. {_SWITCH}"
+            hint = f"Gemini free-tier quota exhausted. Wait for the daily reset or switch providers. {_SWITCH_429}"
         elif "groq" in msg.lower():
-            hint = f"Groq rate limit hit. Wait for the retry window or switch providers. {_SWITCH}"
+            hint = f"Groq rate limit hit. Wait for the retry window or switch providers. {_SWITCH_429}"
         elif "anthropic" in msg.lower():
-            hint = f"Anthropic rate limit hit. Wait a moment or switch providers. {_SWITCH}"
+            hint = f"Anthropic rate limit hit. Wait a moment or switch providers. {_SWITCH_429}"
         elif "openai" in msg.lower():
-            hint = f"OpenAI rate limit hit. Wait a moment or switch providers. {_SWITCH}"
+            hint = f"OpenAI rate limit hit. Wait a moment or switch providers. {_SWITCH_429}"
         else:
-            hint = f"LLM provider rate limit hit. Wait a moment or switch providers. {_SWITCH}"
+            hint = f"LLM provider rate limit hit. Wait a moment or switch providers. {_SWITCH_429}"
         return HTTPException(
             status_code=429,
             detail=f"LLM quota exceeded (429). {hint}",

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -55,6 +55,16 @@ def _classify_llm_error(exc: Exception) -> "HTTPException | None":
             status_code=401,
             detail=f"LLM provider rejected the API key (401). Check that {var} is set correctly and restart the server.",
         )
+    if code == 402:
+        body = getattr(exc, "body", None) or {}
+        err_msg = ""
+        if isinstance(body, dict):
+            err_msg = body.get("error", {}).get("message", "")
+        detail = err_msg or "Insufficient balance"
+        return HTTPException(
+            status_code=402,
+            detail=f"LLM provider payment required (402): {detail}. Top up your account balance at your provider's billing page and retry.",
+        )
     if code == 429:
         msg = str(exc)
         _SWITCH_429 = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: anthropic, openai, gemini, groq, minimax, deepseek, ollama)."

--- a/synthadoc/providers/__init__.py
+++ b/synthadoc/providers/__init__.py
@@ -63,8 +63,16 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
             base_url="https://api.minimax.io/v1",
         )
         return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
+    if name == "deepseek":
+        from synthadoc.providers.openai import OpenAIProvider
+        key = _require_env("DEEPSEEK_API_KEY", "DeepSeek", "https://platform.deepseek.com/api_keys")
+        cfg_with_url = AgentConfig(
+            provider="deepseek", model=agent_cfg.model,
+            base_url="https://api.deepseek.com/v1",
+        )
+        return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "ollama":
         from synthadoc.providers.ollama import OllamaProvider
         return OllamaProvider(config=agent_cfg)
     E.cli_error(E.CFG_UNKNOWN_PROVIDER, f"Unknown provider: {name!r}",
-                "Supported providers: anthropic, openai, gemini, groq, minimax, ollama")
+                "Supported providers: anthropic, openai, gemini, groq, minimax, deepseek, ollama")

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -13,7 +13,7 @@ from synthadoc.providers.base import CompletionResponse, LLMProvider, Message
 logger = logging.getLogger(__name__)
 
 # Providers whose chat endpoint does not support image inputs
-_NO_VISION_HOSTS = ("groq.com",)
+_NO_VISION_HOSTS = ("groq.com", "api.deepseek.com")
 
 # Retry delays (seconds) after an HTTP 429 rate-limit response.
 #

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -724,6 +724,55 @@ async def test_openai_provider_vision_call_uses_image_url_format():
     assert sent_content[1] == {"type": "text", "text": "What is in this image?"}
 
 
+def test_make_provider_missing_deepseek_key_exits(monkeypatch, capsys):
+    import click
+    from synthadoc.providers import make_provider
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "")
+    with pytest.raises(click.exceptions.Exit) as exc_info:
+        make_provider("ingest", _make_cfg("deepseek", "deepseek-chat"))
+    assert exc_info.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "DEEPSEEK_API_KEY" in err
+    assert "platform.deepseek.com" in err
+
+
+def test_make_provider_deepseek_uses_openai_provider_with_base_url(monkeypatch):
+    from synthadoc.providers import make_provider
+    from synthadoc.providers.openai import OpenAIProvider
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-deepseek-key")
+    provider = make_provider("ingest", _make_cfg("deepseek", "deepseek-chat"))
+    assert isinstance(provider, OpenAIProvider)
+    assert "api.deepseek.com" in str(provider._client.base_url)
+    assert provider.supports_vision is False  # DeepSeek is text-only
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_deepseek_r1_think_tags_stripped():
+    """DeepSeek-R1 embeds <think>...</think> in the content field; they must be stripped."""
+    cfg = AgentConfig(provider="deepseek", model="deepseek-reasoner",
+                      base_url="https://api.deepseek.com/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    mock_choice = MagicMock()
+    mock_choice.message.content = (
+        "<think>Let me reason step by step about this.</think>"
+        "The capital of France is Paris."
+    )
+    mock_choice.message.model_extra = {}
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    mock_resp.usage.prompt_tokens = 12
+    mock_resp.usage.completion_tokens = 8
+
+    with patch.object(provider._client.chat.completions, "create",
+                      new=AsyncMock(return_value=mock_resp)):
+        result = await provider.complete(
+            messages=[Message(role="user", content="What is the capital of France?")]
+        )
+    assert result.text == "The capital of France is Paris."
+    assert "<think>" not in result.text
+
+
 @pytest.mark.asyncio
 async def test_ollama_provider_uses_eval_count_for_output_tokens():
     """OllamaProvider must read eval_count from the response for output_tokens."""

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -773,6 +773,57 @@ async def test_openai_provider_deepseek_r1_think_tags_stripped():
     assert "<think>" not in result.text
 
 
+def test_classify_llm_error_returns_401_for_auth_error():
+    """AuthenticationError (401) must return a 401 HTTPException, not fall through to 502."""
+    import openai
+    from synthadoc.integration.http_server import _classify_llm_error
+    exc = openai.AuthenticationError(
+        message="Authentication Fails, Your api key is invalid",
+        response=MagicMock(status_code=401),
+        body={"error": {"message": "Authentication Fails, Your api key: ****2YES is invalid",
+                        "type": "authentication_error"}},
+    )
+    result = _classify_llm_error(exc)
+    assert result is not None
+    assert result.status_code == 401
+    assert "401" in result.detail
+
+
+def test_classify_llm_error_names_deepseek_key_in_401():
+    """A DeepSeek 401 must name DEEPSEEK_API_KEY in the error detail."""
+    import openai
+    from synthadoc.integration.http_server import _classify_llm_error
+    exc = openai.AuthenticationError(
+        message="Authentication Fails from api.deepseek.com",
+        response=MagicMock(status_code=401),
+        body={},
+    )
+    result = _classify_llm_error(exc)
+    assert result is not None
+    assert "DEEPSEEK_API_KEY" in result.detail
+
+
+def test_classify_llm_error_names_gemini_key_in_401():
+    """A Gemini 401 must name GEMINI_API_KEY in the error detail."""
+    import openai
+    from synthadoc.integration.http_server import _classify_llm_error
+    exc = openai.AuthenticationError(
+        message="Invalid key for generativelanguage.googleapis.com",
+        response=MagicMock(status_code=401),
+        body={},
+    )
+    result = _classify_llm_error(exc)
+    assert result is not None
+    assert "GEMINI_API_KEY" in result.detail
+
+
+def test_classify_llm_error_returns_none_for_unrecognised():
+    """Unrecognised exception (no status_code, not DailyQuota) returns None → caller emits 502."""
+    from synthadoc.integration.http_server import _classify_llm_error
+    result = _classify_llm_error(ValueError("something unexpected"))
+    assert result is None
+
+
 @pytest.mark.asyncio
 async def test_ollama_provider_uses_eval_count_for_output_tokens():
     """OllamaProvider must read eval_count from the response for output_tokens."""

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -817,6 +817,22 @@ def test_classify_llm_error_names_gemini_key_in_401():
     assert "GEMINI_API_KEY" in result.detail
 
 
+def test_classify_llm_error_returns_402_for_insufficient_balance():
+    """A 402 Insufficient Balance must return a 402 HTTPException, not 502."""
+    import openai
+    from synthadoc.integration.http_server import _classify_llm_error
+    exc = openai.APIStatusError(
+        message="Insufficient Balance",
+        response=MagicMock(status_code=402),
+        body={"error": {"message": "Insufficient Balance", "type": "unknown_error"}},
+    )
+    result = _classify_llm_error(exc)
+    assert result is not None
+    assert result.status_code == 402
+    assert "Insufficient Balance" in result.detail
+    assert "billing" in result.detail.lower()
+
+
 def test_classify_llm_error_returns_none_for_unrecognised():
     """Unrecognised exception (no status_code, not DailyQuota) returns None → caller emits 502."""
     from synthadoc.integration.http_server import _classify_llm_error

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -137,3 +137,12 @@ def test_llm_timeout_seconds_is_parsed(tmp_path):
     )
     cfg = load_config(project_config=toml)
     assert cfg.agents.llm_timeout_seconds == 90
+
+
+def test_deepseek_is_a_valid_provider(tmp_path):
+    """deepseek must be accepted as a valid provider name without raising."""
+    toml = tmp_path / "config.toml"
+    toml.write_text('[agents]\ndefault = {provider = "deepseek", model = "deepseek-chat"}\n')
+    cfg = load_config(project_config=toml)
+    assert cfg.agents.default.provider == "deepseek"
+    assert cfg.agents.default.model == "deepseek-chat"


### PR DESCRIPTION
 What

  Adds DeepSeek as a supported LLM provider and fixes two HTTP error classification gaps where 401 (invalid API key) and 402 (insufficient balance) were silently returned as 502.

  Why

  DeepSeek-V3 (deepseek-chat) is one of the cheapest available text-only models ($0.14/M input tokens) and a useful alternative when Gemini/Groq quotas are exhausted. The 401/402 fix prevents confusing "LLM provider unavailable" errors when the real cause is a bad API key or empty account balance.

  Changes

  DeepSeek provider
  - Routes through OpenAIProvider with base_url="https://api.deepseek.com/v1" and DEEPSEEK_API_KEY
  - Added "api.deepseek.com" to _NO_VISION_HOSTS — DeepSeek is text-only
  - DeepSeek-R1 <think> tags in content stripped by existing regex
  - "deepseek" added to KNOWN_PROVIDERS in config.py
  - Config template ships a commented-out deepseek-chat example

  HTTP error classification (http_server.py)
  - code == 401 → 401 response naming the specific env var to fix (DEEPSEEK_API_KEY, GEMINI_API_KEY, etc.)
  - code == 402 → 402 response with provider's error message and billing hint
  - Provider list in _SWITCH hint strings updated to include deepseek

  Documentation
  - Provider table, config key reference, feature summary, and Appendix A v0.3.0 in design.md updated
  - Changed README.md

  Tests (tests/providers/test_providers.py, tests/test_config.py)
  - Missing key guard, correct base URL, no-vision flag, DeepSeek-R1 think-tag stripping
  - _classify_llm_error unit tests for 401 (with key name detection) and 402
  - Config acceptance test for deepseek as a valid provider name

  Housekeeping
  - .gitattributes added to enforce LF line endings and silence Windows CRLF warnings

※ recap: Added DeepSeek provider support and fixed 401/402 error classification so bad keys and empty balances return clear errors instead of 502. PR description is ready — user is creating the PR next.