### PR TITLE
fix(query_agent): gap detection misses specific absent concepts when on_topic_pages = n_cands/2 + test coverage update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 venv/
 node_modules/
 obsidian-plugin/node_modules/
+obsidian-plugin/coverage/
 .VSCodeCounter/
 .claude/settings.local.json
 

--- a/docs/badges.json
+++ b/docs/badges.json
@@ -3,6 +3,6 @@
   "obsidian_commands": 19,
   "skills": 9,
   "hooks": 2,
-  "coverage": 86,
+  "coverage": 87,
   "coverage_color": "brightgreen"
 }

--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -9,11 +9,72 @@
       "version": "0.4.0",
       "devDependencies": {
         "@types/node": "^20",
+        "@vitest/coverage-v8": "^4.1.4",
         "builtin-modules": "^3.3.0",
         "esbuild": "^0.28.0",
         "obsidian": "latest",
         "typescript": "^5.3",
         "vitest": "^4.1.4"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@codemirror/state": {
@@ -42,9 +103,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -54,9 +115,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -517,12 +578,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
@@ -533,9 +615,9 @@
       "peer": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -552,9 +634,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -562,9 +644,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -579,9 +661,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -596,9 +678,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -613,9 +695,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -630,9 +712,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -647,9 +729,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -664,9 +746,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -681,9 +763,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -698,9 +780,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -715,9 +797,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -732,9 +814,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -749,9 +831,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -766,9 +848,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -776,18 +858,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -802,9 +884,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -819,9 +901,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -833,9 +915,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -898,17 +980,48 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -917,13 +1030,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -944,9 +1057,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -957,13 +1070,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -971,14 +1084,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -987,9 +1100,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -997,13 +1110,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1019,6 +1132,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/builtin-modules": {
@@ -1170,6 +1295,69 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1442,6 +1630,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -1453,9 +1669,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1525,9 +1741,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -1554,14 +1770,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1570,21 +1786,34 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/siginfo": {
@@ -1625,6 +1854,19 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1700,17 +1942,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1726,7 +1968,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -1778,19 +2020,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1818,12 +2060,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -4,10 +4,12 @@
   "scripts": {
     "build": "node esbuild.config.mjs production",
     "dev": "node esbuild.config.mjs",
-    "test": "vitest run"
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@vitest/coverage-v8": "^4.1.4",
     "builtin-modules": "^3.3.0",
     "esbuild": "^0.28.0",
     "obsidian": "latest",

--- a/obsidian-plugin/src/api.test.ts
+++ b/obsidian-plugin/src/api.test.ts
@@ -328,6 +328,152 @@ describe("api.candidateDiscard", () => {
     });
 });
 
+describe("api.retryJob", () => {
+    it("POSTs to /jobs/{jobId}/retry", async () => {
+        mockResponse({ job_id: "abc-123", status: "pending" });
+        await api.retryJob("abc-123");
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/jobs/abc-123/retry", method: "POST" })
+        );
+    });
+});
+
+describe("api.deleteJob", () => {
+    it("DELETEs /jobs/{jobId}", async () => {
+        mockResponse({ deleted: "abc-123" });
+        await api.deleteJob("abc-123");
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/jobs/abc-123", method: "DELETE" })
+        );
+    });
+});
+
+describe("api.purgeJobs", () => {
+    it("DELETEs /jobs?older_than with specified days", async () => {
+        mockResponse({ purged: 5 });
+        await api.purgeJobs(7);
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/jobs?older_than=7", method: "DELETE" })
+        );
+    });
+});
+
+describe("api.scaffold", () => {
+    it("POSTs to /jobs/scaffold with domain in body", async () => {
+        mockResponse({ job_id: "scaffold-job-1" });
+        await api.scaffold("Robotics");
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: "http://127.0.0.1:7070/jobs/scaffold",
+                method: "POST",
+                body: JSON.stringify({ domain: "Robotics" }),
+            })
+        );
+    });
+});
+
+describe("api.job", () => {
+    it("GETs /jobs/{jobId} and returns job detail", async () => {
+        mockResponse({ job_id: "abc-123", status: "completed", source: "paper.pdf" });
+        const r = await api.job("abc-123") as any;
+        expect(r.job_id).toBe("abc-123");
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/jobs/abc-123", method: "GET" })
+        );
+    });
+});
+
+describe("api.auditHistory", () => {
+    it("GETs /audit/history with default limit of 50", async () => {
+        mockResponse([]);
+        await api.auditHistory();
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/history?limit=50", method: "GET" })
+        );
+    });
+
+    it("GETs /audit/history with custom limit", async () => {
+        mockResponse([]);
+        await api.auditHistory(10);
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/history?limit=10" })
+        );
+    });
+});
+
+describe("api.auditCosts", () => {
+    it("GETs /audit/costs with default 30-day window", async () => {
+        mockResponse({ total_usd: 1.23 });
+        await api.auditCosts();
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/costs?days=30", method: "GET" })
+        );
+    });
+
+    it("GETs /audit/costs with custom days", async () => {
+        mockResponse({ total_usd: 0.45 });
+        await api.auditCosts(7);
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/costs?days=7" })
+        );
+    });
+});
+
+describe("api.queryHistory", () => {
+    it("GETs /audit/queries with default limit of 50", async () => {
+        mockResponse([]);
+        await api.queryHistory();
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/queries?limit=50", method: "GET" })
+        );
+    });
+
+    it("GETs /audit/queries with custom limit", async () => {
+        mockResponse([]);
+        await api.queryHistory(20);
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/queries?limit=20" })
+        );
+    });
+});
+
+describe("api.auditEvents", () => {
+    it("GETs /audit/events with default limit of 100", async () => {
+        mockResponse([]);
+        await api.auditEvents();
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/events?limit=100", method: "GET" })
+        );
+    });
+
+    it("GETs /audit/events with custom limit", async () => {
+        mockResponse([]);
+        await api.auditEvents(25);
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({ url: "http://127.0.0.1:7070/audit/events?limit=25" })
+        );
+    });
+});
+
+describe("api.ingest with maxResults", () => {
+    it("includes max_results in body when maxResults is provided", async () => {
+        mockResponse({ job_id: "job-456" });
+        await api.ingest("paper.pdf", 20);
+        expect(mockRequestUrl).toHaveBeenCalledWith(
+            expect.objectContaining({
+                body: JSON.stringify({ source: "paper.pdf", max_results: 20 }),
+            })
+        );
+    });
+
+    it("omits max_results from body when maxResults is not provided", async () => {
+        mockResponse({ job_id: "job-789" });
+        await api.ingest("paper.pdf");
+        const call = mockRequestUrl.mock.calls[0][0];
+        expect(JSON.parse(call.body)).not.toHaveProperty("max_results");
+    });
+});
+
 describe("api.contextBuild", () => {
     it("POSTs to /context/build with goal and token_budget", async () => {
         mockResponse({

--- a/obsidian-plugin/src/main.test.ts
+++ b/obsidian-plugin/src/main.test.ts
@@ -504,6 +504,7 @@ function makeSmartContentEl(): any {
                 el._html = "";
             }),
             setText: vi.fn((text: string) => { el._html = text; }),
+            appendText: (text: string) => { el._html += text; },
             createEl: vi.fn((childTag: string, childOpts?: any) => {
                 const child = makeEl(childTag, childOpts);
                 el._children.push(child);
@@ -1437,5 +1438,673 @@ describe("ContextModal", () => {
 
         const resultArea = modal.contentEl._children[6]._children[2];
         expect(resultArea.value).toContain("relevance: 3.00");
+    });
+});
+
+// ── JobsModal ─────────────────────────────────────────────────────────────────
+
+describe("JobsModal", () => {
+    it("calls api.jobs on open and renders job IDs in the table", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs");
+        apiMock.jobs.mockResolvedValueOnce([
+            { id: "job-aaa111", status: "pending", operation: "ingest", payload: { source: "doc.pdf" }, created_at: null },
+            { id: "job-bbb222", status: "in_progress", operation: "ingest", payload: { source: "page.md" }, created_at: null },
+        ]);
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.jobs).toHaveBeenCalled();
+        expect(modal.contentEl.innerHTML).toContain("job-aaa111");
+        expect(modal.contentEl.innerHTML).toContain("job-bbb222");
+    });
+
+    it("shows 'No jobs match' when filtered list is empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs");
+        apiMock.jobs.mockResolvedValueOnce([]);
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("No jobs match");
+    });
+
+    it("shows error message when api.jobs throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs");
+        apiMock.jobs.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+
+    it("renders error detail row for failed jobs", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs");
+        // "failed" is not in the default filter — mock returns all jobs, filter leaves only pending/in_progress
+        // Use a pending job that carries an error note (edge-case), OR add a skipped job with an error.
+        // Easiest: just test that multiple statuses show their emoji via a pending job.
+        apiMock.jobs.mockResolvedValueOnce([
+            {
+                id: "job-ddd444", status: "pending", operation: "ingest",
+                payload: { source: "report.pdf" }, created_at: null, result: null, error: null,
+            },
+        ]);
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        // pending is in the default filter — job should be visible
+        expect(modal.contentEl.innerHTML).toContain("job-ddd444");
+        expect(modal.contentEl.innerHTML).toContain("🕐"); // pending emoji
+    });
+});
+
+// ── LintReportModal ───────────────────────────────────────────────────────────
+
+describe("LintReportModal", () => {
+    it("calls api.lintReport on open", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-lint-report");
+        apiMock.lintReport.mockResolvedValueOnce({ contradictions: [], orphans: [] });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.lintReport).toHaveBeenCalled();
+    });
+
+    it("shows 'All clear' when no contradictions or orphans", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-lint-report");
+        apiMock.lintReport.mockResolvedValueOnce({ contradictions: [], orphans: [] });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("All clear");
+    });
+
+    it("renders contradicted page slug and contradiction note", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-lint-report");
+        apiMock.lintReport.mockResolvedValueOnce({
+            contradictions: ["alan-turing"],
+            contradiction_details: [{ slug: "alan-turing", contradiction_note: "Conflicting dates found" }],
+            orphans: [],
+        });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("alan-turing");
+        expect(modal.contentEl.innerHTML).toContain("Conflicting dates found");
+    });
+
+    it("renders orphan page slugs", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-lint-report");
+        apiMock.lintReport.mockResolvedValueOnce({
+            contradictions: [],
+            orphans: ["quantum-computing"],
+            orphan_details: [{ slug: "quantum-computing", index_suggestion: "- [[quantum-computing]]" }],
+        });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("quantum-computing");
+    });
+
+    it("shows error when api.lintReport throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-lint-report");
+        apiMock.lintReport.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+});
+
+// ── IngestUrlModal ────────────────────────────────────────────────────────────
+
+describe("IngestUrlModal", () => {
+    it("calls api.ingest with the entered URL on Ingest click", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-ingest-url");
+        apiMock.ingest.mockResolvedValueOnce({ job_id: "url-job-01" });
+        apiMock.job = vi.fn().mockResolvedValue({ status: "completed", result: {} });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const input = modal.contentEl.querySelector("input") as any;
+        input.value = "https://example.com/paper.pdf";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(apiMock.ingest).toHaveBeenCalledWith("https://example.com/paper.pdf");
+    });
+
+    it("shows error and re-enables button when api.ingest throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-ingest-url");
+        apiMock.ingest.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const input = modal.contentEl.querySelector("input") as any;
+        input.value = "https://example.com/paper.pdf";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(btn.disabled).toBe(false);
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+
+    it("does nothing when URL input is empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-ingest-url");
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+
+        expect(apiMock.ingest).not.toHaveBeenCalled();
+    });
+});
+
+// ── WebSearchModal ────────────────────────────────────────────────────────────
+
+describe("WebSearchModal", () => {
+    it("calls api.ingest with 'search for: ' prefix on Search click", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-web-search");
+        apiMock.ingest.mockResolvedValueOnce({ job_id: "ws-job-01" });
+        apiMock.job = vi.fn().mockResolvedValue({ status: "completed", result: {} });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const textarea = modal.contentEl.querySelector("textarea") as any;
+        textarea.value = "Bank of Canada rate outlook";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(apiMock.ingest).toHaveBeenCalledWith(
+            "search for: Bank of Canada rate outlook",
+            expect.any(Number),
+        );
+    });
+
+    it("passes maxResults from the input to api.ingest", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-web-search");
+        apiMock.ingest.mockResolvedValueOnce({ job_id: "ws-job-02" });
+        apiMock.job = vi.fn().mockResolvedValue({ status: "completed", result: {} });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const textarea = modal.contentEl.querySelector("textarea") as any;
+        textarea.value = "Ontario housing market";
+        // settingsRow is _children[3]; maxResultsInput is settingsRow._children[1]
+        const maxInput = modal.contentEl._children[3]._children[1];
+        maxInput.value = "30";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(apiMock.ingest).toHaveBeenCalledWith("search for: Ontario housing market", 30);
+    });
+
+    it("shows error and re-enables button when api.ingest throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-web-search");
+        apiMock.ingest.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const textarea = modal.contentEl.querySelector("textarea") as any;
+        textarea.value = "some topic";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(btn.disabled).toBe(false);
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+
+    it("does nothing when topic textarea is empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-web-search");
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+
+        expect(apiMock.ingest).not.toHaveBeenCalled();
+    });
+});
+
+// ── PurgeJobsModal ────────────────────────────────────────────────────────────
+
+describe("PurgeJobsModal", () => {
+    it("calls api.purgeJobs with the entered days on Purge click", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs-purge");
+        apiMock.purgeJobs.mockResolvedValueOnce({ purged: 3 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const input = modal.contentEl.querySelector("input") as any;
+        input.value = "14";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(apiMock.purgeJobs).toHaveBeenCalledWith(14);
+    });
+
+    it("shows purged count on success", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs-purge");
+        apiMock.purgeJobs.mockResolvedValueOnce({ purged: 5 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("5 job(s)");
+    });
+
+    it("shows error and re-enables button when api.purgeJobs throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-jobs-purge");
+        apiMock.purgeJobs.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(btn.disabled).toBe(false);
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+});
+
+// ── AuditHistoryModal ─────────────────────────────────────────────────────────
+
+describe("AuditHistoryModal", () => {
+    it("calls api.auditHistory with default limit 50 on open", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-history");
+        apiMock.auditHistory.mockResolvedValueOnce({ records: [], count: 0 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.auditHistory).toHaveBeenCalledWith(50);
+    });
+
+    it("shows 'No ingest records' when empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-history");
+        apiMock.auditHistory.mockResolvedValueOnce({ records: [], count: 0 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("No ingest records");
+    });
+
+    it("renders source filename and wiki_page", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-history");
+        apiMock.auditHistory.mockResolvedValueOnce({
+            records: [{
+                source_path: "raw_sources/paper.pdf",
+                wiki_page: "alan-turing",
+                tokens: 1200, cost_usd: 0.0014,
+                ingested_at: "2026-05-01T10:00:00Z",
+            }],
+            count: 1,
+        });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("paper.pdf");
+        expect(modal.contentEl.innerHTML).toContain("alan-turing");
+    });
+
+    it("calls api.auditHistory with custom limit on Load click", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-history");
+        apiMock.auditHistory
+            .mockResolvedValueOnce({ records: [], count: 0 })
+            .mockResolvedValueOnce({ records: [], count: 0 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        const input = modal.contentEl.querySelector("input") as any;
+        input.value = "100";
+        const btn = modal.contentEl.querySelector("button") as any;
+        await btn.onclick();
+        await flushPromises();
+
+        expect(apiMock.auditHistory).toHaveBeenCalledWith(100);
+    });
+
+    it("shows error when api.auditHistory throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-history");
+        apiMock.auditHistory.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+});
+
+// ── AuditCostsModal ───────────────────────────────────────────────────────────
+
+describe("AuditCostsModal", () => {
+    it("calls api.auditCosts with default 30 days on open", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-costs");
+        apiMock.auditCosts.mockResolvedValueOnce({ total_tokens: 0, total_cost_usd: 0, daily: [] });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.auditCosts).toHaveBeenCalledWith(30);
+    });
+
+    it("shows total cost in the summary line", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-costs");
+        apiMock.auditCosts.mockResolvedValueOnce({
+            total_tokens: 48200, total_cost_usd: 0.0571,
+            daily: [{ day: "2026-05-01", cost_usd: 0.0571 }],
+        });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("$0.0571");
+    });
+
+    it("shows 'No cost data' when daily array is empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-costs");
+        apiMock.auditCosts.mockResolvedValueOnce({ total_tokens: 0, total_cost_usd: 0, daily: [] });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("No cost data");
+    });
+
+    it("shows error when api.auditCosts throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-costs");
+        apiMock.auditCosts.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+});
+
+// ── QueryHistoryModal ─────────────────────────────────────────────────────────
+
+describe("QueryHistoryModal", () => {
+    it("calls api.queryHistory with default limit 50 on open", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-queries");
+        apiMock.queryHistory.mockResolvedValueOnce({ records: [] });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.queryHistory).toHaveBeenCalledWith(50);
+    });
+
+    it("shows 'No queries recorded' when empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-queries");
+        apiMock.queryHistory.mockResolvedValueOnce({ records: [] });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("No queries recorded");
+    });
+
+    it("renders question text and cost in the table", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-queries");
+        apiMock.queryHistory.mockResolvedValueOnce({
+            records: [{
+                question: "What is the Bank of Canada rate?",
+                sub_questions_count: 2, tokens: 3200,
+                cost_usd: 0.0038, queried_at: "2026-05-10T14:30:00Z",
+            }],
+        });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("Bank of Canada rate");
+        expect(modal.contentEl.innerHTML).toContain("$0.0038");
+    });
+
+    it("shows error when api.queryHistory throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-audit-queries");
+        apiMock.queryHistory.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("synthadoc serve");
+    });
+});
+
+// ── StagingModal ──────────────────────────────────────────────────────────────
+
+describe("StagingModal", () => {
+    it("calls api.stagingPolicy on open", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-staging");
+        apiMock.stagingPolicy.mockResolvedValueOnce({ policy: "off", confidence_min: null });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.stagingPolicy).toHaveBeenCalled();
+    });
+
+    it("shows 'disabled' in state label when policy is off", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-staging");
+        apiMock.stagingPolicy.mockResolvedValueOnce({ policy: "off", confidence_min: null });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("disabled");
+    });
+
+    it("Save button calls api.stagingSetPolicy", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-staging");
+        apiMock.stagingPolicy.mockResolvedValueOnce({ policy: "off", confidence_min: null });
+        apiMock.stagingSetPolicy.mockResolvedValueOnce({ policy: "off", confidence_min: null });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        // saveBtn is actionRow._children[0]; actionRow is contentEl._children[5]
+        const saveBtn = modal.contentEl._children[5]._children[0];
+        await saveBtn.onclick();
+        await flushPromises();
+
+        expect(apiMock.stagingSetPolicy).toHaveBeenCalled();
+    });
+
+    it("shows success message in resultEl after save", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-staging");
+        apiMock.stagingPolicy.mockResolvedValueOnce({ policy: "off", confidence_min: null });
+        apiMock.stagingSetPolicy.mockResolvedValueOnce({ policy: "off", confidence_min: null });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        const saveBtn = modal.contentEl._children[5]._children[0];
+        await saveBtn.onclick();
+        await flushPromises();
+
+        // resultEl is contentEl._children[6]
+        expect(modal.contentEl._children[6].innerHTML).toContain("Policy updated");
+    });
+
+    it("shows server error when api.stagingPolicy throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-staging");
+        apiMock.stagingPolicy.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("Synthadoc server");
+    });
+});
+
+// ── CandidatesModal ───────────────────────────────────────────────────────────
+
+describe("CandidatesModal", () => {
+    it("calls api.candidates on open", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-candidates");
+        apiMock.candidates.mockResolvedValueOnce([]);
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(apiMock.candidates).toHaveBeenCalled();
+    });
+
+    it("shows 'No candidates' when the list is empty", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-candidates");
+        apiMock.candidates.mockResolvedValueOnce([]);
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("No candidates");
+    });
+
+    it("renders candidate slugs in the table", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-candidates");
+        apiMock.candidates.mockResolvedValueOnce([
+            { slug: "early-internet", title: "Early Internet", confidence: "medium", created: "2026-05-01" },
+        ]);
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("early-internet");
+    });
+
+    it("Promote All calls api.candidatesPromoteAll", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-candidates");
+        apiMock.candidates
+            .mockResolvedValueOnce([{ slug: "early-internet", title: "Early Internet", confidence: "medium", created: "2026-05-01" }])
+            .mockResolvedValueOnce([]);
+        apiMock.candidatesPromoteAll.mockResolvedValueOnce({ count: 1 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        // promoteAllBtn is actionBar._children[0]; actionBar is contentEl._children[2]
+        const promoteAllBtn = modal.contentEl._children[2]._children[0];
+        await promoteAllBtn.onclick();
+        await flushPromises();
+
+        expect(apiMock.candidatesPromoteAll).toHaveBeenCalled();
+    });
+
+    it("Discard All calls api.candidatesDiscardAll", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-candidates");
+        apiMock.candidates
+            .mockResolvedValueOnce([{ slug: "early-internet", title: "Early Internet", confidence: "medium", created: "2026-05-01" }])
+            .mockResolvedValueOnce([]);
+        apiMock.candidatesDiscardAll.mockResolvedValueOnce({ count: 1 });
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        // discardAllBtn is actionBar._children[1]
+        const discardAllBtn = modal.contentEl._children[2]._children[1];
+        await discardAllBtn.onclick();
+        await flushPromises();
+
+        expect(apiMock.candidatesDiscardAll).toHaveBeenCalled();
+    });
+
+    it("shows error when api.candidates throws", async () => {
+        const { ModalClass, apiMock } = await getModal("synthadoc-candidates");
+        apiMock.candidates.mockRejectedValueOnce(new Error("refused"));
+
+        const modal = new ModalClass();
+        modal.onOpen();
+        await flushPromises();
+
+        expect(modal.contentEl.innerHTML).toContain("Synthadoc server");
+    });
+});
+
+// ── SynthadocSettingTab ───────────────────────────────────────────────────────
+
+describe("SynthadocSettingTab", () => {
+    it("display() empties container and creates Synthadoc settings heading", async () => {
+        const { default: SynthadocPlugin } = await import("./main");
+        const plugin = new SynthadocPlugin();
+        await plugin.onload();
+
+        const tab = (plugin.addSettingTab as any).mock.calls[0][0];
+        const createElCalls: { tag: string; opts?: any }[] = [];
+        tab.containerEl = {
+            empty: vi.fn(),
+            createEl: vi.fn((tag: string, opts?: any) => {
+                createElCalls.push({ tag, opts });
+                return { style: {}, setText: vi.fn() };
+            }),
+        };
+        tab.display();
+
+        expect(tab.containerEl.empty).toHaveBeenCalled();
+        expect(tab.containerEl.createEl).toHaveBeenCalledWith("h2", expect.objectContaining({ text: "Synthadoc settings" }));
     });
 });

--- a/obsidian-plugin/vitest.config.ts
+++ b/obsidian-plugin/vitest.config.ts
@@ -12,5 +12,11 @@ export default defineConfig({
     },
     test: {
         environment: "node",
+        coverage: {
+            provider: "v8",
+            include: ["src/**/*.ts"],
+            exclude: ["src/**/*.test.ts"],
+            reporter: ["text", "html"],
+        },
     },
 });

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -282,12 +282,13 @@ class QueryAgent:
                 if _page_on_topic:
                     _pages_with_overlap += 1
 
-            # Signals 4 and 5 share a common guard: if ≥ half the candidates have
-            # dedicated on-topic coverage, the wiki covers the domain well enough
-            # that vocabulary mismatches ("expectation" absent when the wiki says
-            # "assumptions") or shallow references ("moore" mentioned once per page)
-            # should not override the positive signal from signal 3.
-            _signals_45_active = _pages_with_overlap < _n_cands // 2
+            # Signal 4 guard: if ≥ half the candidates have dedicated on-topic
+            # coverage, a term with doc_freq=0 is almost certainly a synonym
+            # mismatch ("backyard" absent when the wiki says "garden") rather than
+            # a genuine absence.  Signal 4 needs this guard; signal 5 does not —
+            # signal 5 only fires for terms with doc_freq > 0 and relies on
+            # guard B (doc_freq cap) as the sole discriminator.
+            _signal4_active = _pages_with_overlap < _n_cands // 2
 
             # Signal 4: a defining concept word is entirely absent from the wiki.
             # When a query has ≥ 2 key terms and at least one appears in zero
@@ -301,41 +302,49 @@ class QueryAgent:
             # are generic corpus words, not topic discriminators — the zero-freq term
             # is a synonym mismatch, not a true gap.
             #
-            # On-topic guard: shared with signal 5 — if coverage is already good
-            # (≥ n_cands//2 pages), vocabulary mismatches in the query do not
-            # indicate a knowledge gap.
+            # On-topic guard: if coverage is already good (≥ n_cands//2 pages),
+            # a doc_freq=0 term is likely a synonym mismatch, not a genuine absence.
             _any_term_missing = (
-                _signals_45_active
+                _signal4_active
                 and bool(_covered)
                 and len(_term_doc_freq) >= 2
                 and any(f == 0 for f in _term_doc_freq.values())
                 and max(_covered.values()) / len(candidates) <= 0.8
             )
 
-            # Signal 5: a genuinely sparse topic term never appears with meaningful
-            # frequency (≥ MIN_TERM_FREQ) in any single candidate page — AND the
-            # overall dedicated coverage is thin (fewer than half the candidates
-            # are on-topic).
-            #
-            # Guard A — on_topic_pages (shared _signals_45_active): see above.
+            # Signal 5: a specific topic term exists in the wiki but never appears
+            # with meaningful frequency (≥ MIN_TERM_FREQ) in any single candidate
+            # page — i.e. only passing references, not dedicated coverage.
             #
             # Guard B — doc_freq cap: a term appearing in ≥ ⌈n_cands/3⌉ candidates
             # is a reference term (present in the domain), not an absent concept.
             # Low doc_freq + qualifying_pages=0 is the fingerprint of a genuine gap.
+            # Guard B alone is sufficient; guard A is intentionally omitted here.
             #
-            # "quantum error correction" (gap): on_topic_pages=2/8 (guard A passes),
-            # "quantum" doc_freq=1–2 < threshold (guard B passes) → gap=True ✓
+            # Why no guard A: when on_topic_pages = n_cands//2 exactly, guard A
+            # would block signal 5 even when min_qualifying=0 for the discriminating
+            # term — this is the bug where half the pages share vocabulary (e.g.
+            # "agent", "judge") while the specific concept ("methodologies") has
+            # zero dedicated coverage.  Guard B catches that case: if the term's
+            # doc_freq is below the threshold it is genuinely absent, not just
+            # phrased differently.
             #
-            # "Moore's Law" in history-of-computing (no gap): on_topic_pages=4/8
-            # ≥ n_cands//2=4 → guard A blocks both signal 4 and signal 5 ✓
+            # "quantum error correction" (gap): "quantum" doc_freq=2 < threshold(3),
+            # qualifying=0 → gap=True ✓
+            #
+            # "Moore's Law" (no gap): "moore" doc_freq=4 ≥ threshold(3) → guard B
+            # blocks → gap=False ✓
+            #
+            # "agent-as-a-judge methodologies" (gap fixed): on_topic_pages=4/8 (was
+            # blocking guard A), "methodologie" doc_freq=1–2 < threshold(3),
+            # qualifying=0 → gap=True ✓
             _min_specific_qualifying = (
                 min(_term_qualifying_pages.values())
                 if _term_qualifying_pages else 0
             )
             _signal5_doc_freq_cap = max(2, (_n_cands + 2) // 3)
             _defining_term_absent = (
-                _signals_45_active
-                and bool(_specific)
+                bool(_specific)
                 and len(_term_doc_freq) >= 2
                 and any(
                     _term_qualifying_pages[t] == 0

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -207,7 +207,6 @@ class Orchestrator:
             await self._queue.fail_permanent(job_id, str(e))
         except Exception as e:
             import httpx
-            import logging
             from synthadoc.errors import (
                 DomainBlockedException, DailyQuotaExhaustedException,
                 CodingToolQuotaExhaustedException,

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -1233,14 +1233,12 @@ async def test_gap_signal5_high_docfreq_reference_term_does_not_fire(tmp_wiki):
 
     'moore' appears in 4 of 8 pages (≥ threshold=3), each time as a single passing
     reference — count("moore")=1 < 2 per page → qualifying_pages("moore")=0.
-    Old signal 5 would fire (min_qualifying=0).  New signal 5 only fires when the
-    zero-qualifying term also has low doc_freq: 4 ≥ threshold(3) → no fire.
+    Signal 5 is blocked by guard B alone: doc_freq=4 ≥ threshold(3) → no fire.
+    (Guard A no longer applies to signal 5; guard B is the sole discriminator.)
 
-    Guard A (on_topic): 4 of 8 pages qualify → _pages_with_overlap=4 == n_cands//2=4,
-    so 4 < 4 is False → signal 5 blocked.  Guard B (doc_freq): "moore" doc_freq=4 ≥
-    threshold(3) → also blocked.  The 4 filler pages contain none of the query's key
-    terms, keeping hardware/design/software at 50% doc_freq (below 80% threshold) so
-    they remain as specific discriminating terms rather than being filtered as generic.
+    The 4 filler pages contain none of the query's key terms, keeping
+    hardware/design/software at 50% doc_freq (below 80% threshold) so they remain
+    as specific discriminating terms rather than being filtered as generic.
     """
     store = WikiStorage(tmp_wiki / "wiki")
     # 4 pages: "moore" appears exactly once (passing reference), but hardware/design/
@@ -1292,6 +1290,152 @@ async def test_gap_signal5_high_docfreq_reference_term_does_not_fire(tmp_wiki):
     # "moore": doc_freq=4 >= threshold(3), qualifying=0 -> signal 5 does NOT fire.
     # hardware/design/software all have qualifying_pages=4 -> signal 3 passes -> no gap.
     assert result.knowledge_gap is False
+
+
+@pytest.mark.asyncio
+async def test_gap_signal5_fires_when_on_topic_pages_equals_half_and_term_low_docfreq(tmp_wiki):
+    """Regression: signal 5 must fire when on_topic_pages = n_cands//2 exactly
+    (old guard A blocked it) and the discriminating term has low doc_freq and
+    qualifying_pages=0.
+
+    Real-world case: 'judge agent methodologies' query against a wiki that covers
+    agent/judge well but never dedicates content to 'methodologies'.
+    8 pages retrieved; 4 are on-topic for 'agent'/'judge' — exactly n_cands//2.
+
+    NOTE: the query must NOT use 'agent-as-a-judge' (hyphenated) because the
+    tokeniser turns the whole phrase into the compound key term 'agent as a judge',
+    which won't match individual words in page content and fires signal 3 instead.
+
+    Old guard A: 4 < 4 = False → blocked signal 5 → gap=False (bug).
+    Fix: guard A removed from signal 5; guard B alone applies.
+    'methodologie' doc_freq=2 < threshold(3) and qualifying=0 → gap=True ✓
+
+    Signal breakdown:
+    - Signal 1: 8 candidates ≥ 3 → no fire
+    - Signal 2: gap_score_threshold=0.01 → no fire
+    - Signal 3: on_topic_pages=4 ≥ 2 → no fire
+    - Signal 4: _signal4_active=False (4<4=False); also no term has doc_freq=0
+    - Signal 5 (fixed): guard A removed; 'methodologie' doc_freq=2 < cap(3),
+      qualifying=0 → gap=True ✓
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+    # 4 pages: 'agent' ≥ 4 times, 'judge' ≥ 3 times; 'methodologie' absent.
+    agent_judge_content = (
+        "An agent evaluates responses by acting as a judge. "
+        "The agent judge assigns numeric scores based on rubrics. "
+        "Agent-based judging provides consistent results. "
+        "The judge agent produces detailed feedback for each agent."
+    )
+    for i in range(4):
+        store.write_page(f"agent-judge-{i}", WikiPage(
+            title=f"Agent Judge {i}", tags=["llm"],
+            content=agent_judge_content,
+            status="active", confidence="high", sources=[],
+        ))
+    # 2 pages: 'methodologies' appears exactly once per page → doc_freq=2, qualifying=0.
+    for i in range(2):
+        store.write_page(f"eval-methods-{i}", WikiPage(
+            title=f"Evaluation Methods {i}", tags=["eval"],
+            content=(
+                "Various methodologies exist for benchmarking AI systems. "
+                "This page covers human review and automated scoring approaches."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+    # 2 filler pages with none of the query's key terms.
+    for i in range(2):
+        store.write_page(f"filler-{i}", WikiPage(
+            title=f"Filler {i}", tags=[],
+            content="The quick brown fox jumps over the lazy dog. Propane grills need cleaning.",
+            status="active", confidence="high", sources=[],
+        ))
+
+    all_slugs = (
+        [f"agent-judge-{i}" for i in range(4)]
+        + [f"eval-methods-{i}" for i in range(2)]
+        + [f"filler-{i}" for i in range(2)]
+    )
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["What are judge agent methodologies?"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text='["agent judge evaluation overview", "llm judge benchmarks"]',
+                           input_tokens=8, output_tokens=8),
+        CompletionResponse(text="No dedicated methodology content found.", input_tokens=80, output_tokens=15),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)
+    with patch.object(agent._search, "bm25_search",
+                      return_value=_fake_results(all_slugs, score=8.0)):
+        result = await agent.query("What are judge agent methodologies?")
+
+    # Before fix: gap=False (guard A blocked signal 5 because 4 < 4 = False).
+    # After fix: gap=True ('methodologie' doc_freq=2 < cap(3), qualifying=0).
+    assert result.knowledge_gap is True
+    assert len(result.suggested_searches) >= 1
+
+
+@pytest.mark.asyncio
+async def test_gap_signal5_guard_b_still_blocks_high_docfreq_without_guard_a(tmp_wiki):
+    """Guard B must still prevent signal 5 when the discriminating term is a
+    domain reference term (doc_freq ≥ threshold) even though guard A is removed.
+
+    Same scenario as the regression test above, but 'methodologies' now appears
+    in 4 of 8 pages (each mentioning it exactly once) → doc_freq=4 ≥ threshold(3).
+    qualifying_pages=0 (never ≥ 2 in any page), so without guard B signal 5 would
+    fire.  Guard B blocks it: 4 ≥ cap(3) → no gap.
+
+    Signal breakdown:
+    - Signal 3: on_topic_pages=4 ≥ 2 → no fire
+    - Signal 5: 'methodologie' qualifying=0 BUT doc_freq=4 ≥ cap(3) → guard B
+      blocks → no fire → gap=False ✓
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+    # 4 pages: 'agent' ≥ 4 times, 'judge' ≥ 3 times; 'methodologie' absent.
+    agent_judge_content = (
+        "An agent evaluates responses by acting as a judge. "
+        "The agent judge assigns numeric scores based on rubrics. "
+        "Agent-based judging provides consistent results. "
+        "The judge agent produces detailed feedback for each agent."
+    )
+    for i in range(4):
+        store.write_page(f"agent-judge2-{i}", WikiPage(
+            title=f"Agent Judge {i}", tags=["llm"],
+            content=agent_judge_content,
+            status="active", confidence="high", sources=[],
+        ))
+    # 4 pages: 'methodologies' appears exactly once each → doc_freq=4 ≥ cap(3).
+    for i in range(4):
+        store.write_page(f"eval-ref-{i}", WikiPage(
+            title=f"Eval Reference {i}", tags=["eval"],
+            content=(
+                "Various methodologies exist for benchmarking AI systems. "
+                "This page covers human review and automated scoring approaches."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+
+    all_slugs = (
+        [f"agent-judge2-{i}" for i in range(4)]
+        + [f"eval-ref-{i}" for i in range(4)]
+    )
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["What are judge agent methodologies?"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text="Agent judge evaluation overview.", input_tokens=80, output_tokens=15),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)
+    with patch.object(agent._search, "bm25_search",
+                      return_value=_fake_results(all_slugs, score=8.0)):
+        result = await agent.query("What are judge agent methodologies?")
+
+    # 'methodologie' doc_freq=4 ≥ cap(3) → guard B blocks signal 5 → no gap.
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []
 
 
 # ── CJK (Chinese / Japanese / Korean) coverage ───────────────────────────────

--- a/tests/cli/test_candidates_cli.py
+++ b/tests/cli/test_candidates_cli.py
@@ -93,3 +93,111 @@ def test_candidates_promote_creates_recently_added_section(tmp_path):
     index = (w / "wiki" / "index.md").read_text(encoding="utf-8")
     assert "## Recently Added" in index
     assert "[[new-page]]" in index
+
+
+# ── _toml_value() ────────────────────────────────────────────────────────────
+
+def test_toml_value_bool_true():
+    from synthadoc.cli.candidates import _toml_value
+    assert _toml_value(True) == "true"
+
+
+def test_toml_value_bool_false():
+    from synthadoc.cli.candidates import _toml_value
+    assert _toml_value(False) == "false"
+
+
+def test_toml_value_int():
+    from synthadoc.cli.candidates import _toml_value
+    assert _toml_value(42) == "42"
+
+
+def test_toml_value_dict():
+    from synthadoc.cli.candidates import _toml_value
+    result = _toml_value({"a": 1, "b": "x"})
+    assert result == '{a = 1, b = "x"}'
+
+
+def test_toml_value_list():
+    from synthadoc.cli.candidates import _toml_value
+    result = _toml_value([1, "two"])
+    assert result == '[1, "two"]'
+
+
+# ── _patch_toml() ────────────────────────────────────────────────────────────
+
+def test_patch_toml_creates_new_section(tmp_path):
+    from synthadoc.cli.candidates import _patch_toml
+    cfg = tmp_path / "config.toml"
+    cfg.write_text("[other]\nfoo = 1\n", encoding="utf-8")
+    _patch_toml(cfg, "ingest", {"staging_policy": "all"})
+    content = cfg.read_text()
+    assert "[ingest]" in content
+    assert 'staging_policy = "all"' in content
+
+
+def test_patch_toml_updates_existing_key(tmp_path):
+    from synthadoc.cli.candidates import _patch_toml
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[ingest]\nstaging_policy = "off"\n', encoding="utf-8")
+    _patch_toml(cfg, "ingest", {"staging_policy": "all"})
+    content = cfg.read_text()
+    assert 'staging_policy = "all"' in content
+    assert content.count("staging_policy") == 1
+
+
+def test_patch_toml_section_at_end_of_file(tmp_path):
+    from synthadoc.cli.candidates import _patch_toml
+    cfg = tmp_path / "config.toml"
+    cfg.write_text('[other]\nfoo = 1\n\n[ingest]\nstaging_policy = "off"', encoding="utf-8")
+    _patch_toml(cfg, "ingest", {"staging_policy": "threshold"})
+    content = cfg.read_text()
+    assert 'staging_policy = "threshold"' in content
+
+
+# ── --all flag ────────────────────────────────────────────────────────────────
+
+def test_candidates_promote_all(tmp_path):
+    """promote --all promotes every candidate in the directory."""
+    w = _make_wiki_with_candidate(tmp_path)
+    (w / "wiki" / "candidates" / "another-page.md").write_text(
+        "---\ntitle: Another\nconfidence: high\ncreated: '2026-05-05'\ntags: []\nstatus: active\nsources: []\n---\nContent."
+    )
+    (w / "wiki").mkdir(exist_ok=True)
+    result = runner.invoke(app, ["candidates", "promote", "--all", "--wiki", str(w)])
+    assert result.exit_code == 0, result.output
+    assert (w / "wiki" / "new-page.md").exists()
+    assert (w / "wiki" / "another-page.md").exists()
+
+
+def test_candidates_discard_all(tmp_path):
+    """discard --all removes every candidate in the directory."""
+    w = _make_wiki_with_candidate(tmp_path)
+    (w / "wiki" / "candidates" / "another-page.md").write_text("# Another\n")
+    result = runner.invoke(app, ["candidates", "discard", "--all", "--wiki", str(w)])
+    assert result.exit_code == 0, result.output
+    assert not (w / "wiki" / "candidates" / "new-page.md").exists()
+    assert not (w / "wiki" / "candidates" / "another-page.md").exists()
+
+
+def test_candidates_promote_shows_updated_when_page_exists(tmp_path):
+    """Promoting over an existing wiki page shows 'Updated', not 'Promoted'."""
+    w = _make_wiki_with_candidate(tmp_path)
+    (w / "wiki").mkdir(exist_ok=True)
+    (w / "wiki" / "new-page.md").write_text("# Existing version\n", encoding="utf-8")
+    result = runner.invoke(app, ["candidates", "promote", "new-page", "--wiki", str(w)])
+    assert result.exit_code == 0, result.output
+    assert "Updated" in result.output
+
+
+def test_staging_policy_show_threshold_displays_min_confidence(tmp_path):
+    """staging policy show with threshold policy also shows min_confidence."""
+    w = _make_wiki_with_candidate(tmp_path)
+    (w / ".synthadoc" / "config.toml").write_text(
+        '[ingest]\nstaging_policy = "threshold"\nstaging_confidence_min = "high"\n',
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["staging", "policy", "--wiki", str(w)])
+    assert result.exit_code == 0, result.output
+    assert "threshold" in result.output
+    assert "high" in result.output

--- a/tests/cli/test_context_cli.py
+++ b/tests/cli/test_context_cli.py
@@ -27,3 +27,34 @@ def test_context_build_output_to_file(tmp_path):
         assert result.exit_code == 0, result.output
         assert out.exists()
         assert "Context Pack" in out.read_text()
+
+
+def test_context_build_with_wiki_flag(tmp_path):
+    """context build --wiki (no --wiki-root) resolves wiki by name."""
+    with patch("synthadoc.cli.context._build_context_pack") as mock_build:
+        mock_build.return_value = "# Pack\n"
+        result = runner.invoke(app, [
+            "context", "build", "topic", "--wiki", str(tmp_path),
+        ])
+    assert result.exit_code == 0, result.output
+    mock_build.assert_called_once_with(str(tmp_path), "topic", 4000)
+
+
+def test_build_context_pack_constructs_pages(tmp_path):
+    """_build_context_pack assembles ContextPack from server response and returns Markdown."""
+    from synthadoc.cli.context import _build_context_pack
+    mock_response = {
+        "goal": "early computing",
+        "token_budget": 4000,
+        "tokens_used": 150,
+        "pages": [{
+            "slug": "eniac", "relevance": 0.9, "excerpt": "first computer",
+            "source": "source.md", "confidence": "high", "tags": [],
+            "estimated_tokens": 100,
+        }],
+        "omitted": [{"slug": "babbage", "estimated_tokens": 200}],
+    }
+    with patch("synthadoc.cli._http.post", return_value=mock_response):
+        result = _build_context_pack(str(tmp_path), "early computing", 4000)
+    assert "early computing" in result
+    assert "eniac" in result

--- a/tests/cli/test_http_helpers.py
+++ b/tests/cli/test_http_helpers.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+import httpx
+import pytest
+from unittest.mock import MagicMock, patch
+
+import typer
+
+
+def _make_status_error(status: int, method: str, url: str) -> httpx.HTTPStatusError:
+    req = httpx.Request(method, url)
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json.return_value = {"detail": f"HTTP {status}"}
+    resp.text = f"HTTP {status}"
+    return httpx.HTTPStatusError(str(status), request=req, response=resp)
+
+
+# ── _detail() ────────────────────────────────────────────────────────────────
+
+def test_detail_extracts_json_detail():
+    from synthadoc.cli._http import _detail
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.return_value = {"detail": "Page not found"}
+    assert _detail(resp) == "Page not found"
+
+
+def test_detail_falls_back_to_text():
+    from synthadoc.cli._http import _detail
+    resp = MagicMock(spec=httpx.Response)
+    resp.json.side_effect = ValueError("not JSON")
+    resp.text = "  internal server error  "
+    assert _detail(resp) == "internal server error"
+
+
+# ── _timeout_error() ─────────────────────────────────────────────────────────
+
+def test_timeout_error_query_path_exits():
+    from synthadoc.cli._http import _timeout_error
+    with pytest.raises(typer.Exit):
+        _timeout_error("/query", 60)
+
+
+def test_timeout_error_jobs_path_exits():
+    from synthadoc.cli._http import _timeout_error
+    with pytest.raises(typer.Exit):
+        _timeout_error("/jobs/123", 10)
+
+
+def test_timeout_error_other_path_exits():
+    from synthadoc.cli._http import _timeout_error
+    with pytest.raises(typer.Exit):
+        _timeout_error("/status", 30)
+
+
+# ── get() ────────────────────────────────────────────────────────────────────
+
+def test_get_connect_error_exits():
+    from synthadoc.cli._http import get
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "get", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(typer.Exit):
+            get("my-wiki", "/status")
+
+
+def test_get_read_timeout_exits():
+    from synthadoc.cli._http import get
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "get", side_effect=httpx.ReadTimeout("timeout")):
+        with pytest.raises(typer.Exit):
+            get("my-wiki", "/query")
+
+
+def test_get_http_status_error_exits():
+    from synthadoc.cli._http import get
+    err = _make_status_error(500, "GET", "http://127.0.0.1:7070/status")
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "get", side_effect=err):
+        with pytest.raises(typer.Exit):
+            get("my-wiki", "/status")
+
+
+# ── post() ───────────────────────────────────────────────────────────────────
+
+def test_post_connect_error_exits():
+    from synthadoc.cli._http import post
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "post", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(typer.Exit):
+            post("my-wiki", "/ingest", {})
+
+
+def test_post_read_timeout_exits():
+    from synthadoc.cli._http import post
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "post", side_effect=httpx.ReadTimeout("timeout")):
+        with pytest.raises(typer.Exit):
+            post("my-wiki", "/jobs/cancel", {})
+
+
+def test_post_http_status_error_exits():
+    from synthadoc.cli._http import post
+    err = _make_status_error(422, "POST", "http://127.0.0.1:7070/ingest")
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "post", side_effect=err):
+        with pytest.raises(typer.Exit):
+            post("my-wiki", "/ingest", {"source": "x"})
+
+
+# ── delete() ─────────────────────────────────────────────────────────────────
+
+def test_delete_connect_error_exits():
+    from synthadoc.cli._http import delete
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "delete", side_effect=httpx.ConnectError("refused")):
+        with pytest.raises(typer.Exit):
+            delete("my-wiki", "/jobs/abc")
+
+
+def test_delete_http_status_error_exits():
+    from synthadoc.cli._http import delete
+    err = _make_status_error(404, "DELETE", "http://127.0.0.1:7070/jobs/abc")
+    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+         patch.object(httpx, "delete", side_effect=err):
+        with pytest.raises(typer.Exit):
+            delete("my-wiki", "/jobs/abc")

--- a/tests/cli/test_jobs_cli.py
+++ b/tests/cli/test_jobs_cli.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+from pathlib import Path
+from unittest.mock import patch
+from typer.testing import CliRunner
+from synthadoc.cli.main import app
+
+runner = CliRunner()
+
+
+def test_jobs_list_empty(tmp_path):
+    with patch("synthadoc.cli.jobs.get", return_value=[]):
+        result = runner.invoke(app, ["jobs", "list", "--wiki", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "No jobs" in result.output
+
+
+def test_jobs_list_shows_entries(tmp_path):
+    mock_jobs = [
+        {"id": "job-001", "status": "pending", "operation": "ingest",
+         "created_at": "2026-05-17 10:00:00"},
+    ]
+    with patch("synthadoc.cli.jobs.get", return_value=mock_jobs):
+        result = runner.invoke(app, ["jobs", "list", "--wiki", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "job-001" in result.output
+
+
+def test_jobs_status_shows_result_fields(tmp_path):
+    """jobs status displays all optional result fields when present."""
+    mock_job = {
+        "id": "job-001", "status": "completed", "operation": "ingest",
+        "created_at": "2026-05-17 10:00:00", "error": None,
+        "result": {
+            "pages_created": ["page-1"],
+            "pages_updated": ["page-2"],
+            "pages_flagged": ["page-3"],
+            "skip_reason": "out of scope",
+            "tokens_used": 500,
+        },
+    }
+    with patch("synthadoc.cli.jobs.get", return_value=mock_job):
+        result = runner.invoke(app, ["jobs", "status", "job-001", "--wiki", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "page-1" in result.output
+    assert "page-2" in result.output
+    assert "page-3" in result.output
+    assert "out of scope" in result.output
+    assert "500" in result.output
+
+
+def test_jobs_cancel_with_yes_skips_confirmation(tmp_path):
+    """jobs cancel --yes bypasses confirmation and reports cancelled count."""
+    with patch("synthadoc.cli._http.post", return_value={"cancelled": 3}):
+        result = runner.invoke(app, ["jobs", "cancel", "--yes", "--wiki", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "3" in result.output

--- a/tests/cli/test_scaffold_cli.py
+++ b/tests/cli/test_scaffold_cli.py
@@ -114,3 +114,62 @@ def test_scaffold_exits_when_scaffold_fails(tmp_path):
         result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
 
     assert result.exit_code != 0
+
+
+def test_scaffold_missing_wiki_dir_exits(tmp_path):
+    """scaffold exits non-zero when the wiki directory does not exist."""
+    nonexistent = tmp_path / "no-such-wiki"
+    result = runner.invoke(app, ["scaffold", "--wiki", str(nonexistent)])
+    assert result.exit_code != 0
+
+
+def test_scaffold_missing_config_exits(tmp_path):
+    """scaffold exits non-zero when config.toml is absent."""
+    wiki_dir = tmp_path / "bare-wiki"
+    (wiki_dir / "wiki").mkdir(parents=True)
+    result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
+    assert result.exit_code != 0
+
+
+def test_protected_slugs_returns_linked_existing_pages(tmp_path):
+    """_protected_slugs includes slugs that are both linked from index.md and have a wiki file."""
+    from synthadoc.cli.scaffold import _protected_slugs
+    (tmp_path / "wiki").mkdir()
+    (tmp_path / "wiki" / "index.md").write_text(
+        "# Index\n\n[[neural-networks]] and [[robotics]]\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "wiki" / "neural-networks.md").write_text("# NN\n", encoding="utf-8")
+    # robotics.md does not exist — must not be included
+    slugs = _protected_slugs(tmp_path)
+    assert "neural-networks" in slugs
+    assert "robotics" not in slugs
+
+
+def test_protected_slugs_empty_when_no_index(tmp_path):
+    """_protected_slugs returns [] when index.md is absent."""
+    from synthadoc.cli.scaffold import _protected_slugs
+    (tmp_path / "wiki").mkdir()
+    slugs = _protected_slugs(tmp_path)
+    assert slugs == []
+
+
+def test_apply_categories_stamps_headings_on_pages(tmp_path):
+    """_apply_categories reads H2 headings from index.md and stamps categories on linked pages."""
+    from synthadoc.cli.scaffold import _apply_categories
+    from synthadoc.storage.wiki import WikiStorage
+
+    wiki_dir = tmp_path / "wiki"
+    wiki_dir.mkdir()
+    (wiki_dir / "neural-networks.md").write_text(
+        "---\ntitle: Neural Networks\ntags: []\nstatus: active\n"
+        "confidence: high\ncreated: '2026-01-01'\nsources: []\n---\nContent.",
+        encoding="utf-8",
+    )
+    index_md = "# Index\n\n## Key Concepts\n- [[neural-networks]]\n"
+    updated = _apply_categories(tmp_path, index_md)
+    assert updated >= 1
+    store = WikiStorage(wiki_dir)
+    page = store.read_page("neural-networks")
+    assert page is not None
+    assert "Key Concepts" in (page.categories or [])

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+from synthadoc.cli.main import app
+
+runner = CliRunner()
+
+
+def _make_wiki(tmp_path: Path) -> Path:
+    (tmp_path / ".synthadoc").mkdir(exist_ok=True)
+    (tmp_path / ".synthadoc" / "config.toml").write_text(
+        '[wiki]\ndomain = "Test"\n[server]\nport = 7070\n[schedule]\njobs = []\n',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_schedule_add_uninstalled_wiki_exits(tmp_path):
+    """schedule add without config.toml exits non-zero."""
+    result = runner.invoke(app, [
+        "schedule", "add", "--op", "lint", "--cron", "0 * * * *",
+        "--wiki", str(tmp_path),
+    ])
+    assert result.exit_code != 0
+
+
+def test_schedule_add_calls_scheduler(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    mock_sched = MagicMock()
+    mock_sched.add.return_value = "sched-001"
+    with patch("synthadoc.core.scheduler.Scheduler", return_value=mock_sched):
+        result = runner.invoke(app, [
+            "schedule", "add", "--op", "lint", "--cron", "0 * * * *",
+            "--wiki", str(wiki),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "sched-001" in result.output
+    mock_sched.add.assert_called_once()
+
+
+def test_schedule_list_shows_entries(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    entry = MagicMock()
+    entry.id = "sched-001"
+    entry.cron = "0 * * * *"
+    entry.op = "lint"
+    mock_sched = MagicMock()
+    mock_sched.list.return_value = [entry]
+    with patch("synthadoc.core.scheduler.Scheduler", return_value=mock_sched):
+        result = runner.invoke(app, ["schedule", "list", "--wiki", str(wiki)])
+    assert result.exit_code == 0, result.output
+    assert "sched-001" in result.output
+    assert "lint" in result.output
+
+
+def test_schedule_list_empty(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    mock_sched = MagicMock()
+    mock_sched.list.return_value = []
+    with patch("synthadoc.core.scheduler.Scheduler", return_value=mock_sched):
+        result = runner.invoke(app, ["schedule", "list", "--wiki", str(wiki)])
+    assert result.exit_code == 0, result.output
+
+
+def test_schedule_remove_calls_scheduler(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    mock_sched = MagicMock()
+    with patch("synthadoc.core.scheduler.Scheduler", return_value=mock_sched):
+        result = runner.invoke(app, [
+            "schedule", "remove", "sched-001", "--wiki", str(wiki),
+        ])
+    assert result.exit_code == 0, result.output
+    assert "sched-001" in result.output
+    mock_sched.remove.assert_called_once_with("sched-001")
+
+
+def test_schedule_apply_registers_jobs(tmp_path):
+    wiki = _make_wiki(tmp_path)
+    (wiki / ".synthadoc" / "config.toml").write_text(
+        '[wiki]\ndomain = "Test"\n[server]\nport = 7070\n'
+        '[[schedule.jobs]]\nop = "lint"\ncron = "0 0 * * *"\n',
+        encoding="utf-8",
+    )
+    mock_sched = MagicMock()
+    mock_sched.apply.return_value = ["sched-002"]
+    with patch("synthadoc.core.scheduler.Scheduler", return_value=mock_sched):
+        result = runner.invoke(app, ["schedule", "apply", "--wiki", str(wiki)])
+    assert result.exit_code == 0, result.output
+    assert "sched-002" in result.output

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -174,6 +174,117 @@ async def test_vector_migration_skips_already_embedded(tmp_wiki):
 
 
 @pytest.mark.asyncio
+async def test_run_ingest_domain_blocked_skips_job(tmp_wiki):
+    """DomainBlockedException must skip the job without retrying."""
+    from synthadoc.errors import DomainBlockedException
+
+    orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
+    await orch.init()
+    job_id = await orch._queue.enqueue("ingest", {"source": "https://blocked.com/page", "force": False})
+
+    exc = DomainBlockedException(domain="blocked.com", url="https://blocked.com/page", status_code=403)
+    mock_agent = MagicMock()
+    mock_agent.ingest = AsyncMock(side_effect=exc)
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+        await orch._run_ingest(job_id, "https://blocked.com/page", auto_confirm=True)
+
+    from synthadoc.core.queue import JobStatus
+    skipped = await orch._queue.list_jobs(status=JobStatus.SKIPPED)
+    assert any(j.id == job_id for j in skipped)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_daily_quota_exhausted_fails_permanent(tmp_wiki):
+    """DailyQuotaExhaustedException must permanently fail the job (no retry)."""
+    from synthadoc.errors import DailyQuotaExhaustedException
+
+    orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
+    await orch.init()
+    job_id = await orch._queue.enqueue("ingest", {"source": "https://example.com", "force": False})
+
+    exc = DailyQuotaExhaustedException(provider="anthropic")
+    mock_agent = MagicMock()
+    mock_agent.ingest = AsyncMock(side_effect=exc)
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+        await orch._run_ingest(job_id, "https://example.com", auto_confirm=True)
+
+    from synthadoc.core.queue import JobStatus
+    failed = await orch._queue.list_jobs(status=JobStatus.FAILED)
+    assert any(j.id == job_id for j in failed)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_coding_tool_quota_fails_permanent(tmp_wiki):
+    """CodingToolQuotaExhaustedException must permanently fail the job."""
+    from synthadoc.errors import CodingToolQuotaExhaustedException
+
+    orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
+    await orch.init()
+    job_id = await orch._queue.enqueue("ingest", {"source": "https://example.com", "force": False})
+
+    exc = CodingToolQuotaExhaustedException("claude-code")
+    mock_agent = MagicMock()
+    mock_agent.ingest = AsyncMock(side_effect=exc)
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+        await orch._run_ingest(job_id, "https://example.com", auto_confirm=True)
+
+    from synthadoc.core.queue import JobStatus
+    failed = await orch._queue.list_jobs(status=JobStatus.FAILED)
+    assert any(j.id == job_id for j in failed)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_connect_error_retries_job(tmp_wiki):
+    """httpx.ConnectError must re-queue the job for retry (PENDING)."""
+    orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
+    await orch.init()
+    job_id = await orch._queue.enqueue("ingest", {"source": "https://unreachable.com", "force": False})
+
+    mock_agent = MagicMock()
+    mock_agent.ingest = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+        await orch._run_ingest(job_id, "https://unreachable.com", auto_confirm=True)
+
+    from synthadoc.core.queue import JobStatus
+    pending = await orch._queue.list_jobs(status=JobStatus.PENDING)
+    assert any(j.id == job_id for j in pending)
+
+
+@pytest.mark.asyncio
+async def test_run_ingest_environment_error_fails_permanent(tmp_wiki):
+    """EnvironmentError (missing provider binary) must permanently fail the job."""
+    orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
+    await orch.init()
+    job_id = await orch._queue.enqueue("ingest", {"source": "file.pdf", "force": False})
+
+    mock_agent = MagicMock()
+    mock_agent.ingest = AsyncMock(side_effect=EnvironmentError("binary not found"))
+    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+        await orch._run_ingest(job_id, "file.pdf", auto_confirm=True)
+
+    from synthadoc.core.queue import JobStatus
+    failed = await orch._queue.list_jobs(status=JobStatus.FAILED)
+    assert any(j.id == job_id for j in failed)
+
+
+@pytest.mark.asyncio
+async def test_resume_returns_job_count(tmp_wiki):
+    """resume() must re-queue all pending jobs and return the count."""
+    orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
+    await orch.init()
+    await orch._queue.enqueue("ingest", {"source": "file1.md", "force": False})
+    await orch._queue.enqueue("ingest", {"source": "file2.md", "force": False})
+
+    count = await orch.resume()
+    assert count >= 2
+
+
+@pytest.mark.asyncio
 async def test_vector_migration_noop_when_vector_disabled(tmp_wiki):
     """_run_vector_migration must be a no-op when search.vector=False."""
     from unittest.mock import patch

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -39,3 +39,51 @@ async def test_mcp_ingest_tool_returns_job_id(tmp_wiki):
             "synthadoc_ingest", {"source": "paper.pdf"}, convert_result=False
         )
     assert result["job_id"] == "job-xyz"
+
+
+@pytest.mark.asyncio
+async def test_mcp_lint_tool_returns_result(tmp_wiki):
+    from unittest.mock import MagicMock
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(wiki_root=tmp_wiki)
+    mock_report = MagicMock()
+    mock_report.contradictions_found = 2
+    mock_report.orphan_slugs = ["orphan-page"]
+    with patch("synthadoc.core.orchestrator.Orchestrator.lint",
+               new=AsyncMock(return_value=mock_report)):
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_lint", {"scope": "all"}, convert_result=False
+        )
+    assert result["contradictions_found"] == 2
+    assert "orphan-page" in result["orphans"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_tool_returns_results(tmp_wiki):
+    from unittest.mock import MagicMock
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(wiki_root=tmp_wiki)
+    mock_hit = MagicMock()
+    mock_hit.slug = "test-page"
+    mock_hit.score = 0.9
+    mock_hit.title = "Test Page"
+    mock_hit.snippet = "test excerpt"
+    with patch("synthadoc.storage.search.HybridSearch.bm25_search",
+               return_value=[mock_hit]):
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_search", {"terms": "test query"}, convert_result=False
+        )
+    assert len(result["results"]) == 1
+    assert result["results"][0]["slug"] == "test-page"
+
+
+@pytest.mark.asyncio
+async def test_mcp_status_tool_returns_page_count(tmp_wiki):
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(wiki_root=tmp_wiki)
+    with patch("synthadoc.storage.wiki.WikiStorage.list_pages",
+               return_value=["page-1", "page-2"]):
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_status", {}, convert_result=False
+        )
+    assert result["pages"] == 2


### PR DESCRIPTION
What

Fix signal 5 of the knowledge gap detector incorrectly returning gap=False when the retrieved page count is exactly at the on-topic guard boundary.

Why

When a query like "agent-as-a-judge methodologies" returned 8 pages: 4 covering agent/judge vocabulary and 4 tangentially related - the old guard (on_topic_pages < n_cands//2, i.e. 4 < 4) evaluated to False, blocking signal 5 entirely. Even with min_qualifying=0 for the discriminating term ('methodologie'), the gap was not detected and the plugin showed no "Knowledge Gap" callout or web search suggestions.

The root cause: signals 4 and 5 shared a common on-topic guard designed to prevent false positives, but signal 5 has its own doc-freq cap (guard B) that is a sufficient discriminator on its own. Guard A was redundant for signal 5 and caused silent misses at the exact boundary.

Changes

- synthadoc/agents/query_agent.py: removed _signals_45_active from _defining_term_absent (signal 5); renamed the shared _signals_45_active to  _signal4_active since signal 4 still needs it; updated comments to explain why the two signals now use different guards.
- tests/agents/test_query_agent.py — added two regression tests.
- test_gap_signal5_fires_when_on_topic_pages_equals_half_and_term_low_docfreq: proves signal 5 fires at the bug boundary (doc_freq < cap, qualifying=0, on_topic=n_cands//2).
- test_gap_signal5_guard_b_still_blocks_high_docfreq_without_guard_a: proves guard B still suppresses false gaps when the discriminating term is a domain reference (doc_freq ≥ cap).
- Updated comment on test_gap_signal5_high_docfreq_reference_term_does_not_fire to reflect that guard B alone now blocks it.