### PR TITLE
Code refactor: Pylance type warnings, background PID mismatch, and batch ingest…

### DIFF
--- a/synthadoc/agents/lint_agent.py
+++ b/synthadoc/agents/lint_agent.py
@@ -303,7 +303,7 @@ class LintAgent:
                 loop = asyncio.get_event_loop()
                 await loop.run_in_executor(
                     None,
-                    lambda: YouTubeTranscriptApi.get_transcript(m.group(1))
+                    lambda: YouTubeTranscriptApi.get_transcript(m.group(1))  # type: ignore[attr-defined]
                 )
                 _log.debug("lifecycle url-check [youtube] unavailable=%s url=%s", False, url)
                 return False

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from synthadoc.agents._utils import parse_json_string_array
 from synthadoc.agents.search_decompose_agent import SearchDecomposeAgent
 from synthadoc.providers.base import LLMProvider, Message
-from synthadoc.storage.search import HybridSearch
+from synthadoc.storage.search import HybridSearch, SearchResult
 from synthadoc.storage.wiki import WikiStorage
 
 logger = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ class QueryAgent:
 
         results_per_sub = await asyncio.gather(*[_search_one(q) for q in sub_questions])
 
-        best: dict[str, object] = {}
+        best: dict[str, SearchResult] = {}
         for results in results_per_sub:
             for r in results:
                 if r.slug not in best or r.score > best[r.slug].score:

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -33,7 +33,7 @@ _GLOBAL_SKILLS_DIR = Path.home() / ".synthadoc" / "skills"
 
 
 class SkillNotFoundError(Exception):
-    def __init__(self, source: str, available: list[str] = None):
+    def __init__(self, source: str, available: list[str] | None = None):
         msg = f"[ERR-SKILL-001] No skill matched: {source!r}."
         if available:
             msg += f" Available: {', '.join(sorted(available))}"
@@ -62,6 +62,8 @@ def _skill_dirs_in(base: Optional[Path]) -> list[Path]:
 
 def _import_class(script: Path, class_name: str) -> type:
     spec = importlib.util.spec_from_file_location(script.stem, script)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load spec for {script}")
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     cls = getattr(mod, class_name, None)
@@ -160,6 +162,8 @@ class SkillAgent:
             raise SkillNotFoundError(name, list(self._registry.keys()))
         if name not in self._loaded:
             meta = self._registry[name]
+            if meta.skill_dir is None:
+                raise ImportError(f"Skill '{name}' has no skill_dir set")
             self._check_requires(meta)
             cls = _import_class(meta.skill_dir / meta.entry_script, meta.entry_class)
             self._loaded[name] = cls

--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import httpx
 import typer
+from typing import NoReturn
 
 from synthadoc.config import load_config
 from synthadoc.cli.install import resolve_wiki_path
@@ -70,7 +71,7 @@ def delete(wiki: str, path: str) -> dict:
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
-def _timeout_error(path: str, timeout: int) -> None:
+def _timeout_error(path: str, timeout: int) -> NoReturn:
     if "/query" in path:
         E.cli_error(
             E.QUERY_TIMEOUT,
@@ -101,7 +102,7 @@ def _detail(response: httpx.Response) -> str:
         return response.text.strip()
 
 
-def _no_server(wiki: str) -> None:
+def _no_server(wiki: str) -> NoReturn:
     E.cli_error(
         E.SRV_NOT_RUNNING,
         f"No synthadoc server is running for wiki '{wiki}'.",

--- a/synthadoc/cli/context.py
+++ b/synthadoc/cli/context.py
@@ -13,10 +13,10 @@ context_app = typer.Typer(name="context", help="Build token-bounded evidence pac
 app.add_typer(context_app)
 
 
-def _build_context_pack(wiki_or_root: str, goal: str, tokens: int) -> str:
+def _build_context_pack(wiki_or_root: Path | str, goal: str, tokens: int) -> str:
     """Call server POST /context/build and return Markdown string."""
     from synthadoc.cli._http import post
-    result = post(wiki_or_root, "/context/build", {"goal": goal, "token_budget": tokens})
+    result = post(str(wiki_or_root), "/context/build", {"goal": goal, "token_budget": tokens})
     from synthadoc.agents.context_agent import ContextPack, ContextPage
     pages = [
         ContextPage(
@@ -56,13 +56,12 @@ def context_build(
 ) -> None:
     """Build a token-bounded, cited evidence pack from the wiki."""
     wiki_root_path = Path(wiki_root) if wiki_root else None
-    if not wiki_root_path:
-        from synthadoc.cli._wiki import resolve_wiki
-        wiki_name = wiki or resolve_wiki(None)
+    if wiki_root_path is not None:
+        markdown = _build_context_pack(wiki_root_path, goal, tokens)
     else:
-        wiki_name = wiki
-
-    markdown = _build_context_pack(wiki_root_path or wiki_name, goal, tokens)
+        from synthadoc.cli._wiki import resolve_wiki
+        resolved_wiki: str = wiki or resolve_wiki(None)
+        markdown = _build_context_pack(resolved_wiki, goal, tokens)
 
     if output:
         Path(output).write_text(markdown, encoding="utf-8")

--- a/synthadoc/cli/logo.py
+++ b/synthadoc/cli/logo.py
@@ -69,6 +69,7 @@ def print_banner(
     provider: str = "",
     model: str = "",
     llm_note: str = "",
+    pid: int | None = None,
 ) -> None:
     """Print the startup banner to stdout."""
     use_color = _color_supported()
@@ -86,7 +87,7 @@ def print_banner(
         _c(_WHITE,          f"  Port:  {port}", use_color),
         _c(_WHITE,          f"  Wiki:  {Path(wiki).name}", use_color),
         _c(_WHITE,          f"  LLM:   {llm_label}", use_color),
-        _c(_WHITE,          f"  PID:   {os.getpid()}", use_color),
+        _c(_WHITE,          f"  PID:   {pid if pid is not None else os.getpid()}", use_color),
         "",
         _c(_DIM,            f"  http://127.0.0.1:{port}", use_color),
     ]

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -152,11 +152,13 @@ def _check_network(provider: str) -> None:
         )
 
 
-def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path) -> None:
+def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path,
+                       banner_kwargs: dict | None = None) -> None:
     """Detach the server as a background process and return to the shell."""
     # Strip --background / -b from the forwarded args.
     server_args = [a for a in sys.argv[1:] if a not in ("--background", "-b")]
 
+    shared_env = {**os.environ, _NO_BANNER_ENV: "1"}
     if sys.platform == "win32":
         # pythonw.exe runs Python with no console window at all — the child
         # process has zero console association, so the parent's CMD/PowerShell
@@ -164,30 +166,32 @@ def _spawn_background(wiki_root: Path, effective_port: int, log_path: Path) -> N
         pythonw = Path(sys.executable).with_name("pythonw.exe")
         interpreter = str(pythonw) if pythonw.exists() else sys.executable
         cmd = [interpreter, "-m", "synthadoc"] + server_args
-        popen_kwargs: dict = dict(
-            args=cmd,
+        proc = subprocess.Popen(
+            cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
-            env={**os.environ, _NO_BANNER_ENV: "1"},
+            env=shared_env,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
         )
     else:
         cmd = [sys.argv[0]] + server_args
-        popen_kwargs = dict(
-            args=cmd,
+        proc = subprocess.Popen(
+            cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
-            env={**os.environ, _NO_BANNER_ENV: "1"},
+            env=shared_env,
             start_new_session=True,
         )
-
-    proc = subprocess.Popen(**popen_kwargs)
 
     # Persist PID so the user (or a stop command) can terminate the server.
     pid_path = wiki_root / ".synthadoc" / "server.pid"
     pid_path.write_text(str(proc.pid), encoding="utf-8")
+
+    if banner_kwargs is not None:
+        from synthadoc.cli.logo import print_banner
+        print_banner(**banner_kwargs, pid=proc.pid)
 
     # Brief pause — detect immediate crashes before telling the user it worked.
     time.sleep(1.5)
@@ -317,8 +321,8 @@ def serve_cmd(
 
     _check_network(provider)
 
-    if not os.environ.get(_NO_BANNER_ENV):
-        from synthadoc.cli.logo import print_banner
+    _print_banner = not os.environ.get(_NO_BANNER_ENV)
+    if _print_banner:
         mode = "MCP (stdio)" if mcp_only else "HTTP" if http_only else "HTTP + MCP"
         _agent_cfg = cfg.agents.resolve("default")
         _override_count = sum(
@@ -326,14 +330,19 @@ def serve_cmd(
             if getattr(cfg.agents, slot, None) is not None
         )
         _llm_note = f"(+ {_override_count} override{'s' if _override_count != 1 else ''})" if _override_count else ""
-        print_banner(port=effective_port, wiki=str(root), mode=mode,
-                     provider=_agent_cfg.provider, model=_agent_cfg.model,
-                     llm_note=_llm_note)
+        _banner_kwargs = dict(port=effective_port, wiki=str(root), mode=mode,
+                              provider=_agent_cfg.provider, model=_agent_cfg.model,
+                              llm_note=_llm_note)
 
     if background:
         log_path = root / ".synthadoc" / "logs" / "synthadoc.log"
-        _spawn_background(root, effective_port, log_path)
+        _spawn_background(root, effective_port, log_path,
+                          banner_kwargs=_banner_kwargs if _print_banner else None)
         return
+
+    if _print_banner:
+        from synthadoc.cli.logo import print_banner
+        print_banner(**_banner_kwargs)
 
     if not mcp_only:
         from synthadoc.integration.http_server import create_app

--- a/synthadoc/core/cache.py
+++ b/synthadoc/core/cache.py
@@ -33,7 +33,7 @@ class CacheManager:
                 )""")
             await db.commit()
 
-    async def get(self, key: str) -> Optional[dict]:
+    async def get(self, key: str) -> Any:
         async with aiosqlite.connect(self._path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
@@ -42,7 +42,7 @@ class CacheManager:
                 row = await cur.fetchone()
             return json.loads(row["value"]) if row else None
 
-    async def set(self, key: str, value: dict) -> None:
+    async def set(self, key: str, value: Any) -> None:
         async with aiosqlite.connect(self._path) as db:
             await db.execute(
                 "INSERT OR REPLACE INTO response_cache (key,value) VALUES (?,?)",

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -9,6 +9,7 @@ from typing import Optional
 import logging
 
 from synthadoc.config import Config, load_config
+from synthadoc.errors import DomainBlockedException
 from synthadoc.core.cache import CacheManager
 from synthadoc.core.cost_guard import CostGuard
 from synthadoc.core.hooks import HookExecutor
@@ -58,7 +59,12 @@ def _read_manifest(path: Path) -> list[str] | None:
             continue
         candidate = Path(line)
         resolved = candidate if candidate.is_absolute() else (base / candidate)
-        if resolved.exists():
+        try:
+            path_exists = resolved.exists()
+        except OSError:
+            # ENAMETOOLONG (errno 63) or other OS error — line can't be a valid path
+            path_exists = False
+        if path_exists:
             continue
         return None  # line is not a URL, intent, or valid path — not a manifest
 
@@ -343,7 +349,7 @@ class Orchestrator:
                 await self._queue.fail(job_id, str(e))
                 raise
 
-    async def _auto_block_domain(self, exc: "DomainBlockedException") -> None:
+    async def _auto_block_domain(self, exc: DomainBlockedException) -> None:
         """Persist a newly discovered blocked domain and record an audit event."""
         import json
         import logging

--- a/synthadoc/core/queue.py
+++ b/synthadoc/core/queue.py
@@ -187,7 +187,8 @@ class JobQueue:
         """Mark all pending jobs as cancelled. Returns the number of jobs cancelled."""
         async with aiosqlite.connect(self._path) as db:
             async with db.execute("SELECT COUNT(*) FROM jobs WHERE status='pending'") as cur:
-                count = (await cur.fetchone())[0]
+                row = await cur.fetchone()
+                count = row[0] if row else 0
             await db.execute(
                 "UPDATE jobs SET status='cancelled', error='cancelled by user' WHERE status='pending'"
             )
@@ -201,7 +202,8 @@ class JobQueue:
                 "AND created_at < datetime('now', ?)",
                 (f"-{older_than_days} days",)
             ) as cur:
-                count = (await cur.fetchone())[0]
+                row = await cur.fetchone()
+                count = row[0] if row else 0
             await db.execute(
                 "DELETE FROM jobs WHERE status IN ('completed','dead') "
                 "AND created_at < datetime('now', ?)",

--- a/synthadoc/core/routing.py
+++ b/synthadoc/core/routing.py
@@ -20,7 +20,7 @@ class RoutingIndex:
         for line in path.read_text(encoding="utf-8").splitlines():
             if m := _BRANCH_RE.match(line):
                 current = m.group(1).strip()
-                branches.setdefault(current, [])
+                branches.setdefault(current, [])  # type: ignore[arg-type]
             elif current and (m := _SLUG_RE.match(line)):
                 branches[current].append(m.group(1).strip())
         return cls(branches)
@@ -36,7 +36,7 @@ class RoutingIndex:
                 name = m.group(1).strip()
                 if name not in ("Index", "Recently Added"):
                     current = name
-                    branches.setdefault(current, [])
+                    branches.setdefault(name, [])
                 else:
                     current = None
             elif current:

--- a/synthadoc/demos/ai-research/_generate_raw_sources.py
+++ b/synthadoc/demos/ai-research/_generate_raw_sources.py
@@ -9,8 +9,8 @@ from openpyxl.styles import Font, PatternFill, Alignment
 from pptx import Presentation
 from pptx.util import Inches, Pt
 from pptx.dml.color import RGBColor
-from reportlab.pdfgen import canvas
-from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas  # type: ignore[import-untyped]
+from reportlab.lib.pagesizes import letter  # type: ignore[import-untyped]
 from PIL import Image, ImageDraw, ImageFont
 
 OUT = Path(__file__).parent / "raw_sources"
@@ -21,6 +21,7 @@ OUT = Path(__file__).parent / "raw_sources"
 def make_xlsx():
     wb = openpyxl.Workbook()
     ws = wb.active
+    assert ws is not None
     ws.title = "Model Comparison"
 
     header_fill = PatternFill("solid", fgColor="1F4E79")
@@ -89,19 +90,20 @@ def make_pptx():
     prs.slide_width  = Inches(13.33)
     prs.slide_height = Inches(7.5)
 
-    blank = prs.slide_layouts[6]   # blank
     title_content = prs.slide_layouts[1]
 
     def add_title_slide(title, subtitle=""):
         sl = prs.slides.add_slide(prs.slide_layouts[0])
+        assert sl.shapes.title is not None
         sl.shapes.title.text = title
         sl.shapes.title.text_frame.paragraphs[0].font.size = Pt(40)
-        sl.placeholders[1].text = subtitle
+        sl.placeholders[1].text = subtitle  # type: ignore[union-attr]
 
     def add_content_slide(title, bullets):
         sl = prs.slides.add_slide(title_content)
+        assert sl.shapes.title is not None
         sl.shapes.title.text = title
-        tf = sl.placeholders[1].text_frame
+        tf = sl.placeholders[1].text_frame  # type: ignore[union-attr]
         tf.text = bullets[0]
         for b in bullets[1:]:
             p = tf.add_paragraph()
@@ -213,14 +215,6 @@ def make_png():
     draw.text((W // 2, 30), "Neural Network Architecture", fill=title_color, anchor="mm")
     draw.text((W // 2, 55), "Feedforward Network — Fully Connected Layers", fill="#888888", anchor="mm")
 
-    # Layer positions
-    layers = [
-        ("Input\nLayer",  "input",  [150]),
-        ("Hidden\nLayer 1", "hidden", [250]),
-        ("Hidden\nLayer 2", "hidden", [350]),
-        ("Output\nLayer", "output", [550]),  # using x as position holder
-    ]
-
     # x positions and node counts
     x_positions = [120, 270, 420, 600, 750]
     node_counts  = [4, 6, 6, 5, 3]
@@ -230,7 +224,7 @@ def make_png():
     node_radius = 18
     node_positions = []
 
-    for li, (x, n, ltype) in enumerate(zip(x_positions, node_counts, layer_types)):
+    for _, (x, n, ltype) in enumerate(zip(x_positions, node_counts, layer_types)):
         y_start = (H - n * 70) // 2 + 60
         layer_nodes = []
         for ni in range(n):
@@ -245,7 +239,7 @@ def make_png():
                 draw.line([(px + node_radius, py), (nx - node_radius, ny)], fill=edge_color, width=1)
 
     # Draw nodes
-    for li, (layer_nodes, ltype) in enumerate(zip(node_positions, layer_types)):
+    for _, (layer_nodes, ltype) in enumerate(zip(node_positions, layer_types)):
         color = node_colors.get(ltype, "#7b68ee")
         for nx, ny in layer_nodes:
             draw.ellipse(
@@ -254,7 +248,7 @@ def make_png():
             )
 
     # Layer labels
-    for li, (x, name) in enumerate(zip(x_positions, layer_names)):
+    for _, (x, name) in enumerate(zip(x_positions, layer_names)):
         draw.text((x, H - 35), name, fill=label_color, anchor="mm")
 
     # Legend

--- a/synthadoc/errors.py
+++ b/synthadoc/errors.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
+from __future__ import annotations
+from typing import NoReturn
+
 """Synthadoc error code registry.
 
 Every user-facing error carries a short, stable code so that errors can be
@@ -16,7 +19,6 @@ SKILL  Skill dispatch and execution errors (not found, missing dep, blocked)
 INGEST Ingest source errors (file not found, empty, wrong type)
 JOB    Job management errors (not found)
 """
-from __future__ import annotations
 
 # ── Server ────────────────────────────────────────────────────────────────────
 SRV_NOT_RUNNING  = "ERR-SRV-001"   # No server listening for the requested wiki
@@ -106,7 +108,7 @@ QUERY_TIMEOUT = "ERR-QUERY-001"  # LLM synthesis timed out; retry the query
 JOB_NOT_FOUND = "ERR-JOB-001"   # Job ID does not exist in jobs.db
 
 
-def cli_error(code: str, message: str, hint: str = "") -> None:
+def cli_error(code: str, message: str, hint: str = "") -> NoReturn:
     """Print a categorised error and exit with code 1.
 
     Only call from CLI-layer code. Agents and skills raise standard Python

--- a/synthadoc/observability/telemetry.py
+++ b/synthadoc/observability/telemetry.py
@@ -21,6 +21,8 @@ class _JsonlExporter(SpanExporter):
     def export(self, spans):
         with open(self._path, "a", newline="\n") as f:
             for span in spans:
+                if span.context is None:
+                    continue
                 f.write(json.dumps({
                     "name": span.name,
                     "trace_id": format(span.context.trace_id, "032x"),
@@ -47,6 +49,7 @@ def get_tracer() -> trace.Tracer:
     global _tracer
     if _tracer is None:
         setup_telemetry()
+    assert _tracer is not None
     return _tracer
 
 

--- a/synthadoc/providers/anthropic.py
+++ b/synthadoc/providers/anthropic.py
@@ -29,7 +29,7 @@ class AnthropicProvider(LLMProvider):
         }
         if system:
             kwargs["system"] = system
-        last_exc = None
+        last_exc: Exception | None = None
         for attempt in range(_MAX_RETRIES):
             try:
                 resp = await self._client.messages.create(**kwargs)
@@ -46,4 +46,5 @@ class AnthropicProvider(LLMProvider):
                 continue
             except Exception:
                 raise
+        assert last_exc is not None
         raise last_exc

--- a/synthadoc/skills/base.py
+++ b/synthadoc/skills/base.py
@@ -23,15 +23,15 @@ class SkillMeta:
     version: str = "1.0"
     entry_script: str = "scripts/main.py"
     entry_class: str = ""
-    triggers: Optional[Triggers] = None
+    triggers: Triggers = field(default_factory=Triggers)
     requires: list[str] = field(default_factory=list)
     skill_dir: Optional[Path] = None
     # Deprecated: kept for backwards compat with old flat-file skill classes
     extensions: list[str] = field(default_factory=list)
 
     def __post_init__(self):
-        if self.triggers is None:
-            self.triggers = Triggers(extensions=list(self.extensions), intents=[])
+        if not self.triggers.extensions and self.extensions:
+            self.triggers = Triggers(extensions=list(self.extensions), intents=self.triggers.intents)
         if not self.entry_class:
             self.entry_class = "".join(p.title() for p in self.name.split("_")) + "Skill"
 

--- a/tests/agents/test_lint_agent.py
+++ b/tests/agents/test_lint_agent.py
@@ -145,13 +145,17 @@ async def test_orphan_flag_cleared_when_inbound_link_added(tmp_wiki):
         content="Links to [[page-a]] here.", status="active", confidence="high",
         sources=[]))
 
-    assert store.read_page("page-a").orphan is True
+    page_before = store.read_page("page-a")
+    assert page_before is not None
+    assert page_before.orphan is True
 
     log = LogWriter(tmp_wiki / "wiki" / "log.md")
     agent = LintAgent(provider=AsyncMock(), store=store, log_writer=log)
     await agent.lint(scope="orphans")
 
-    assert store.read_page("page-a").orphan is False
+    page_after = store.read_page("page-a")
+    assert page_after is not None
+    assert page_after.orphan is False
 
 
 # ── CJK (Chinese / Japanese / Korean) coverage ───────────────────────────────
@@ -297,6 +301,7 @@ async def test_lint_removes_dangling_links(tmp_wiki):
 
     assert report.dangling_links_removed == 1
     updated = store.read_page("index")
+    assert updated is not None
     assert "[[crashcourse-computer-science]]" not in updated.content
     assert "[[alan-turing]]" in updated.content
 
@@ -348,6 +353,7 @@ async def test_adversarial_pass_stores_warnings(tmp_wiki):
     )
     report = await agent.lint(adversarial=True)
     page = store.read_page("ai-page")
+    assert page is not None
     assert len(page.lint_warnings) == 1
     assert page.lint_warnings[0]["claim"] == "Transformers replaced RNNs entirely by 2020."
     assert len(report.adversarial_warnings) == 1
@@ -370,7 +376,9 @@ async def test_adversarial_pass_no_warnings_on_clean_page(tmp_wiki):
         adversarial_provider=adv_provider,
     )
     report = await agent.lint(adversarial=True)
-    assert store.read_page("clean").lint_warnings == []
+    clean_page = store.read_page("clean")
+    assert clean_page is not None
+    assert clean_page.lint_warnings == []
     assert report.adversarial_warnings == []
 
 
@@ -400,7 +408,8 @@ async def test_adversarial_pass_rate_limit_is_non_fatal(tmp_wiki):
     all_warnings = [
         w
         for slug in ["p1", "p2"]
-        for w in (store.read_page(slug).lint_warnings or [])
+        for p in [store.read_page(slug)] if p is not None
+        for w in (p.lint_warnings or [])
     ]
     claims = {w["claim"] for w in all_warnings}
     # list_pages() order is filesystem-dependent (inode order on macOS), so assert
@@ -421,7 +430,9 @@ async def test_no_adversarial_clears_existing_warnings(tmp_wiki):
     log = LogWriter(tmp_wiki / "wiki" / "log.md")
     agent = LintAgent(provider=AsyncMock(), store=store, log_writer=log)
     await agent.lint(adversarial=False)
-    assert store.read_page("p").lint_warnings == []
+    p_page = store.read_page("p")
+    assert p_page is not None
+    assert p_page.lint_warnings == []
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_logging_config.py
+++ b/tests/core/test_logging_config.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
 import logging
+import logging.handlers
 import json
 from pathlib import Path
 from synthadoc.config import LogsConfig
@@ -15,9 +16,11 @@ def _reset_root_logger():
 
 
 def _cfg(**kwargs) -> LogsConfig:
-    defaults = dict(level="INFO", max_file_mb=1, backup_count=3)
-    defaults.update(kwargs)
-    return LogsConfig(**defaults)
+    return LogsConfig(
+        level=kwargs.get("level", "INFO"),
+        max_file_mb=kwargs.get("max_file_mb", 1),
+        backup_count=kwargs.get("backup_count", 3),
+    )
 
 
 def test_setup_creates_log_file(tmp_path):

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -297,6 +297,7 @@ async def test_run_ingest_sources_txt_is_expanded_into_child_jobs(tmp_wiki):
     completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
     parent = next((j for j in completed if j.id == job_id), None)
     assert parent is not None, "parent job should be completed"
+    assert parent.result is not None
     assert parent.result["child_sources_enqueued"] == 3
     assert len(parent.result["child_job_ids"]) == 3
 

--- a/tests/core/test_orchestrator_cost.py
+++ b/tests/core/test_orchestrator_cost.py
@@ -143,7 +143,7 @@ async def _run_and_capture_ingest_cost(orch, input_tokens: int, output_tokens: i
          patch.object(orch._queue, "complete", side_effect=spy_complete):
         await orch._run_ingest(job_id, "test.md", auto_confirm=True)
 
-    return captured.get("cost_usd", None)
+    return float(captured.get("cost_usd") or 0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_queue.py
+++ b/tests/core/test_queue.py
@@ -10,6 +10,7 @@ async def test_enqueue_dequeue(tmp_wiki):
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "paper.pdf"})
     job = await q.dequeue()
+    assert job is not None
     assert job.id == job_id
     assert job.operation == "ingest"
     assert job.status == JobStatus.IN_PROGRESS
@@ -21,6 +22,7 @@ async def test_complete_job(tmp_wiki):
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "x.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.complete(job.id)
     jobs = await q.list_jobs(status=JobStatus.COMPLETED)
     assert any(j.id == job_id for j in jobs)
@@ -32,8 +34,10 @@ async def test_fail_retries_then_dies(tmp_wiki):
     await q.init()
     await q.enqueue("ingest", {"source": "x.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.fail(job.id, "timeout")
     job = await q.dequeue()
+    assert job is not None
     await q.fail(job.id, "timeout")
     dead = await q.list_jobs(status=JobStatus.DEAD)
     assert len(dead) == 1
@@ -48,6 +52,7 @@ async def test_delete_job_atomic(tmp_wiki):
     await audit.init()
     job_id = await q.enqueue("ingest", {"source": "x.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.complete(job.id)
     await q.delete(job_id, audit_db=audit)
     all_jobs = await q.list_jobs()
@@ -87,6 +92,7 @@ async def test_fail_before_max_retries_stays_pending(tmp_wiki):
     await q.init()
     await q.enqueue("ingest", {"source": "x.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.fail(job.id, "transient error")
     pending = await q.list_jobs(status=JobStatus.PENDING)
     assert any(j.id == job.id for j in pending)
@@ -99,6 +105,7 @@ async def test_skip_does_not_retry(tmp_wiki):
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "blocked.com"})
     job = await q.dequeue()
+    assert job is not None
     await q.skip(job.id, "domain blocked")
     pending = await q.list_jobs(status=JobStatus.PENDING)
     assert not any(j.id == job_id for j in pending)
@@ -113,6 +120,7 @@ async def test_fail_permanent_goes_to_failed_not_dead(tmp_wiki):
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "stub.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.fail_permanent(job.id, "NotImplementedError: skill stub")
     failed = await q.list_jobs(status=JobStatus.FAILED)
     assert any(j.id == job_id for j in failed)
@@ -139,6 +147,7 @@ async def test_dequeue_fifo_order(tmp_wiki):
         ids.append(await q.enqueue("ingest", {"source": f"file{i}.pdf"}))
     for expected_id in ids:
         job = await q.dequeue()
+        assert job is not None
         assert job.id == expected_id
         await q.complete(job.id)
 
@@ -164,6 +173,7 @@ async def test_retry_resets_retries_counter(tmp_wiki):
     # Exhaust retries → dead
     for _ in range(2):
         job = await q.dequeue()
+        assert job is not None
         await q.fail(job.id, "error")
     dead = await q.list_jobs(status=JobStatus.DEAD)
     assert any(j.id == job_id for j in dead)
@@ -183,6 +193,7 @@ async def test_purge_removes_old_completed_and_dead(tmp_wiki):
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "old.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.complete(job.id)
     # Backdate the job so it appears old
     async with aiosqlite.connect(q._path) as db:
@@ -203,6 +214,7 @@ async def test_purge_keeps_recent_jobs(tmp_wiki):
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "recent.pdf"})
     job = await q.dequeue()
+    assert job is not None
     await q.complete(job.id)
     removed = await q.purge(older_than_days=7)
     assert removed == 0
@@ -229,6 +241,7 @@ async def test_update_progress_overwrites(tmp_wiki):
     await q.update_progress(job_id, {"phase": "found_urls", "total": 5})
     jobs = await q.list_jobs()
     job = next(j for j in jobs if j.id == job_id)
+    assert job.progress is not None
     assert job.progress["phase"] == "found_urls"
     assert job.progress["total"] == 5
 
@@ -351,6 +364,7 @@ async def test_cancel_pending_marks_all_pending_as_cancelled(tmp_wiki):
     ids = [await q.enqueue("ingest", {"source": f"url{i}.com"}) for i in range(4)]
     # Complete one so it should not be cancelled
     job = await q.dequeue()
+    assert job is not None
     await q.complete(job.id)
     count = await q.cancel_pending()
     assert count == 3

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -654,7 +654,7 @@ def test_delete_completed_job_endpoint(tmp_wiki):
     import datetime
     completed_job = Job(id="done-1", operation="lint", payload={},
                         status=JobStatus.COMPLETED, retries=0, error=None,
-                        created_at=datetime.datetime.now(datetime.timezone.utc))
+                        created_at=datetime.datetime.now(datetime.timezone.utc).isoformat())
     with patch("synthadoc.core.queue.JobQueue.list_jobs",
                new=AsyncMock(return_value=[completed_job])):
         with patch("synthadoc.core.queue.JobQueue.delete", new=AsyncMock()):
@@ -671,7 +671,7 @@ def test_delete_pending_job_returns_409(tmp_wiki):
     import datetime
     pending_job = Job(id="run-1", operation="lint", payload={},
                       status=JobStatus.PENDING, retries=0, error=None,
-                      created_at=datetime.datetime.now(datetime.timezone.utc))
+                      created_at=datetime.datetime.now(datetime.timezone.utc).isoformat())
     with patch("synthadoc.core.queue.JobQueue.list_jobs",
                new=AsyncMock(return_value=[pending_job])):
         with TestClient(create_app(wiki_root=tmp_wiki)) as client:

--- a/tests/storage/test_wiki.py
+++ b/tests/storage/test_wiki.py
@@ -11,6 +11,7 @@ def test_write_and_read_page(tmp_wiki):
                     status="active", confidence="medium", sources=[])
     store.write_page("test", page)
     loaded = store.read_page("test")
+    assert loaded is not None
     assert loaded.title == "Test"
     assert "ai" in loaded.tags
     assert "[[Other]]" in loaded.content
@@ -59,6 +60,7 @@ def test_unicode_title_and_content(tmp_wiki):
                     status="active", confidence="high", sources=[])
     store.write_page("pool-zh", page)
     loaded = store.read_page("pool-zh")
+    assert loaded is not None
     assert loaded.title == "游泳池维护 🏊"
     assert "氯气含量 ppm" in loaded.content
     assert "中文" in loaded.tags
@@ -72,6 +74,7 @@ def test_overwrite_page_replaces_content(tmp_wiki):
     store.write_page("doc", WikiPage(title="v2", tags=[], content="second",
                      status="active", confidence="high", sources=[]))
     loaded = store.read_page("doc")
+    assert loaded is not None
     assert loaded.title == "v2"
     assert loaded.content == "second"
     assert "first" not in loaded.content
@@ -83,6 +86,7 @@ def test_empty_content_roundtrip(tmp_wiki):
     store.write_page("empty", WikiPage(title="Empty", tags=[], content="",
                      status="active", confidence="low", sources=[]))
     loaded = store.read_page("empty")
+    assert loaded is not None
     assert loaded.content == ""
 
 
@@ -94,6 +98,7 @@ def test_categories_roundtrip(tmp_wiki):
                     categories=["Swimming Pool", "Recently Added"])
     store.write_page("cat-page", page)
     loaded = store.read_page("cat-page")
+    assert loaded is not None
     assert loaded.categories == ["Swimming Pool", "Recently Added"]
 
 
@@ -107,6 +112,7 @@ def test_categories_missing_defaults_to_empty(tmp_wiki):
         encoding="utf-8"
     )
     loaded = store.read_page("no-cats")
+    assert loaded is not None
     assert loaded.categories == []
 
 
@@ -123,6 +129,7 @@ def test_orphan_flag_roundtrip(tmp_wiki):
     store.write_page("orphan-page", WikiPage(title="Orphan", tags=[], content="alone",
                      status="active", confidence="low", sources=[], orphan=True))
     loaded = store.read_page("orphan-page")
+    assert loaded is not None
     assert loaded.orphan is True
 
 
@@ -134,6 +141,7 @@ def test_set_page_categories_replaces_existing(tmp_wiki):
                      categories=["Old Category"]))
     store.set_page_categories("p", ["New Category"])
     loaded = store.read_page("p")
+    assert loaded is not None
     assert loaded.categories == ["New Category"]
     assert "Old Category" not in loaded.categories
 
@@ -204,6 +212,7 @@ def test_lint_warnings_round_trip(tmp_wiki):
                     lint_warnings=[{"claim": "Claim A", "concern": "Overstated"}])
     store.write_page("test", page)
     loaded = store.read_page("test")
+    assert loaded is not None
     assert loaded.lint_warnings == [{"claim": "Claim A", "concern": "Overstated"}]
 
 
@@ -225,5 +234,6 @@ def test_lint_warnings_null_claim_round_trip(tmp_wiki):
                                     "concern": "adversarial-pass-skipped: rate limit"}])
     store.write_page("test", page)
     loaded = store.read_page("test")
+    assert loaded is not None
     assert loaded.lint_warnings[0]["claim"] is None
     assert "rate limit" in loaded.lint_warnings[0]["concern"]

--- a/tests/test_ingest_lifecycle.py
+++ b/tests/test_ingest_lifecycle.py
@@ -22,6 +22,7 @@ def test_new_page_status_is_draft(tmp_path):
     page = _make_page(status="draft")
     store.write_page("test-page", page)
     read_back = store.read_page("test-page")
+    assert read_back is not None
     assert read_back.status == "draft"
 
 

--- a/tests/test_lint_lifecycle.py
+++ b/tests/test_lint_lifecycle.py
@@ -41,8 +41,10 @@ async def test_draft_promoted_to_active_on_clean_lint(tmp_path):
     agent = LintAgent(AsyncMock(), store, _make_log(), audit_db=db, wiki_root=tmp_path)
     await agent.lint(scope="all", adversarial=False)
     page = store.read_page("alan-turing")
+    assert page is not None
     assert page.status == LifecycleState.ACTIVE
     state = await db.get_page_state("alan-turing")
+    assert state is not None
     assert state["state"] == LifecycleState.ACTIVE
     events = await db.get_lifecycle_events(slug="alan-turing")
     assert any(e["to_state"] == LifecycleState.ACTIVE for e in events)
@@ -72,6 +74,7 @@ async def test_stale_detection_on_hash_mismatch(tmp_path):
     agent = LintAgent(AsyncMock(), store, _make_log(), audit_db=db, wiki_root=tmp_path)
     await agent.lint(scope="all", adversarial=False)
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status == LifecycleState.STALE
     events = await db.get_lifecycle_events(slug="test-page")
     assert any(e["to_state"] == LifecycleState.STALE for e in events)
@@ -94,6 +97,7 @@ async def test_archived_detection_on_missing_source(tmp_path):
     agent = LintAgent(AsyncMock(), store, _make_log(), audit_db=db, wiki_root=tmp_path)
     await agent.lint(scope="all", adversarial=False)
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status == LifecycleState.ARCHIVED
     events = await db.get_lifecycle_events(slug="test-page")
     assert any(e["to_state"] == LifecycleState.ARCHIVED for e in events)
@@ -109,4 +113,5 @@ async def test_no_lifecycle_flag_skips_checks(tmp_path):
     agent = LintAgent(AsyncMock(), store, _make_log(), audit_db=db, wiki_root=tmp_path)
     await agent.lint(scope="all", adversarial=False, lifecycle=False)
     page = store.read_page("alan-turing")
+    assert page is not None
     assert page.status == LifecycleState.DRAFT  # unchanged

--- a/tests/test_lint_lifecycle_url.py
+++ b/tests/test_lint_lifecycle_url.py
@@ -35,6 +35,7 @@ async def test_url_archived_on_404(tmp_path):
         await agent.lint(scope="all", adversarial=False, check_url_availability=True)
 
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status == "archived"
 
 
@@ -52,6 +53,7 @@ async def test_url_not_archived_on_200(tmp_path):
         await agent.lint(scope="all", adversarial=False, check_url_availability=True)
 
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status != "archived"
 
 
@@ -69,6 +71,7 @@ async def test_url_not_archived_when_flag_off(tmp_path):
         await agent.lint(scope="all", adversarial=False, check_url_availability=False)
 
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status != "archived"  # flag off → no check
 
 
@@ -101,6 +104,7 @@ async def test_url_stale_on_old_ingest(tmp_path):
 
     await agent.lint(scope="all", adversarial=False, check_url_availability=False)
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status == "stale"
 
 
@@ -132,4 +136,5 @@ async def test_url_not_stale_when_recent(tmp_path):
 
     await agent.lint(scope="all", adversarial=False, check_url_availability=False)
     page = store.read_page("test-page")
+    assert page is not None
     assert page.status != "stale"  # only 5 days old, threshold is 30


### PR DESCRIPTION
… ENAMETOOLONG crash

- Fix background server banner showing parent PID instead of child PID by moving print_banner() into _spawn_background() after Popen so proc.pid is available
- Fix batch ingest Errno 63 (ENAMETOOLONG) crash: _read_manifest() called Path.exists() on base/content_line without catching OSError; on Python <3.12 this propagates for path components >255 bytes, permanently failing .txt ingest jobs — wrap in try/except OSError so content files are correctly rejected as non-manifests and fall through to normal ingest
- Resolve Pylance type warnings across agents, cli, core, providers, skills, observability, demos, and tests with zero runtime side effects