### PR TITLE
fix(providers): surface opencode API errors clearly; exclude integrat…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,9 @@ synthadoc = "synthadoc.cli.main:app"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+addopts = "-m 'not integration'"
 markers = [
-    "integration: marks tests that require real external tools (deselect with '-m not integration')",
+    "integration: marks tests that require real external tools (run explicitly with '-m integration')",
 ]
 
 [tool.hatch.version]

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -274,6 +274,11 @@ class OpencodeProvider(CodingToolCLIProvider):
                         if chunk:
                             text_parts.append(chunk)
 
+            elif etype == "error":
+                err = event.get("error") or {}
+                msg = (err.get("data") or {}).get("message") or err.get("name") or "unknown error"
+                raise RuntimeError(f"opencode: API error — {msg}")
+
             # --- token counts ---
             elif etype == "step_finish":
                 if event.get("reason") == "error":


### PR DESCRIPTION
…ion tests from default run

- _parse_output now raises RuntimeError with the actual API message on type=error events instead of falling through to a cryptic 'no text content' ValueError
- Add addopts to pytest config so integration tests (real CLI calls) are excluded from plain 'pytest' runs; run explicitly with -m integration