### PR TITLE
fix(demo): remove duplicate aliases field from ai-research pre-built wiki pages

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -26,6 +26,10 @@
 15. [Observability and Logging](#15-observability-and-logging)
 16. [Security](#16-security)
 17. [Plugin Development Guide](#17-plugin-development-guide)
+18. [Routing](#18-routing)
+19. [Candidates Staging](#19-candidates-staging)
+20. [Context Packs](#20-context-packs)
+
 **Appendices**
 - [Appendix A — Release Feature Index](#appendix-a--release-feature-index)
 

--- a/synthadoc/demos/ai-research/wiki/andrej-karpathy.md
+++ b/synthadoc/demos/ai-research/wiki/andrej-karpathy.md
@@ -11,7 +11,6 @@ sources:
     ingested: '2026-05-09'
 orphan: false
 aliases: []
-aliases: []
 ---
 
 # Andrej Karpathy

--- a/synthadoc/demos/ai-research/wiki/attention-mechanisms.md
+++ b/synthadoc/demos/ai-research/wiki/attention-mechanisms.md
@@ -11,7 +11,6 @@ sources:
     ingested: '2026-05-09'
 orphan: false
 aliases: []
-aliases: []
 ---
 
 # Attention Mechanisms

--- a/synthadoc/demos/ai-research/wiki/geoffrey-hinton.md
+++ b/synthadoc/demos/ai-research/wiki/geoffrey-hinton.md
@@ -11,7 +11,6 @@ sources:
     ingested: '2026-05-09'
 orphan: false
 aliases: []
-aliases: []
 ---
 
 # Geoffrey Hinton

--- a/synthadoc/demos/ai-research/wiki/llm-benchmarks.md
+++ b/synthadoc/demos/ai-research/wiki/llm-benchmarks.md
@@ -11,7 +11,6 @@ sources:
     ingested: '2026-05-09'
 orphan: false
 aliases: []
-aliases: []
 ---
 
 # LLM Benchmarks

--- a/synthadoc/demos/ai-research/wiki/reinforcement-learning-from-human-feedback.md
+++ b/synthadoc/demos/ai-research/wiki/reinforcement-learning-from-human-feedback.md
@@ -10,7 +10,6 @@ sources:
     size: 3847
     ingested: '2026-05-09'
 orphan: false
-aliases: []
 aliases: [RLHF]
 ---
 

--- a/synthadoc/demos/ai-research/wiki/scaling-laws.md
+++ b/synthadoc/demos/ai-research/wiki/scaling-laws.md
@@ -11,7 +11,6 @@ sources:
     ingested: '2026-05-09'
 orphan: false
 aliases: []
-aliases: []
 ---
 
 # Scaling Laws

--- a/synthadoc/demos/ai-research/wiki/transformer-architecture.md
+++ b/synthadoc/demos/ai-research/wiki/transformer-architecture.md
@@ -11,7 +11,6 @@ sources:
     ingested: '2026-05-09'
 orphan: false
 aliases: []
-aliases: []
 ---
 
 # Transformer Architecture


### PR DESCRIPTION
1. fix(demo): remove duplicate aliases field from ai-research pre-built wiki pages
2. TOC fixes in design.md