### PR TITLE
[v0.3.0] fix: Claude Code and Opencode provider reliability — binary discovery, clean errors, JSONL parsing

### DIFF
--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -190,6 +190,10 @@ class Orchestrator:
         except (NotImplementedError, FileNotFoundError) as e:
             # Permanent failures — source is invalid, retry can never help
             await self._queue.fail_permanent(job_id, str(e))
+        except EnvironmentError as e:
+            # Provider binary not installed (ERR-PROV-003) — log cleanly, no traceback
+            logging.getLogger(__name__).warning("%s", e)
+            await self._queue.fail_permanent(job_id, str(e))
         except Exception as e:
             import httpx
             import logging

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -282,6 +282,9 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
             if known:
                 logger.warning("LLM rate limit during query: %s", exc)
                 raise known from exc
+            if isinstance(exc, (EnvironmentError, OSError)) and "[ERR-PROV-" in str(exc):
+                logger.warning("Provider not available: %s", exc)
+                raise HTTPException(status_code=503, detail=str(exc)) from exc
             logger.exception("Query failed")
             raise HTTPException(status_code=502, detail="LLM provider unavailable") from exc
         return {

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -11,7 +11,11 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Optional
 
+import logging as _logging
+
 from synthadoc.providers.base import CompletionResponse, LLMProvider, Message
+
+_logger = _logging.getLogger(__name__)
 
 # Common locations where npm-installed CLIs (claude, opencode) live on macOS/Linux
 # that are absent from the minimal PATH seen by GUI apps and non-login shells.
@@ -221,9 +225,13 @@ class OpencodeProvider(CodingToolCLIProvider):
         return cmd
 
     def _parse_output(self, raw: str) -> CompletionResponse:
+        _logger.debug("opencode raw output (%d bytes):\n%s", len(raw), raw[:4000])
+
         text_parts: list[str] = []
         input_tokens = 0
         output_tokens = 0
+        seen_types: list[str] = []
+
         for line in raw.splitlines():
             line = line.strip()
             if not line:
@@ -232,17 +240,61 @@ class OpencodeProvider(CodingToolCLIProvider):
                 event = _json.loads(line)
             except _json.JSONDecodeError:
                 continue
-            etype = event.get("type")
+
+            etype = event.get("type", "")
+            if etype:
+                seen_types.append(etype)
+
+            # --- text content ---
+            # Known layout A: {"type":"text","data":"..."}
             if etype == "text":
-                text_parts.append(event.get("data", ""))
+                chunk = event.get("data") or event.get("text") or ""
+                if chunk:
+                    text_parts.append(chunk)
+
+            # Known layout B: {"type":"PartTextEvent","properties":{"part":{"type":"text","text":"..."}}}
+            elif etype == "PartTextEvent":
+                part = (event.get("properties") or {}).get("part") or {}
+                chunk = part.get("text") or part.get("data") or ""
+                if chunk:
+                    text_parts.append(chunk)
+
+            # Known layout C: {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
+            elif etype == "assistant":
+                msg = event.get("message") or event
+                for block in msg.get("content") or []:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        chunk = block.get("text") or block.get("data") or ""
+                        if chunk:
+                            text_parts.append(chunk)
+
+            # --- token counts ---
             elif etype == "step_finish":
                 if event.get("reason") == "error":
                     raise RuntimeError("opencode: step finished with error")
                 tokens = event.get("tokens") or {}
                 input_tokens = int(tokens.get("input", 0))
                 output_tokens = int(tokens.get("output", 0))
+
+            elif etype in ("message_finish", "session_end"):
+                info = event.get("info") or event.get("properties") or {}
+                usage = info.get("tokens") or info.get("usage") or {}
+                if usage:
+                    input_tokens = int(usage.get("input", 0) or usage.get("input_tokens", 0))
+                    output_tokens = int(usage.get("output", 0) or usage.get("output_tokens", 0))
+
         if not text_parts:
-            raise ValueError("opencode: no text events in JSONL output")
+            _logger.warning(
+                "opencode: no text content extracted. Event types seen: %s\n"
+                "Raw output (first 2000 chars):\n%s",
+                sorted(set(seen_types)), raw[:2000],
+            )
+            raise ValueError(
+                f"opencode: no text content in JSONL output. "
+                f"Event types seen: {sorted(set(seen_types))}. "
+                f"Check DEBUG logs for the full raw output."
+            )
+
         return CompletionResponse(
             text="".join(text_parts),
             input_tokens=input_tokens,

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -33,18 +33,48 @@ def _extra_binary_dirs() -> list[Path]:
 
 
 def _find_binary(name: str) -> Optional[str]:
-    """Locate *name* in the process PATH first, then common extra locations."""
+    """Locate *name* using three escalating strategies.
+
+    1. shutil.which with the current process PATH (fast path).
+    2. shutil.which with well-known npm/nvm/Homebrew/Go directories appended.
+    3. Ask the user's login shell (zsh/bash -lc "which <name>") so that
+       ~/.zshrc, ~/.zprofile, ~/.bashrc etc. are sourced — handles Go, Cargo,
+       custom install scripts and anything else that modifies PATH at shell init.
+    """
+    import subprocess
+
+    # 1. Current PATH
     found = shutil.which(name)
     if found:
         return found
-    # Extend the search to directories not in the current PATH
+
+    # 2. Well-known extra dirs
     current_path = os.environ.get("PATH", "")
     extra = os.pathsep.join(
         str(d) for d in _extra_binary_dirs()
         if str(d) not in current_path and d.is_dir()
     )
     augmented = extra + os.pathsep + current_path if extra else current_path
-    return shutil.which(name, path=augmented)
+    found = shutil.which(name, path=augmented)
+    if found:
+        return found
+
+    # 3. Login shell — loads user profile so all PATH mutations are visible
+    if sys.platform != "win32":
+        shell = os.environ.get("SHELL", "/bin/zsh")
+        try:
+            result = subprocess.run(
+                [shell, "-lc", f"which {name}"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                candidate = result.stdout.strip()
+                if candidate and Path(candidate).is_file():
+                    return candidate
+        except Exception:
+            pass
+
+    return None
 
 
 class CodingToolCLIProvider(LLMProvider):

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -246,9 +246,15 @@ class OpencodeProvider(CodingToolCLIProvider):
                 seen_types.append(etype)
 
             # --- text content ---
-            # Known layout A: {"type":"text","data":"..."}
+            # Layout A: {"type":"text","data":"..."}
+            # Layout D (current opencode): {"type":"text","part":{"text":"...",...}}
             if etype == "text":
-                chunk = event.get("data") or event.get("text") or ""
+                chunk = (
+                    event.get("data")
+                    or event.get("text")
+                    or (event.get("part") or {}).get("text")
+                    or ""
+                )
                 if chunk:
                     text_parts.append(chunk)
 

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -4,12 +4,47 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
+import os
 import shutil
 import sys
 from abc import abstractmethod
+from pathlib import Path
 from typing import Optional
 
 from synthadoc.providers.base import CompletionResponse, LLMProvider, Message
+
+# Common locations where npm-installed CLIs (claude, opencode) live on macOS/Linux
+# that are absent from the minimal PATH seen by GUI apps and non-login shells.
+def _extra_binary_dirs() -> list[Path]:
+    dirs = [
+        Path.home() / ".npm" / "bin",
+        Path("/usr/local/bin"),
+        Path("/opt/homebrew/bin"),        # Homebrew on Apple Silicon
+        Path("/usr/local/opt/node/bin"),  # Homebrew node on Intel
+        Path.home() / ".local" / "bin",
+        Path.home() / ".yarn" / "bin",
+        Path.home() / "bin",
+    ]
+    # nvm-managed node versions
+    nvm_node = Path.home() / ".nvm" / "versions" / "node"
+    if nvm_node.is_dir():
+        dirs.extend(sorted(nvm_node.glob("*/bin")))
+    return dirs
+
+
+def _find_binary(name: str) -> Optional[str]:
+    """Locate *name* in the process PATH first, then common extra locations."""
+    found = shutil.which(name)
+    if found:
+        return found
+    # Extend the search to directories not in the current PATH
+    current_path = os.environ.get("PATH", "")
+    extra = os.pathsep.join(
+        str(d) for d in _extra_binary_dirs()
+        if str(d) not in current_path and d.is_dir()
+    )
+    augmented = extra + os.pathsep + current_path if extra else current_path
+    return shutil.which(name, path=augmented)
 
 
 class CodingToolCLIProvider(LLMProvider):
@@ -22,11 +57,13 @@ class CodingToolCLIProvider(LLMProvider):
     _tool_binary: str  # e.g. "claude" or "opencode" — set by subclass
 
     def __init__(self, model: Optional[str], timeout: int) -> None:
-        resolved = shutil.which(self._tool_binary)
+        resolved = _find_binary(self._tool_binary)
         if resolved is None:
             raise EnvironmentError(
                 f"[ERR-PROV-003] '{self._tool_binary}' not found in PATH. "
-                f"Install it and ensure it is authenticated before using this provider."
+                f"Install it and ensure it is authenticated before using this provider. "
+                f"If it is installed, add its directory to PATH before starting synthadoc serve "
+                f"(e.g. export PATH=\"$HOME/.npm/bin:$PATH\")."
             )
         # On Windows, .cmd/.bat wrappers cannot be executed directly by
         # create_subprocess_exec — they must be run via "cmd /c".
@@ -34,12 +71,13 @@ class CodingToolCLIProvider(LLMProvider):
             ["cmd", "/c"] if sys.platform == "win32" and resolved.lower().endswith((".cmd", ".bat"))
             else []
         )
+        self._resolved_binary = resolved  # absolute path, avoids PATH issues at exec time
         self._model = model
         self._timeout = timeout or None
 
     @abstractmethod
-    def _build_command(self) -> list[str]:
-        """Return the subprocess argv list (prompt is passed via stdin, not here)."""
+    def _build_command(self, binary: str) -> list[str]:
+        """Return the subprocess argv list using *binary* (absolute path). Prompt is via stdin."""
 
     @abstractmethod
     def _parse_output(self, raw: str) -> CompletionResponse:
@@ -62,7 +100,7 @@ class CodingToolCLIProvider(LLMProvider):
     async def complete(self, messages: list[Message], system: Optional[str] = None,
                        temperature: float = 0.0, max_tokens: int = 4096) -> CompletionResponse:
         prompt = self._build_prompt(messages, system)
-        cmd = self._cmd_prefix + self._build_command()
+        cmd = self._cmd_prefix + self._build_command(self._resolved_binary)
 
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -107,8 +145,8 @@ class ClaudeCodeCLIProvider(CodingToolCLIProvider):
     """
     _tool_binary = "claude"
 
-    def _build_command(self) -> list[str]:
-        cmd = ["claude", "-p", "--output-format", "json"]
+    def _build_command(self, binary: str) -> list[str]:
+        cmd = [binary, "-p", "--output-format", "json"]
         if self._model:
             cmd += ["--model", self._model]
         return cmd
@@ -146,8 +184,8 @@ class OpencodeProvider(CodingToolCLIProvider):
     """
     _tool_binary = "opencode"
 
-    def _build_command(self) -> list[str]:
-        cmd = ["opencode", "run", "--format", "json"]
+    def _build_command(self, binary: str) -> list[str]:
+        cmd = [binary, "run", "--format", "json"]
         if self._model:
             cmd += ["--model", self._model]
         return cmd

--- a/tests/providers/test_coding_tool_providers.py
+++ b/tests/providers/test_coding_tool_providers.py
@@ -130,15 +130,16 @@ def test_claude_is_quota_exhausted_false():
 
 def test_claude_build_command_no_model():
     provider = _make_claude_provider()
-    cmd = provider._build_command()
-    assert cmd == ["claude", "-p", "--output-format", "json"]
-
+    cmd = provider._build_command(provider._resolved_binary)
+    assert cmd[0] == provider._resolved_binary
+    assert "-p" in cmd
+    assert "--output-format" in cmd
 
 def test_claude_build_command_with_model():
     with patch("shutil.which", return_value="/usr/bin/claude"):
         from synthadoc.providers.coding_tool import ClaudeCodeCLIProvider
         provider = ClaudeCodeCLIProvider(model="claude-sonnet-4-5", timeout=30)
-    cmd = provider._build_command()
+    cmd = provider._build_command(provider._resolved_binary)
     assert "--model" in cmd
     assert "claude-sonnet-4-5" in cmd
 
@@ -212,14 +213,16 @@ def test_opencode_is_quota_exhausted_false():
 
 def test_opencode_build_command_no_model():
     provider = _make_opencode_provider()
-    assert provider._build_command() == ["opencode", "run", "--format", "json"]
-
+    cmd = provider._build_command(provider._resolved_binary)
+    assert cmd[0] == provider._resolved_binary
+    assert "run" in cmd
+    assert "--format" in cmd
 
 def test_opencode_build_command_with_model():
     with patch("shutil.which", return_value="/usr/bin/opencode"):
         from synthadoc.providers.coding_tool import OpencodeProvider
         provider = OpencodeProvider(model="anthropic/claude-sonnet-4-5", timeout=30)
-    cmd = provider._build_command()
+    cmd = provider._build_command(provider._resolved_binary)
     assert "--model" in cmd
     assert "anthropic/claude-sonnet-4-5" in cmd
 

--- a/tests/providers/test_coding_tool_providers.py
+++ b/tests/providers/test_coding_tool_providers.py
@@ -177,7 +177,7 @@ def test_opencode_parse_output_no_text_events_raises():
         json.dumps({"type": "step_start"}),
         json.dumps({"type": "step_finish", "reason": "stop", "tokens": {}}),
     ]
-    with pytest.raises(ValueError, match="no text events"):
+    with pytest.raises(ValueError, match="no text content"):
         provider._parse_output("\n".join(lines))
 
 
@@ -196,7 +196,7 @@ def test_opencode_parse_output_step_finish_error_raises():
 def test_opencode_parse_output_truncated_jsonl_raises():
     """Truncated JSONL (no step_finish, no text) → ValueError."""
     provider = _make_opencode_provider()
-    with pytest.raises(ValueError, match="no text events"):
+    with pytest.raises(ValueError, match="no text content"):
         provider._parse_output('{"type": "step_start"}\n{"type": "ste')
 
 


### PR DESCRIPTION
Summary

  - Binary discovery: claude and opencode are now found even when the server is started from a GUI app (Obsidian, Finder) or non-login shell with a stripped PATH. Resolution tries three strategies in order: current PATH → well-known npm/nvm/Homebrew/Go directories → login shell (zsh -lc "which <binary>") which sources ~/.zshrc and picks up any install method.
  
  - Clean error logging: when the provider binary is not installed, the server now logs a single WARNING line instead of a full stack trace. The query endpoint returns HTTP 503 with the actionable error message; ingest jobs are permanently failed (no pointless retries).
  
  - Opencode JSONL parsing: the opencode CLI outputs text as {"type":"text","part":{"text":"..."}} - the part.text nested field. The previous parser only checked top-level data/text fields and produced empty output. The parser now handles all known layouts (flat data, flat text, part.text, PartTextEvent, assistant content blocks) and logs he raw JSONL at DEBUG level plus a WARNING with all seen event types when parsing fails, making future format changes diagnosable without a code change.
  
Fixes #46 
