### PR TITLE
[v0.3.0] fix: knowledge gap detection issues + win32 socket noise

### DIFF
--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -158,6 +158,7 @@ class QueryAgent:
         # Zero-freq terms (synonyms like "backyard" vs "garden") are excluded;
         # they reflect vocabulary mismatch, not missing content.
         _MIN_TERM_FREQ = 2
+        _any_term_missing = False   # signal 4 default
         if _key_terms and candidates:
             # Count how many candidates contain each key term (doc frequency).
             _term_doc_freq = {
@@ -169,6 +170,24 @@ class QueryAgent:
             }
             _covered = {t: f for t, f in _term_doc_freq.items() if f > 0}
 
+            # Signal 4: a defining concept word is entirely absent from the wiki.
+            # When a query has ≥ 2 key terms and at least one appears in zero
+            # retrieved pages, the topic's core vocabulary is missing — not a
+            # synonym/vocabulary mismatch.  E.g. "quantum error correction" in a
+            # history-of-computing wiki: "error" and "correction" hit Bombe pages
+            # (high BM25 score, signal 3 passes), but "quantum" has zero coverage,
+            # definitively flagging the topic as absent.
+            #
+            # Coverage guard: if non-zero terms appear in >80% of candidates they
+            # are generic corpus words ("plant", "garden"), not topic discriminators.
+            # In that case the zero-freq term is a synonym mismatch, not a true gap.
+            _any_term_missing = (
+                bool(_covered)
+                and len(_term_doc_freq) >= 2
+                and any(f == 0 for f in _term_doc_freq.values())
+                and max(_covered.values()) / len(candidates) <= 0.8
+            )
+
             # Drop hyper-generic terms that appear in >80% of candidates.
             # Using 80% (not 60%) so moderately-common topic words like "partial"
             # (present in ~60-70% of pages in a shade-focused wiki) are kept as
@@ -179,7 +198,7 @@ class QueryAgent:
                 _specific = _covered  # all terms are corpus-generic; use full covered set
             # If every term in _specific appears in only one page it is too rare to
             # discriminate topic coverage — expand to include all covered terms.
-            elif max(_specific.values()) <= 1:
+            elif max(_specific.values(), default=0) <= 1:
                 _specific = _covered
 
             # Log the rarest specific term as a representative discriminator.
@@ -204,6 +223,7 @@ class QueryAgent:
             len(candidates) < 3                          # signal 1: too few pages
             or _max_score < self._gap_score_threshold    # signal 2: low BM25 scores
             or _pages_with_overlap < 2                   # signal 3: no dedicated coverage
+            or _any_term_missing                         # signal 4: defining concept absent
         )
 
         # Always log retrieval quality so operators can tune gap_score_threshold.

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -210,37 +210,51 @@ class QueryAgent:
             else:
                 _discriminating_term = min(_term_doc_freq, key=lambda t: _term_doc_freq[t])
 
-            # A page is on-topic if it mentions ANY specific term with sufficient freq.
-            _pages_with_overlap = sum(
-                1 for r in candidates
-                if (p := self._store.read_page(r.slug)) and
-                   any(p.content.lower().count(t) >= _MIN_TERM_FREQ for t in _specific)
-            )
+            # Single pass: compute both signal 3 (any specific term ≥ freq) and
+            # per-term qualifying page counts (needed for signal 5).
+            _term_qualifying_pages: dict[str, int] = {t: 0 for t in _specific}
+            _pages_with_overlap = 0
+            for _r in candidates:
+                _p = self._store.read_page(_r.slug)
+                if not _p:
+                    continue
+                _content = _p.content.lower()
+                _page_on_topic = False
+                for _t in _specific:
+                    if _content.count(_t) >= _MIN_TERM_FREQ:
+                        _term_qualifying_pages[_t] += 1
+                        _page_on_topic = True
+                if _page_on_topic:
+                    _pages_with_overlap += 1
 
-            # Signal 5: discriminating term (rarest non-generic specific term) appears
-            # with meaningful frequency (≥ MIN_TERM_FREQ) in fewer than 2 candidates.
-            # Catches the "quantum error correction" case: "quantum" has freq=1 (an
-            # index mention) so signal 4 doesn't fire (no zero-freq terms), while
-            # "error"/"correction" incidentally give on_topic_pages=2 so signal 3
-            # also doesn't fire.  But "quantum" itself never appears ≥ 2 times in
-            # any page, definitively showing the defining concept is absent.
-            _discriminating_term_pages = (
-                sum(
-                    1 for r in candidates
-                    if (p := self._store.read_page(r.slug)) and
-                       p.content.lower().count(_discriminating_term) >= _MIN_TERM_FREQ
-                )
-                if _discriminating_term else 0
+            # Signal 5: at least one specific topic term never appears with meaningful
+            # frequency (≥ MIN_TERM_FREQ) in any single candidate page.
+            #
+            # A term that appears scattered (once per page across many pages) is
+            # incidentally present — the wiki touches the vocabulary but lacks a page
+            # that actually discusses the concept.
+            #
+            # "quantum error correction": "quantum" and "correction" each appear in
+            # 1 page with ≥ 2 occurrences (transistor and bombe respectively), but
+            # "error" appears only once each in 2 separate pages (never ≥ 2 in any
+            # one page) — min qualifying = 0 → gap.
+            #
+            # "unix open-source movement": every specific term ("open-source",
+            # "movement", "influence") has at least 1 page where it appears ≥ 2 times
+            # — min qualifying ≥ 1 → no gap.
+            _min_specific_qualifying = (
+                min(_term_qualifying_pages.values())
+                if _term_qualifying_pages else 0
             )
             _defining_term_absent = (
                 bool(_specific)
                 and len(_term_doc_freq) >= 2
-                and _discriminating_term_pages < 2
+                and _min_specific_qualifying == 0
             )
         else:
             _discriminating_term = ""
             _pages_with_overlap = len(candidates)   # no key terms → skip check
-            _discriminating_term_pages = len(candidates)
+            _min_specific_qualifying = len(candidates)
 
         _gap = self._gap_score_threshold > 0 and (
             len(candidates) < 3                          # signal 1: too few pages
@@ -253,9 +267,9 @@ class QueryAgent:
         # Always log retrieval quality so operators can tune gap_score_threshold.
         logger.info(
             "query retrieval — pages=%d, max_score=%.2f, "
-            "discriminating_term=%r, on_topic_pages=%d, discriminating_pages=%d, gap=%s",
+            "discriminating_term=%r, on_topic_pages=%d, min_qualifying=%d, gap=%s",
             len(candidates), _max_score, _discriminating_term,
-            _pages_with_overlap, _discriminating_term_pages, _gap,
+            _pages_with_overlap, _min_specific_qualifying, _gap,
         )
         if _gap:
             _suggested = await SearchDecomposeAgent(self._provider).decompose(question)

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -224,10 +224,22 @@ class QueryAgent:
             if (p := self._store.read_page(r.slug))
         ) or "No relevant pages found."
 
+        if _gap:
+            synthesis_prompt = (
+                f"The wiki does not yet have a page on this topic. "
+                f"Answer the question using your general knowledge, then note in one sentence "
+                f"that the wiki does not currently cover this topic and suggest the user enriches it.\n\n"
+                f"Question: {question}\n\n"
+                f"Wiki pages available (unrelated to this question):\n{context}"
+            )
+        else:
+            synthesis_prompt = (
+                f"Answer using ONLY these wiki pages. Cite with [[PageTitle]].\n\n"
+                f"Question: {question}\n\nPages:\n{context}"
+            )
+
         resp2 = await self._provider.complete(
-            messages=[Message(role="user",
-                content=f"Answer using ONLY these wiki pages. Cite with [[PageTitle]].\n\n"
-                        f"Question: {question}\n\nPages:\n{context}")],
+            messages=[Message(role="user", content=synthesis_prompt)],
             temperature=0.0,
         )
         logger.info("query answered — %d page(s) cited, %d tokens",

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -159,6 +159,7 @@ class QueryAgent:
         # they reflect vocabulary mismatch, not missing content.
         _MIN_TERM_FREQ = 2
         _any_term_missing = False   # signal 4 default
+        _defining_term_absent = False  # signal 5 default
         if _key_terms and candidates:
             # Count how many candidates contain each key term (doc frequency).
             _term_doc_freq = {
@@ -215,22 +216,46 @@ class QueryAgent:
                 if (p := self._store.read_page(r.slug)) and
                    any(p.content.lower().count(t) >= _MIN_TERM_FREQ for t in _specific)
             )
+
+            # Signal 5: discriminating term (rarest non-generic specific term) appears
+            # with meaningful frequency (≥ MIN_TERM_FREQ) in fewer than 2 candidates.
+            # Catches the "quantum error correction" case: "quantum" has freq=1 (an
+            # index mention) so signal 4 doesn't fire (no zero-freq terms), while
+            # "error"/"correction" incidentally give on_topic_pages=2 so signal 3
+            # also doesn't fire.  But "quantum" itself never appears ≥ 2 times in
+            # any page, definitively showing the defining concept is absent.
+            _discriminating_term_pages = (
+                sum(
+                    1 for r in candidates
+                    if (p := self._store.read_page(r.slug)) and
+                       p.content.lower().count(_discriminating_term) >= _MIN_TERM_FREQ
+                )
+                if _discriminating_term else 0
+            )
+            _defining_term_absent = (
+                bool(_specific)
+                and len(_term_doc_freq) >= 2
+                and _discriminating_term_pages < 2
+            )
         else:
             _discriminating_term = ""
             _pages_with_overlap = len(candidates)   # no key terms → skip check
+            _discriminating_term_pages = len(candidates)
 
         _gap = self._gap_score_threshold > 0 and (
             len(candidates) < 3                          # signal 1: too few pages
             or _max_score < self._gap_score_threshold    # signal 2: low BM25 scores
             or _pages_with_overlap < 2                   # signal 3: no dedicated coverage
             or _any_term_missing                         # signal 4: defining concept absent
+            or _defining_term_absent                     # signal 5: defining term barely present
         )
 
         # Always log retrieval quality so operators can tune gap_score_threshold.
         logger.info(
             "query retrieval — pages=%d, max_score=%.2f, "
-            "discriminating_term=%r, on_topic_pages=%d, gap=%s",
-            len(candidates), _max_score, _discriminating_term, _pages_with_overlap, _gap,
+            "discriminating_term=%r, on_topic_pages=%d, discriminating_pages=%d, gap=%s",
+            len(candidates), _max_score, _discriminating_term,
+            _pages_with_overlap, _discriminating_term_pages, _gap,
         )
         if _gap:
             _suggested = await SearchDecomposeAgent(self._provider).decompose(question)

--- a/synthadoc/core/logging_config.py
+++ b/synthadoc/core/logging_config.py
@@ -21,7 +21,7 @@ File handler
 
 Root logger
     Level  : DEBUG — lets each handler decide what to show/store.
-    Third-party noise (httpx, uvicorn access) is suppressed to WARNING.
+    Third-party noise (httpx, uvicorn access, aiosqlite, asyncio) is suppressed to WARNING.
 
 Configuration (in .synthadoc/config.toml)
 ------------------------------------------
@@ -158,7 +158,8 @@ def setup_logging(
     root.addHandler(file_handler)
 
     # --- Suppress noisy third-party loggers ---
-    for noisy in ("httpx", "httpcore", "uvicorn.access", "anthropic", "openai"):
+    for noisy in ("httpx", "httpcore", "uvicorn.access", "anthropic", "openai",
+                  "aiosqlite", "asyncio"):
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
     logging.getLogger(__name__).info(

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -16,6 +17,30 @@ import re
 logger = logging.getLogger(__name__)
 
 _MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _install_win32_conn_reset_filter() -> None:
+    """Downgrade spurious ConnectionResetError noise from asyncio on Windows.
+
+    When a client abruptly closes a TCP connection (RST instead of FIN),
+    Windows IOCP raises ConnectionResetError inside the cleanup callback
+    _ProactorBasePipeTransport._call_connection_lost.  Python's asyncio logs
+    this at ERROR level even though no request is dropped and nothing is wrong.
+    We install a tight exception handler that downgrades only this specific case
+    to DEBUG (still visible via --verbose / log file) and forwards everything
+    else to the default handler unchanged.
+    """
+    loop = asyncio.get_event_loop()
+    _prev = loop.get_exception_handler()
+
+    def _handler(loop, context):
+        exc = context.get("exception")
+        if isinstance(exc, ConnectionResetError) and "_call_connection_lost" in context.get("message", ""):
+            logger.debug("win32 socket closed by remote host (WinError 10054) — harmless")
+            return
+        (_prev or loop.default_exception_handler)(loop, context)
+
+    loop.set_exception_handler(_handler)
 
 
 def _classify_llm_error(exc: Exception) -> "HTTPException | None":
@@ -220,6 +245,8 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        if sys.platform == "win32":
+            _install_win32_conn_reset_filter()
         orch = Orchestrator(wiki_root=wiki_root, config=cfg)
         await orch.init()
         app.state.orch = orch

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -948,20 +948,27 @@ async def test_no_gap_multi_aspect_query_with_generic_corpus_term(tmp_wiki):
 
 @pytest.mark.asyncio
 async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
-    """Signal 5: gap triggers when the discriminating (rarest specific) term appears
-    with meaningful frequency (≥ 2 times) in zero candidate pages, even though other
-    key terms appear incidentally in 2+ pages (so signal 3 passes).
+    """Signal 5: gap triggers when at least one specific key term never appears ≥ 2
+    times in any single candidate page, even though it exists in the wiki (freq > 0
+    across pages) so signal 4 does not fire.
 
     Real-world case: "quantum error correction" in a history-of-computing wiki.
-    "quantum" appears once in the index page (freq=1, so signal 4 doesn't fire) while
-    "error" and "correction" appear in Bombe/AI pages incidentally (on_topic_pages=2).
-    Signal 5 catches this: "quantum" never appears ≥ 2 times in any page.
+    "quantum" is present in 2 candidate pages but only once per page (passing mention).
+    "error" and "correction" each appear ≥ 2 times in dedicated Bombe pages.
+
+    Signal breakdown for this test:
+    - Signal 1: 8 candidates ≥ 3 → no fire
+    - Signal 2: gap_score_threshold=0.01 → no fire
+    - Signal 3: 2 pages have error/correction ≥ 2 → on_topic_pages=2 ≥ 2 → no fire
+    - Signal 4: all 3 terms have doc_freq > 0 → no zero-freq → no fire
+    - Signal 5: quantum_qualifying_pages=0 (never ≥ 2 in any page) →
+                min(quantum=0, error=2, correction=2)=0 → gap=True ✓
 
     bm25_search is mocked so BM25 IDF behaviour does not affect this test.
     """
     store = WikiStorage(tmp_wiki / "wiki")
 
-    # 2 pages where "error" and "correction" appear ≥ 2 times (incidental matches).
+    # 2 pages where "error" and "correction" appear ≥ 2 times (Bombe incidental matches).
     for i in range(2):
         store.write_page(f"bombe-page-{i}", WikiPage(
             title=f"The Bombe Machine {i}", tags=["history"],
@@ -973,8 +980,19 @@ async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
             ),
             status="active", confidence="high", sources=[],
         ))
-    # 6 pages with no "error"/"correction" but also no "quantum".
-    for i in range(6):
+    # 2 pages that each mention "quantum" exactly once — present but not covered.
+    for i in range(2):
+        store.write_page(f"quantum-mention-{i}", WikiPage(
+            title=f"Computing Frontiers {i}", tags=["history"],
+            content=(
+                "Transistors replaced vacuum tubes in the 1950s, paving the way for "
+                "integrated circuits. Researchers have since explored quantum computing "
+                "as the next frontier, but this wiki does not yet cover that topic."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+    # 4 filler pages with none of the key terms.
+    for i in range(4):
         store.write_page(f"other-page-{i}", WikiPage(
             title=f"Computing History {i}", tags=["history"],
             content=(
@@ -983,18 +1001,11 @@ async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
             ),
             status="active", confidence="high", sources=[],
         ))
-    # Index page that mentions "quantum" exactly once (passing mention, not coverage).
-    store.write_page("index", WikiPage(
-        title="Index", tags=["index"],
-        content=(
-            "Topics: transistors, microchips, bombe, artificial intelligence, quantum (not yet covered)."
-        ),
-        status="active", confidence="high", sources=[],
-    ))
 
     all_slugs = (
         [f"bombe-page-{i}" for i in range(2)]
-        + [f"other-page-{i}" for i in range(6)]
+        + [f"quantum-mention-{i}" for i in range(2)]
+        + [f"other-page-{i}" for i in range(4)]
     )
     search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
     provider = AsyncMock()
@@ -1010,9 +1021,6 @@ async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
                        gap_score_threshold=0.01)  # signal 2 disabled
     with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
         result = await agent.query("What is quantum error correction?")
-    # "quantum" is the discriminating term. It appears in the index page once but is
-    # NOT in the 8 mocked candidates (all_slugs excludes "index"). So discriminating
-    # pages = 0 < 2 → signal 5 fires → gap=True.
-    # Signal 3 would NOT fire alone: "error"/"correction" appear ≥ 2 times in 2 pages.
+    # "quantum" never appears ≥ 2 times in any candidate → min_qualifying=0 → signal 5.
     assert result.knowledge_gap is True
     assert len(result.suggested_searches) >= 1

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -944,3 +944,75 @@ async def test_no_gap_multi_aspect_query_with_generic_corpus_term(tmp_wiki):
     # 4 pages mention "partial" ≥ 2 times → on_topic_pages = 4 ≥ 2 → no gap.
     assert result.knowledge_gap is False
     assert result.suggested_searches == []
+
+
+@pytest.mark.asyncio
+async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
+    """Signal 5: gap triggers when the discriminating (rarest specific) term appears
+    with meaningful frequency (≥ 2 times) in zero candidate pages, even though other
+    key terms appear incidentally in 2+ pages (so signal 3 passes).
+
+    Real-world case: "quantum error correction" in a history-of-computing wiki.
+    "quantum" appears once in the index page (freq=1, so signal 4 doesn't fire) while
+    "error" and "correction" appear in Bombe/AI pages incidentally (on_topic_pages=2).
+    Signal 5 catches this: "quantum" never appears ≥ 2 times in any page.
+
+    bm25_search is mocked so BM25 IDF behaviour does not affect this test.
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+
+    # 2 pages where "error" and "correction" appear ≥ 2 times (incidental matches).
+    for i in range(2):
+        store.write_page(f"bombe-page-{i}", WikiPage(
+            title=f"The Bombe Machine {i}", tags=["history"],
+            content=(
+                "The Bombe detected incorrect Enigma settings by finding contradictions. "
+                "Each error in the assumed settings triggered a correction cycle. "
+                "The machine applied error correction logic to narrow down Enigma keys. "
+                "Finding an error led to rejecting that key and applying a correction."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+    # 6 pages with no "error"/"correction" but also no "quantum".
+    for i in range(6):
+        store.write_page(f"other-page-{i}", WikiPage(
+            title=f"Computing History {i}", tags=["history"],
+            content=(
+                "Alan Turing proposed the Turing machine as a theoretical model of computation. "
+                "John von Neumann designed the stored-program architecture."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+    # Index page that mentions "quantum" exactly once (passing mention, not coverage).
+    store.write_page("index", WikiPage(
+        title="Index", tags=["index"],
+        content=(
+            "Topics: transistors, microchips, bombe, artificial intelligence, quantum (not yet covered)."
+        ),
+        status="active", confidence="high", sources=[],
+    ))
+
+    all_slugs = (
+        [f"bombe-page-{i}" for i in range(2)]
+        + [f"other-page-{i}" for i in range(6)]
+    )
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["What is quantum error correction?"]',
+                           input_tokens=5, output_tokens=5),
+        # SearchDecomposeAgent call for suggestions (gap triggered):
+        CompletionResponse(text='["quantum error correction explained", "qubit error rates"]',
+                           input_tokens=8, output_tokens=8),
+        CompletionResponse(text="No quantum info found.", input_tokens=80, output_tokens=15),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)  # signal 2 disabled
+    with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
+        result = await agent.query("What is quantum error correction?")
+    # "quantum" is the discriminating term. It appears in the index page once but is
+    # NOT in the 8 mocked candidates (all_slugs excludes "index"). So discriminating
+    # pages = 0 < 2 → signal 5 fires → gap=True.
+    # Signal 3 would NOT fire alone: "error"/"correction" appear ≥ 2 times in 2 pages.
+    assert result.knowledge_gap is True
+    assert len(result.suggested_searches) >= 1


### PR DESCRIPTION
 What

  Hardens the knowledge gap detector in the query agent (signals 4 & 5) and silences a spurious ERROR asyncio on Windows when clients close connections abruptly.

  Why

  Signal 4 was too broad: it fired for synonym/vocabulary mismatches (e.g. "backyard" vs "garden"), generating false knowledge gaps for topics the wiki clearly covered. Signal 5 used a single non-deterministically selected term, so it fired for "How did Unix influence the open-source movement?" depending on which term the LLM happened to pick. On Windows, the roactorEventLoop logs every client disconnect as ERROR asyncio … WinError 10054, creating alarm noise in the server console for completely normal behaviour.

  Changes

  - Signal 4 coverage guard: only flags a zero-frequency term as a true gap if the covered terms are specific to the query (appear in ≤80% of candidates); blocks false positives from generic corpus vocabulary.
  - Signal 5 redesign: replaced single-discriminating-term check with min(qualifying pages per specific term) == 0; fires only when at least one specific key term never appears ≥2 times in any single candidate page (deterministic, handles multi-aspect queries correctly).
  - Signal 5 test fixed: previous test was exercising signal 4 (key term with doc_freq=0); new test has all key terms present in the wiki but "quantum" appearing only once per page, correctly targeting signal 5.
  - Win32 socket noise: installs a tight asyncio exception handler on lifespan startup (Windows only) that downgrades ConnectionResetError in _call_connection_lost from ERROR to DEBUG; still visible via --verbose / log file.
 