### PR TITLE
feat(schedule): Fix schedule list with cron/next-run/last-run, schedule run/history audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,6 +832,26 @@ synthadoc schedule history -w my-wiki
 synthadoc schedule history --limit 50 -w my-wiki
 ```
 
+**Cron expression format:** `minute  hour  day-of-month  month  day-of-week`
+
+| Field | Range | Examples |
+|-------|-------|---------|
+| minute | 0–59 | `0` = on the hour |
+| hour | 0–23 | `2` = 2 AM, `22` = 10 PM |
+| day of month | 1–31 | `*` = every day |
+| month | 1–12 | `*` = every month |
+| day of week | 0–6 | `0` = Sunday, `1` = Monday |
+
+Common schedules:
+
+| Expression | Meaning |
+|------------|---------|
+| `0 2 * * *` | Every day at 2 AM |
+| `0 22 * * *` | Every night at 10 PM |
+| `0 3 * * 0` | Every Sunday at 3 AM |
+| `0 */6 * * *` | Every 6 hours |
+| `30 8 * * 1-5` | Weekdays at 8:30 AM |
+
 ### Routing
 
 ROUTING.md maps wiki branches to page slugs so queries and ingest jobs are scoped to the relevant section of the wiki. Create it once from your existing `index.md`, then let Synthadoc maintain it automatically as new pages are added.

--- a/README.md
+++ b/README.md
@@ -818,11 +818,18 @@ synthadoc schedule add --op "ingest --batch raw_sources/" --cron "0 2 * * *" -w 
 # Weekly lint
 synthadoc schedule add --op "lint run" --cron "0 3 * * 0" -w my-wiki
 
-# List scheduled jobs
+# List scheduled jobs (shows schedule, next run, last run, last result)
 synthadoc schedule list -w my-wiki
 
 # Remove a scheduled job
 synthadoc schedule remove <id> -w my-wiki
+
+# Run a scheduled operation immediately and record the result in the audit trail
+synthadoc schedule run --op "lint run" -w my-wiki
+
+# Show recent scheduled run history
+synthadoc schedule history -w my-wiki
+synthadoc schedule history --limit 50 -w my-wiki
 ```
 
 ### Routing

--- a/README.md
+++ b/README.md
@@ -811,6 +811,8 @@ synthadoc audit citations --json -w my-wiki             # raw JSON for scripting
 
 ### Scheduling recurring jobs
 
+Relative paths in `--op` (e.g. `raw_sources/`) are resolved against the **wiki root directory**, not the working directory of the shell that runs the schedule. This means they work correctly even when the OS scheduler fires the task with a different working directory (e.g. `C:\Windows\System32` on Windows).
+
 ```bash
 # Register a nightly ingest
 synthadoc schedule add --op "ingest --batch raw_sources/" --cron "0 2 * * *" -w my-wiki

--- a/docs/badges.json
+++ b/docs/badges.json
@@ -1,5 +1,5 @@
 {
-  "cli_commands": 46,
+  "cli_commands": 48,
   "obsidian_commands": 14,
   "skills": 9,
   "hooks": 2,

--- a/docs/design.md
+++ b/docs/design.md
@@ -836,7 +836,9 @@ synthadoc
     ├── add --op "<cmd>" --cron "<expr>" [-w wiki]
     ├── list [-w wiki]
     ├── remove <id> [-w wiki]
-    └── apply [-w wiki]
+    ├── apply [-w wiki]
+    ├── run --op "<cmd>" [-w wiki]
+    └── history [-w wiki] [-n N]
 ```
 
 `synthadoc status -w <wiki>` now shows a per-state page count breakdown alongside the existing page total and job counts.

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -1254,19 +1254,32 @@ Next run time is computed from the cron expression on macOS/Linux, and read from
 
 ### Check run history
 
-Each time a scheduled job fires, the result is recorded in the audit trail. View recent runs:
+Each time a scheduled job fires, the outcome (status, duration, and any output or error) is recorded in the schedule history log. View recent runs:
 
 ```bash
 synthadoc schedule history
 ```
 
 ```
-Run ID               Op              Started                Duration    Status     Error
-run-a1b2c3d4         lint run        2026-05-31 03:00:00      47.3s     success
-run-e5f6a7b8         lint run        2026-05-24 03:00:00      12.1s     failed     connection refused
+Run ID               Op              Started              Duration    Status
+------------------------------------------------------------------------
+run-a1b2c3d4         lint run        2026-05-31 03:00       47.3s    success
+run-342a7e95         ingest          2026-05-30 23:11        0.8s    failed
+run-bc56dc6a         scaffold        2026-05-30 23:04       31.2s    success
+
+Details
+-------
+run-a1b2c3d4  lint run  success
+  Checked 47 pages. 2 adversarial warnings. 0 orphan pages.
+
+run-342a7e95  ingest  failed
+  exit code 1: MINIMAX_API_KEY is not set
+
+run-bc56dc6a  scaffold  success
+  Scaffold complete — domain-specific content generated.
 ```
 
-A `failed` run means either `synthadoc serve` was not running when the task fired, or the operation itself encountered an error. Re-run manually with `synthadoc schedule run --op "lint run"` to recover.
+The **Details** section only appears when runs have output to show. Successful runs display captured output; failed runs display the error. A `failed` run means either `synthadoc serve` was not running when the task fired, or the operation itself encountered an error. Re-run manually with `synthadoc schedule run --op "lint run"` to recover.
 
 ### Clean up (demo only)
 

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -1241,13 +1241,32 @@ synthadoc schedule add --op "scaffold" --cron "0 4 * * 0"
 synthadoc schedule list
 ```
 
-Expected:
+Expected output — each row now shows the schedule, next run time, last run, and last result:
 
 ```
-sched-a3f1b2c4  0 2 * * *  ingest --batch raw_sources/
-sched-b7e9d012  0 3 * * 0  lint run
-sched-c9f3e201  0 4 * * 0  scaffold
+ID                   Schedule           Next Run             Last Run             Last Result    Command
+sched-a3f1b2c4       0 2 * * *          2026-05-31 02:00     —                    —              synthadoc ... schedule run --op "ingest --batch raw_sources/"
+sched-b7e9d012       0 3 * * 0          2026-06-01 03:00     —                    —              synthadoc ... schedule run --op "lint run"
+sched-c9f3e201       0 4 * * 0          2026-06-01 04:00     —                    —              synthadoc ... schedule run --op "scaffold"
 ```
+
+Next run time is computed from the cron expression on macOS/Linux, and read from the OS Task Scheduler on Windows.
+
+### Check run history
+
+Each time a scheduled job fires, the result is recorded in the audit trail. View recent runs:
+
+```bash
+synthadoc schedule history
+```
+
+```
+Run ID               Op              Started                Duration    Status     Error
+run-a1b2c3d4         lint run        2026-05-31 03:00:00      47.3s     success
+run-e5f6a7b8         lint run        2026-05-24 03:00:00      12.1s     failed     connection refused
+```
+
+A `failed` run means either `synthadoc serve` was not running when the task fired, or the operation itself encountered an error. Re-run manually with `synthadoc schedule run --op "lint run"` to recover.
 
 ### Clean up (demo only)
 
@@ -1261,7 +1280,9 @@ synthadoc schedule remove sched-c9f3e201
 
 > **Production use:** for always-on scheduling, run `synthadoc serve` as a background
 > service (systemd, launchd, or Windows Service) so the server is available when the OS
-> fires the scheduled task.
+> fires the scheduled task. If a run is missed (server down or machine asleep), it will
+> not automatically retry — check `synthadoc schedule history` for failures and re-run
+> manually if needed.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tavily-python>=0.5",
     "youtube-transcript-api>=0.6",
+    "croniter>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -59,6 +60,10 @@ testpaths = ["tests"]
 addopts = "-m 'not integration'"
 markers = [
     "integration: marks tests that require real external tools (run explicitly with '-m integration')",
+    "windows: marks tests that run only on Windows",
+    "linux: marks tests that run only on Linux",
+    "macos: marks tests that run only on macOS",
+    "posix: marks tests that run only on Linux or macOS",
 ]
 
 [tool.hatch.version]

--- a/synthadoc/cli/ingest.py
+++ b/synthadoc/cli/ingest.py
@@ -99,6 +99,6 @@ def ingest_cmd(
         if max_results is not None:
             body["max_results"] = max_results
         result = post(wiki, "/jobs/ingest", body)
-        typer.echo(f"Enqueued {s} → job {result['job_id']}")
+        typer.echo(f"Enqueued {s} -> job {result['job_id']}")
         w_flag = f" -w {wiki}" if wiki != "." else ""
         typer.echo(f"Check status: synthadoc jobs status {result['job_id']}{w_flag}")

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -65,7 +65,6 @@ def list_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")) -> None:
     if not entries:
         typer.echo("No scheduled jobs found.")
         return
-    typer.echo(f"[wiki: {wiki}]")
     typer.echo(f"{'ID':<20} {'Schedule':<18} {'Next Run':<20} {'Last Run':<20} {'Last Result':<14} Command")
     typer.echo("-" * 110)
     for e in entries:
@@ -166,7 +165,6 @@ def history_cmd(
     if not runs:
         typer.echo("No scheduled run history found.")
         return
-    typer.echo(f"[wiki: {wiki_name}]")
     typer.echo(f"{'Run ID':<20} {'Op':<14} {'Started':<22} {'Duration':>10}  {'Status':<10} Error")
     typer.echo("-" * 90)
     for r in runs:

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -43,7 +43,7 @@ def add_cmd(
     cron: str = typer.Option(..., "--cron", help="Cron expression"),
     wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
 ) -> None:
-    """Register a recurring operation with the OS scheduler."""
+    """Register a recurring operation with the synthadoc server scheduler."""
     from synthadoc.cli._wiki import resolve_wiki
     wiki = resolve_wiki(wiki)
     from synthadoc.core.scheduler import Scheduler

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -126,15 +126,20 @@ def run_cmd(
     t0 = time.monotonic()
     try:
         cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + op.split()
-        result = subprocess.run(cmd, cwd=str(root))
+        result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True)
         duration = time.monotonic() - t0
+        if result.stdout:
+            typer.echo(result.stdout, nl=False)
         if result.returncode == 0:
             asyncio.run(db.record_scheduled_run_finish(run_id, "success", duration))
-            typer.echo(f"  {run_id}  {op}  {duration:.1f}s  success")
+            typer.echo(f"[schedule] {run_id}  {op}  {duration:.1f}s  success")
         else:
-            err = f"exit code {result.returncode}"
+            stderr_snippet = result.stderr.strip()[:300] if result.stderr else ""
+            err = f"exit code {result.returncode}" + (f": {stderr_snippet}" if stderr_snippet else "")
             asyncio.run(db.record_scheduled_run_finish(run_id, "failed", duration, err))
-            typer.echo(f"  {run_id}  {op}  {duration:.1f}s  failed ({err})", err=True)
+            if result.stderr:
+                typer.echo(result.stderr, nl=False, err=True)
+            typer.echo(f"[schedule] {run_id}  {op}  {duration:.1f}s  failed ({err})", err=True)
             raise typer.Exit(result.returncode)
     except typer.Exit:
         raise

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -170,15 +170,37 @@ def history_cmd(
         await db.init()
         return await db.list_scheduled_runs(limit=limit)
 
+    from synthadoc.core.scheduler import _format_run_ts
+
     runs = asyncio.run(_fetch())
     if not runs:
         typer.echo("No scheduled run history found.")
         return
-    typer.echo(f"{'Run ID':<20} {'Op':<14} {'Started':<22} {'Duration':>10}  {'Status':<10} Error")
-    typer.echo("-" * 90)
+
+    typer.echo(f"{'Run ID':<20} {'Op':<14} {'Started':<20} {'Duration':>10}  Status")
+    typer.echo("-" * 72)
     for r in runs:
-        dur = f"{r['duration_s']:.1f}s" if r.get("duration_s") is not None else "—"
+        dur = f"{r['duration_s']:.1f}s" if r.get("duration_s") is not None else "-"
+        started = _format_run_ts(r.get("started_at") or "")
         typer.echo(
-            f"{r['run_id']:<20} {r['op']:<14} {(r['started_at'] or '')[:19]:<22}"
-            f" {dur:>10}  {(r['status'] or '—'):<10} {r.get('error') or ''}"
+            f"{r['run_id']:<20} {r['op']:<14} {started:<20} {dur:>10}  {r.get('status') or '-'}"
         )
+
+    detail_runs = [
+        r for r in runs
+        if (r.get("status") == "success" and r.get("output"))
+        or (r.get("status") != "success" and (r.get("error") or r.get("output")))
+    ]
+    if detail_runs:
+        typer.echo("")
+        typer.echo("Details")
+        typer.echo("-" * 7)
+        for r in detail_runs:
+            typer.echo(f"{r['run_id']}  {r['op']}  {r.get('status') or '-'}")
+            content = (
+                r.get("error") if r.get("status") != "success"
+                else r.get("output") or ""
+            )
+            for line in (content or "").splitlines():
+                typer.echo(f"  {line}")
+            typer.echo("")

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# Copyright (C) 2026 Paul Chen / axoviq.com
+# Copyright (C) 2026 William Johnason / axoviq.com
 from __future__ import annotations
 
+import asyncio
+import subprocess
+import sys
+import time
+import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -16,7 +21,6 @@ app.add_typer(schedule_app, name="schedule")
 
 
 def _resolve_and_validate(wiki: Optional[str]) -> Path:
-    """Resolve wiki name to path and fail early if it is not installed."""
     if wiki is None:
         E.cli_error(
             E.WIKI_NOT_FOUND,
@@ -35,10 +39,10 @@ def _resolve_and_validate(wiki: Optional[str]) -> Path:
 
 @schedule_app.command("add")
 def add_cmd(
-    op: str = typer.Option(..., "--op", help="synthadoc operation (e.g. 'lint')"),
+    op: str = typer.Option(..., "--op", help="synthadoc operation (e.g. 'lint run')"),
     cron: str = typer.Option(..., "--cron", help="Cron expression"),
     wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
-):
+) -> None:
     """Register a recurring operation with the OS scheduler."""
     from synthadoc.cli._wiki import resolve_wiki
     wiki = resolve_wiki(wiki)
@@ -50,22 +54,32 @@ def add_cmd(
 
 
 @schedule_app.command("list")
-def list_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")):
-    """List all synthadoc-registered scheduled jobs."""
+def list_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")) -> None:
+    """List all synthadoc-registered scheduled jobs with schedule and run history."""
     from synthadoc.cli._wiki import resolve_wiki
     wiki = resolve_wiki(wiki)
     from synthadoc.core.scheduler import Scheduler
     root = _resolve_and_validate(wiki)
     sched = Scheduler(wiki=wiki, wiki_root=str(root))
-    for e in sched.list():
-        typer.echo(f"{e.id}  {e.cron}  {e.op}")
+    entries = sched.list()
+    if not entries:
+        typer.echo("No scheduled jobs found.")
+        return
+    typer.echo(f"[wiki: {wiki}]")
+    typer.echo(f"{'ID':<20} {'Schedule':<18} {'Next Run':<20} {'Last Run':<20} {'Last Result':<14} Command")
+    typer.echo("-" * 110)
+    for e in entries:
+        typer.echo(
+            f"{e.id:<20} {(e.cron or '—'):<18} {(e.next_run or '—'):<20}"
+            f" {(e.last_run or '—'):<20} {(e.last_result or '—'):<14} {e.op}"
+        )
 
 
 @schedule_app.command("remove")
 def remove_cmd(
     entry_id: str = typer.Argument(...),
     wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
-):
+) -> None:
     """Remove a scheduled job by ID."""
     from synthadoc.cli._wiki import resolve_wiki
     wiki = resolve_wiki(wiki)
@@ -77,7 +91,7 @@ def remove_cmd(
 
 
 @schedule_app.command("apply")
-def apply_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")):
+def apply_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")) -> None:
     """Register all jobs declared in [schedule] in the project config."""
     from synthadoc.cli._wiki import resolve_wiki
     wiki = resolve_wiki(wiki)
@@ -90,3 +104,74 @@ def apply_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")):
                        for j in cfg.schedule.jobs])
     for entry_id in ids:
         typer.echo(f"Registered: {entry_id}")
+
+
+@schedule_app.command("run")
+def run_cmd(
+    op: str = typer.Option(..., "--op", help="Operation to run (e.g. 'lint run')"),
+    wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
+) -> None:
+    """Execute a scheduled operation and record the result in the audit trail."""
+    from synthadoc.cli._wiki import resolve_wiki
+    from synthadoc.storage.log import AuditDB
+
+    wiki_name = resolve_wiki(wiki)
+    root = _resolve_and_validate(wiki_name)
+    run_id = f"run-{uuid.uuid4().hex[:8]}"
+
+    db = AuditDB(root / ".synthadoc" / "audit.db")
+    asyncio.run(db.init())
+    asyncio.run(db.record_scheduled_run_start(run_id, op, wiki_name))
+
+    t0 = time.monotonic()
+    try:
+        cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + op.split()
+        result = subprocess.run(cmd)
+        duration = time.monotonic() - t0
+        if result.returncode == 0:
+            asyncio.run(db.record_scheduled_run_finish(run_id, "success", duration))
+            typer.echo(f"  {run_id}  {op}  {duration:.1f}s  success")
+        else:
+            err = f"exit code {result.returncode}"
+            asyncio.run(db.record_scheduled_run_finish(run_id, "failed", duration, err))
+            typer.echo(f"  {run_id}  {op}  {duration:.1f}s  failed ({err})", err=True)
+            raise typer.Exit(result.returncode)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        duration = time.monotonic() - t0
+        asyncio.run(db.record_scheduled_run_finish(run_id, "failed", duration, str(exc)))
+        typer.echo(f"  {run_id}  {op}  failed: {exc}", err=True)
+        raise typer.Exit(1)
+
+
+@schedule_app.command("history")
+def history_cmd(
+    wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
+    limit: int = typer.Option(20, "--limit", "-n"),
+) -> None:
+    """Show recent scheduled run history from the audit trail."""
+    from synthadoc.cli._wiki import resolve_wiki
+    from synthadoc.storage.log import AuditDB
+
+    wiki_name = resolve_wiki(wiki)
+    root = _resolve_and_validate(wiki_name)
+    db = AuditDB(root / ".synthadoc" / "audit.db")
+
+    async def _fetch():
+        await db.init()
+        return await db.list_scheduled_runs(limit=limit)
+
+    runs = asyncio.run(_fetch())
+    if not runs:
+        typer.echo("No scheduled run history found.")
+        return
+    typer.echo(f"[wiki: {wiki_name}]")
+    typer.echo(f"{'Run ID':<20} {'Op':<14} {'Started':<22} {'Duration':>10}  {'Status':<10} Error")
+    typer.echo("-" * 90)
+    for r in runs:
+        dur = f"{r['duration_s']:.1f}s" if r.get("duration_s") is not None else "—"
+        typer.echo(
+            f"{r['run_id']:<20} {r['op']:<14} {(r['started_at'] or '')[:19]:<22}"
+            f" {dur:>10}  {(r['status'] or '—'):<10} {r.get('error') or ''}"
+        )

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -122,6 +122,7 @@ def run_cmd(
     asyncio.run(db.init())
     asyncio.run(db.record_scheduled_run_start(run_id, op, wiki_name))
 
+    typer.echo(f"[schedule] {run_id}  {op}  starting")
     t0 = time.monotonic()
     try:
         cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + op.split()

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import sys
 import time
@@ -126,7 +127,9 @@ def run_cmd(
     t0 = time.monotonic()
     try:
         cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + op.split()
-        result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True)
+        sub_env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
+        result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True,
+                                encoding="utf-8", env=sub_env)
         duration = time.monotonic() - t0
         if result.stdout:
             typer.echo(result.stdout, nl=False)

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -125,7 +125,7 @@ def run_cmd(
     t0 = time.monotonic()
     try:
         cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + op.split()
-        result = subprocess.run(cmd)
+        result = subprocess.run(cmd, cwd=str(root))
         duration = time.monotonic() - t0
         if result.returncode == 0:
             asyncio.run(db.record_scheduled_run_finish(run_id, "success", duration))

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -59,7 +59,7 @@ class Scheduler:
                 cron=cron,
                 wiki=e.get("wiki", self._wiki),
                 next_run=_cron_next_run(cron),
-                last_run=lr.get("started_at", ""),
+                last_run=_format_run_ts(lr.get("started_at", "")),
                 last_result=lr.get("status", ""),
             ))
         return result
@@ -174,6 +174,20 @@ def _cron_next_run(cron: str) -> str:
         return it.get_next(datetime).strftime("%Y-%m-%d %H:%M")
     except Exception:
         return ""
+
+
+def _format_run_ts(ts: str) -> str:
+    """Convert a stored UTC ISO timestamp to local YYYY-MM-DD HH:MM, or '' on error."""
+    if not ts:
+        return ""
+    try:
+        from datetime import timezone
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone().replace(tzinfo=None)
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except Exception:
+        return ts
 
 
 def _matches_cron(cron: str, dt: datetime) -> bool:

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -162,7 +162,9 @@ class Scheduler:
                     current["next_run"] = line.split(":", 1)[-1].strip()
                 elif line.startswith("Last Run Time:"):
                     val = line.split(":", 1)[-1].strip()
-                    current["last_run"] = "" if val == "N/A" else val
+                    # "11/30/1999 12:00:00 AM" is Windows' sentinel for "never run"
+                    never_run = val in ("N/A", "") or val.startswith("11/30/1999")
+                    current["last_run"] = "" if never_run else val
                 elif line.startswith("Last Result:"):
                     current["last_result"] = line.split(":", 1)[-1].strip()
                 elif line.startswith("Start Time:"):

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import sys
 import time
 import uuid
@@ -141,6 +142,7 @@ async def _run_scheduled_job(
             cwd=str(wiki_root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         )
         stdout, stderr = await proc.communicate()
         duration = time.monotonic() - t0

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -9,7 +9,7 @@ import sys
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -170,7 +170,7 @@ def _cron_next_run(cron: str) -> str:
     """Return the next scheduled datetime string for a cron expression, or ''."""
     try:
         from croniter import croniter
-        it = croniter(cron, datetime.now(timezone.utc))
+        it = croniter(cron, datetime.now())
         return it.get_next(datetime).strftime("%Y-%m-%d %H:%M")
     except Exception:
         return ""

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# Copyright (C) 2026 Paul Chen / axoviq.com
+# Copyright (C) 2026 William Johnason / axoviq.com
 from __future__ import annotations
 
 import platform
 import subprocess
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Optional
 
 
@@ -15,6 +16,9 @@ class ScheduleEntry:
     cron: str
     wiki: str
     id: str = field(default_factory=lambda: f"sched-{uuid.uuid4().hex[:8]}")
+    next_run: str = ""
+    last_run: str = ""
+    last_result: str = ""
 
 
 class Scheduler:
@@ -38,6 +42,10 @@ class Scheduler:
     def apply(self, jobs: list[ScheduleEntry]) -> list[str]:
         return [self.add(op=j.op, cron=j.cron) for j in jobs]
 
+    # ------------------------------------------------------------------
+    # OS task registration
+    # ------------------------------------------------------------------
+
     def _register_os_task(self, op: str, cron: str, entry_id: str) -> None:
         if platform.system() == "Windows":
             args = self._build_schtasks_args(op=op, cron=cron, entry_id=entry_id)
@@ -45,8 +53,11 @@ class Scheduler:
         else:
             self._add_crontab_entry(op=op, cron=cron, entry_id=entry_id)
 
+    def _build_run_cmd(self, op: str) -> str:
+        return f'synthadoc -w {self._wiki} schedule run --op "{op}"'
+
     def _build_crontab_line(self, op: str, cron: str, entry_id: str) -> str:
-        cmd = f"synthadoc -w {self._wiki} {op}"
+        cmd = self._build_run_cmd(op)
         return f"{cron} {cmd} {self._TAG_PREFIX}{entry_id}"
 
     def _add_crontab_entry(self, op: str, cron: str, entry_id: str) -> None:
@@ -59,7 +70,7 @@ class Scheduler:
     def _build_schtasks_args(self, op: str, cron: str, entry_id: str) -> list[str]:
         parts = cron.split()
         minute, hour = parts[0], parts[1]
-        cmd = f"synthadoc -w {self._wiki} {op}"
+        cmd = self._build_run_cmd(op)
         return [
             "/Create", "/F",
             "/TN", f"synthadoc-{entry_id}",
@@ -67,6 +78,10 @@ class Scheduler:
             "/SC", "DAILY",
             "/ST", f"{int(hour):02d}:{int(minute):02d}",
         ]
+
+    # ------------------------------------------------------------------
+    # OS task listing
+    # ------------------------------------------------------------------
 
     def _list_os_tasks(self) -> list[ScheduleEntry]:
         if platform.system() == "Windows":
@@ -77,39 +92,106 @@ class Scheduler:
         result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
         entries = []
         for line in result.stdout.splitlines():
-            if self._TAG_PREFIX in line:
-                entry_id = line.split(self._TAG_PREFIX)[-1].strip()
-                parts = line.split()
-                cron = " ".join(parts[:5])
-                op_parts = parts[5:]
-                tag = self._TAG_PREFIX.strip()
-                op = " ".join(p for p in op_parts if not p.startswith(tag))
-                entries.append(ScheduleEntry(id=entry_id, op=op.strip(),
-                                             cron=cron, wiki=self._wiki))
+            if self._TAG_PREFIX not in line:
+                continue
+            entry_id = line.split(self._TAG_PREFIX)[-1].strip()
+            parts = line.split()
+            cron = " ".join(parts[:5])
+            op_parts = parts[5:]
+            tag = self._TAG_PREFIX.strip()
+            op = " ".join(p for p in op_parts if not p.startswith(tag))
+            next_run = _cron_next_run(cron)
+            entries.append(ScheduleEntry(
+                id=entry_id, op=op.strip(), cron=cron,
+                wiki=self._wiki, next_run=next_run,
+            ))
         return entries
 
     def _list_schtasks(self) -> list[ScheduleEntry]:
         result = subprocess.run(
-            ["schtasks", "/Query", "/FO", "LIST", "/V"], capture_output=True, text=True)
+            ["schtasks", "/Query", "/FO", "LIST", "/V"],
+            capture_output=True, text=True,
+        )
         entries = []
-        current_name = None
-        for line in result.stdout.splitlines():
+        current: dict = {}
+
+        def _flush(d: dict) -> None:
+            if "id" in d and "op" in d:
+                result_raw = d.get("last_result", "")
+                last_result = (
+                    "success" if result_raw == "0"
+                    else ("N/A" if result_raw in ("", "267011") else f"failed ({result_raw})")
+                )
+                entries.append(ScheduleEntry(
+                    id=d["id"],
+                    op=d["op"],
+                    cron=d.get("cron", ""),
+                    wiki=self._wiki,
+                    next_run=d.get("next_run", ""),
+                    last_run=d.get("last_run", ""),
+                    last_result=last_result,
+                ))
+
+        for raw_line in result.stdout.splitlines():
+            line = raw_line.strip()
             if line.startswith("TaskName:") and "synthadoc-" in line:
-                current_name = line.split("synthadoc-")[-1].strip()
-            if current_name and line.startswith("Task To Run:"):
-                cmd = line.split(":", 1)[-1].strip()
-                entries.append(ScheduleEntry(id=current_name, op=cmd,
-                                             cron="", wiki=self._wiki))
-                current_name = None
+                _flush(current)
+                current = {"id": line.split("synthadoc-")[-1].strip()}
+            elif current:
+                if line.startswith("Task To Run:"):
+                    current["op"] = line.split(":", 1)[-1].strip()
+                elif line.startswith("Next Run Time:"):
+                    current["next_run"] = line.split(":", 1)[-1].strip()
+                elif line.startswith("Last Run Time:"):
+                    val = line.split(":", 1)[-1].strip()
+                    current["last_run"] = "" if val == "N/A" else val
+                elif line.startswith("Last Result:"):
+                    current["last_result"] = line.split(":", 1)[-1].strip()
+                elif line.startswith("Start Time:"):
+                    time_str = line.split(":", 1)[-1].strip()
+                    current["cron"] = _schtasks_time_to_cron(time_str)
+
+        _flush(current)
         return entries
+
+    # ------------------------------------------------------------------
+    # OS task removal
+    # ------------------------------------------------------------------
 
     def _remove_os_task(self, entry_id: str) -> None:
         if platform.system() == "Windows":
-            subprocess.run(["schtasks", "/Delete", "/TN", f"synthadoc-{entry_id}", "/F"],
-                           check=True)
+            subprocess.run(
+                ["schtasks", "/Delete", "/TN", f"synthadoc-{entry_id}", "/F"],
+                check=True,
+            )
         else:
             result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
             lines = [ln for ln in result.stdout.splitlines()
                      if f"{self._TAG_PREFIX}{entry_id}" not in ln]
             subprocess.run(["crontab", "-"], input="\n".join(lines) + "\n",
                            text=True, check=True)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _cron_next_run(cron: str) -> str:
+    """Return the next scheduled datetime string for a cron expression, or ''."""
+    try:
+        from croniter import croniter
+        it = croniter(cron, datetime.now(timezone.utc))
+        return it.get_next(datetime).strftime("%Y-%m-%d %H:%M")
+    except Exception:
+        return ""
+
+
+def _schtasks_time_to_cron(time_str: str) -> str:
+    """Convert a schtasks Start Time string (e.g. '2:00:00 AM') to a cron expression."""
+    for fmt in ("%I:%M:%S %p", "%H:%M:%S", "%I:%M %p", "%H:%M"):
+        try:
+            t = datetime.strptime(time_str.strip(), fmt)
+            return f"{t.minute} {t.hour} * * *"
+        except ValueError:
+            continue
+    return ""

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -2,15 +2,21 @@
 # Copyright (C) 2026 William Johnason / axoviq.com
 from __future__ import annotations
 
-import platform
-import re
-import shutil
-import subprocess
+import asyncio
+import json
+import logging
 import sys
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from synthadoc.storage.log import AuditDB
+
+logger = logging.getLogger("synthadoc.scheduler")
 
 
 @dataclass
@@ -25,171 +31,135 @@ class ScheduleEntry:
 
 
 class Scheduler:
-    _TAG_PREFIX = "# synthadoc:"
-
     def __init__(self, wiki: str, wiki_root: str) -> None:
         self._wiki = wiki
-        self._wiki_root = wiki_root
+        self._wiki_root = Path(wiki_root)
+        self._path = self._wiki_root / ".synthadoc" / "schedules.json"
 
     def add(self, op: str, cron: str) -> str:
         entry_id = f"sched-{uuid.uuid4().hex[:8]}"
-        self._register_os_task(op=op, cron=cron, entry_id=entry_id)
+        entries = self._load_raw()
+        entries.append({"id": entry_id, "op": op, "cron": cron, "wiki": self._wiki})
+        self._save_raw(entries)
         return entry_id
 
-    def list(self) -> list[ScheduleEntry]:
-        return self._list_os_tasks()
-
     def remove(self, entry_id: str) -> None:
-        self._remove_os_task(entry_id)
+        self._save_raw([e for e in self._load_raw() if e["id"] != entry_id])
+
+    def list(self) -> list[ScheduleEntry]:
+        raw = self._load_raw()
+        last_runs = self._fetch_last_runs()
+        result = []
+        for e in raw:
+            cron = e.get("cron", "")
+            lr = last_runs.get(e["id"], {})
+            result.append(ScheduleEntry(
+                id=e["id"],
+                op=e["op"],
+                cron=cron,
+                wiki=e.get("wiki", self._wiki),
+                next_run=_cron_next_run(cron),
+                last_run=lr.get("started_at", ""),
+                last_result=lr.get("status", ""),
+            ))
+        return result
 
     def apply(self, jobs: list[ScheduleEntry]) -> list[str]:
         return [self.add(op=j.op, cron=j.cron) for j in jobs]
 
     # ------------------------------------------------------------------
-    # OS task registration
+    # Internal storage
     # ------------------------------------------------------------------
 
-    def _register_os_task(self, op: str, cron: str, entry_id: str) -> None:
-        if platform.system() == "Windows":
-            args = self._build_schtasks_args(op=op, cron=cron, entry_id=entry_id)
-            subprocess.run(["schtasks"] + args, check=True)
-        else:
-            self._add_crontab_entry(op=op, cron=cron, entry_id=entry_id)
+    def _load_raw(self) -> list[dict]:
+        if not self._path.exists():
+            return []
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
 
-    def _build_run_cmd(self, op: str) -> str:
-        exe = shutil.which("synthadoc")
-        if exe:
-            prefix = f'"{exe}"' if " " in exe else exe
-        else:
-            python = sys.executable
-            python_q = f'"{python}"' if " " in python else python
-            prefix = f"{python_q} -m synthadoc"
-        return f'{prefix} -w {self._wiki} schedule run --op "{op}"'
+    def _save_raw(self, entries: list[dict]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
 
-    def _build_crontab_line(self, op: str, cron: str, entry_id: str) -> str:
-        cmd = self._build_run_cmd(op)
-        return f"{cron} {cmd} {self._TAG_PREFIX}{entry_id}"
+    def _fetch_last_runs(self) -> dict[str, dict]:
+        from synthadoc.storage.log import AuditDB
+        db = AuditDB(self._wiki_root / ".synthadoc" / "audit.db")
 
-    def _add_crontab_entry(self, op: str, cron: str, entry_id: str) -> None:
-        current = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        existing = current.stdout if current.returncode == 0 else ""
-        new_line = self._build_crontab_line(op=op, cron=cron, entry_id=entry_id)
-        updated = existing.rstrip("\n") + "\n" + new_line + "\n"
-        subprocess.run(["crontab", "-"], input=updated, text=True, check=True)
+        async def _query():
+            await db.init()
+            return await db.get_last_run_per_entry()
 
-    def _build_schtasks_args(self, op: str, cron: str, entry_id: str) -> list[str]:
-        parts = cron.split()
-        minute, hour = parts[0], parts[1]
-        cmd = self._build_run_cmd(op)
-        return [
-            "/Create", "/F",
-            "/TN", f"synthadoc-{entry_id}",
-            "/TR", cmd,
-            "/SC", "DAILY",
-            "/ST", f"{int(hour):02d}:{int(minute):02d}",
-        ]
+        try:
+            return asyncio.run(_query())
+        except Exception:
+            return {}
 
-    # ------------------------------------------------------------------
-    # OS task listing
-    # ------------------------------------------------------------------
 
-    def _list_os_tasks(self) -> list[ScheduleEntry]:
-        if platform.system() == "Windows":
-            return self._list_schtasks()
-        return self._list_crontab()
+# ------------------------------------------------------------------
+# Server-side scheduler loop — runs inside synthadoc serve
+# ------------------------------------------------------------------
 
-    def _list_crontab(self) -> list[ScheduleEntry]:
-        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-        entries = []
-        for line in result.stdout.splitlines():
-            if self._TAG_PREFIX not in line:
-                continue
-            entry_id = line.split(self._TAG_PREFIX)[-1].strip()
-            parts = line.split()
-            cron = " ".join(parts[:5])
-            m = re.search(r'--op\s+"([^"]+)"', line)
-            op = m.group(1) if m else " ".join(parts[5:]).split(self._TAG_PREFIX)[0].strip()
-            next_run = _cron_next_run(cron)
-            entries.append(ScheduleEntry(
-                id=entry_id, op=op.strip(), cron=cron,
-                wiki=self._wiki, next_run=next_run,
-            ))
-        return entries
+async def run_scheduler_loop(wiki: str, wiki_root: Path, audit_db: "AuditDB") -> None:
+    """Asyncio background task: fire scheduled jobs at their cron times."""
+    while True:
+        now = datetime.now()
+        sleep_secs = max(1.0, 60.0 - now.second - now.microsecond / 1_000_000)
+        await asyncio.sleep(sleep_secs)
 
-    def _list_schtasks(self) -> list[ScheduleEntry]:
-        result = subprocess.run(
-            ["schtasks", "/Query", "/FO", "LIST", "/V"],
-            capture_output=True, text=True,
+        now = datetime.now()
+        try:
+            sched = Scheduler(wiki=wiki, wiki_root=str(wiki_root))
+            for entry in sched._load_raw():
+                if _matches_cron(entry.get("cron", ""), now):
+                    asyncio.create_task(
+                        _run_scheduled_job(entry, wiki, wiki_root, audit_db)
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("scheduler loop error: %s", exc)
+
+
+async def _run_scheduled_job(
+    entry: dict, wiki: str, wiki_root: Path, audit_db: "AuditDB"
+) -> None:
+    """Execute one scheduled job and record the result in the audit DB."""
+    run_id = f"run-{uuid.uuid4().hex[:8]}"
+    op = entry["op"]
+    entry_id = entry["id"]
+
+    await audit_db.record_scheduled_run_start(run_id, op, wiki, entry_id)
+    logger.info("[schedule] %s  %s  starting", run_id, op)
+
+    t0 = time.monotonic()
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-m", "synthadoc", "-w", wiki,
+            *op.split(),
+            cwd=str(wiki_root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        entries = []
-        current: dict = {}
+        stdout, stderr = await proc.communicate()
+        duration = time.monotonic() - t0
 
-        def _flush(d: dict) -> None:
-            if "id" in d and "op" in d:
-                result_raw = d.get("last_result", "")
-                last_result = (
-                    "success" if result_raw == "0"
-                    else ("N/A" if result_raw in ("", "267011") else f"failed ({result_raw})")
-                )
-                cron = d.get("cron", "")
-                next_run = d.get("next_run", "")
-                if next_run in ("N/A", ""):
-                    next_run = _cron_next_run(cron)
-                entries.append(ScheduleEntry(
-                    id=d["id"],
-                    op=d["op"],
-                    cron=cron,
-                    wiki=self._wiki,
-                    next_run=next_run,
-                    last_run=d.get("last_run", ""),
-                    last_result=last_result,
-                ))
-
-        for raw_line in result.stdout.splitlines():
-            line = raw_line.strip()
-            if line.startswith("TaskName:"):
-                _flush(current)
-                current = (
-                    {"id": line.split("synthadoc-")[-1].strip()}
-                    if "synthadoc-" in line else {}
-                )
-            elif current:
-                if line.startswith("Task To Run:"):
-                    full_cmd = line.split(":", 1)[-1].strip()
-                    m = re.search(r'--op\s+"([^"]+)"', full_cmd)
-                    current["op"] = m.group(1) if m else full_cmd
-                elif line.startswith("Next Run Time:"):
-                    current["next_run"] = line.split(":", 1)[-1].strip()
-                elif line.startswith("Last Run Time:"):
-                    val = line.split(":", 1)[-1].strip()
-                    # "11/30/1999 12:00:00 AM" is Windows' sentinel for "never run"
-                    never_run = val in ("N/A", "") or val.startswith("11/30/1999")
-                    current["last_run"] = "" if never_run else val
-                elif line.startswith("Last Result:"):
-                    current["last_result"] = line.split(":", 1)[-1].strip()
-                elif line.startswith("Start Time:"):
-                    time_str = line.split(":", 1)[-1].strip()
-                    current["cron"] = _schtasks_time_to_cron(time_str)
-
-        _flush(current)
-        return entries
-
-    # ------------------------------------------------------------------
-    # OS task removal
-    # ------------------------------------------------------------------
-
-    def _remove_os_task(self, entry_id: str) -> None:
-        if platform.system() == "Windows":
-            subprocess.run(
-                ["schtasks", "/Delete", "/TN", f"synthadoc-{entry_id}", "/F"],
-                check=True,
-            )
+        if proc.returncode == 0:
+            await audit_db.record_scheduled_run_finish(run_id, "success", duration)
+            logger.info("[schedule] %s  %s  %.1fs  success", run_id, op, duration)
         else:
-            result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
-            lines = [ln for ln in result.stdout.splitlines()
-                     if f"{self._TAG_PREFIX}{entry_id}" not in ln]
-            subprocess.run(["crontab", "-"], input="\n".join(lines) + "\n",
-                           text=True, check=True)
+            err = f"exit code {proc.returncode}"
+            if stderr:
+                err += f": {stderr.decode(errors='replace').strip()[:300]}"
+            await audit_db.record_scheduled_run_finish(run_id, "failed", duration, err)
+            logger.warning("[schedule] %s  %s  %.1fs  failed (%s)", run_id, op, duration, err)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        duration = time.monotonic() - t0
+        await audit_db.record_scheduled_run_finish(run_id, "failed", duration, str(exc))
+        logger.error("[schedule] %s  %s  failed: %s", run_id, op, exc)
 
 
 # ------------------------------------------------------------------
@@ -206,12 +176,10 @@ def _cron_next_run(cron: str) -> str:
         return ""
 
 
-def _schtasks_time_to_cron(time_str: str) -> str:
-    """Convert a schtasks Start Time string (e.g. '2:00:00 AM') to a cron expression."""
-    for fmt in ("%I:%M:%S %p", "%H:%M:%S", "%I:%M %p", "%H:%M"):
-        try:
-            t = datetime.strptime(time_str.strip(), fmt)
-            return f"{t.minute} {t.hour} * * *"
-        except ValueError:
-            continue
-    return ""
+def _matches_cron(cron: str, dt: datetime) -> bool:
+    """Return True if dt (at minute precision) matches the cron expression."""
+    try:
+        from croniter import croniter
+        return croniter.match(cron, dt)
+    except Exception:
+        return False

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import platform
+import re
+import shutil
 import subprocess
+import sys
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -54,7 +57,14 @@ class Scheduler:
             self._add_crontab_entry(op=op, cron=cron, entry_id=entry_id)
 
     def _build_run_cmd(self, op: str) -> str:
-        return f'synthadoc -w {self._wiki} schedule run --op "{op}"'
+        exe = shutil.which("synthadoc")
+        if exe:
+            prefix = f'"{exe}"' if " " in exe else exe
+        else:
+            python = sys.executable
+            python_q = f'"{python}"' if " " in python else python
+            prefix = f"{python_q} -m synthadoc"
+        return f'{prefix} -w {self._wiki} schedule run --op "{op}"'
 
     def _build_crontab_line(self, op: str, cron: str, entry_id: str) -> str:
         cmd = self._build_run_cmd(op)
@@ -97,9 +107,8 @@ class Scheduler:
             entry_id = line.split(self._TAG_PREFIX)[-1].strip()
             parts = line.split()
             cron = " ".join(parts[:5])
-            op_parts = parts[5:]
-            tag = self._TAG_PREFIX.strip()
-            op = " ".join(p for p in op_parts if not p.startswith(tag))
+            m = re.search(r'--op\s+"([^"]+)"', line)
+            op = m.group(1) if m else " ".join(parts[5:]).split(self._TAG_PREFIX)[0].strip()
             next_run = _cron_next_run(cron)
             entries.append(ScheduleEntry(
                 id=entry_id, op=op.strip(), cron=cron,
@@ -146,7 +155,9 @@ class Scheduler:
                 )
             elif current:
                 if line.startswith("Task To Run:"):
-                    current["op"] = line.split(":", 1)[-1].strip()
+                    full_cmd = line.split(":", 1)[-1].strip()
+                    m = re.search(r'--op\s+"([^"]+)"', full_cmd)
+                    current["op"] = m.group(1) if m else full_cmd
                 elif line.startswith("Next Run Time:"):
                     current["next_run"] = line.split(":", 1)[-1].strip()
                 elif line.startswith("Last Run Time:"):

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -122,21 +122,28 @@ class Scheduler:
                     "success" if result_raw == "0"
                     else ("N/A" if result_raw in ("", "267011") else f"failed ({result_raw})")
                 )
+                cron = d.get("cron", "")
+                next_run = d.get("next_run", "")
+                if next_run in ("N/A", ""):
+                    next_run = _cron_next_run(cron)
                 entries.append(ScheduleEntry(
                     id=d["id"],
                     op=d["op"],
-                    cron=d.get("cron", ""),
+                    cron=cron,
                     wiki=self._wiki,
-                    next_run=d.get("next_run", ""),
+                    next_run=next_run,
                     last_run=d.get("last_run", ""),
                     last_result=last_result,
                 ))
 
         for raw_line in result.stdout.splitlines():
             line = raw_line.strip()
-            if line.startswith("TaskName:") and "synthadoc-" in line:
+            if line.startswith("TaskName:"):
                 _flush(current)
-                current = {"id": line.split("synthadoc-")[-1].strip()}
+                current = (
+                    {"id": line.split("synthadoc-")[-1].strip()}
+                    if "synthadoc-" in line else {}
+                )
             elif current:
                 if line.startswith("Task To Run:"):
                     current["op"] = line.split(":", 1)[-1].strip()

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -146,15 +146,16 @@ async def _run_scheduled_job(
         )
         stdout, stderr = await proc.communicate()
         duration = time.monotonic() - t0
+        out = _truncate_output(stdout.decode(errors="replace").strip() if stdout else "")
 
         if proc.returncode == 0:
-            await audit_db.record_scheduled_run_finish(run_id, "success", duration)
+            await audit_db.record_scheduled_run_finish(run_id, "success", duration, output=out)
             logger.info("[schedule] %s  %s  %.1fs  success", run_id, op, duration)
         else:
             err = f"exit code {proc.returncode}"
             if stderr:
                 err += f": {stderr.decode(errors='replace').strip()[:300]}"
-            await audit_db.record_scheduled_run_finish(run_id, "failed", duration, err)
+            await audit_db.record_scheduled_run_finish(run_id, "failed", duration, err, out)
             logger.warning("[schedule] %s  %s  %.1fs  failed (%s)", run_id, op, duration, err)
     except asyncio.CancelledError:
         raise
@@ -167,6 +168,15 @@ async def _run_scheduled_job(
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
+_OUTPUT_LIMIT = 500
+
+
+def _truncate_output(text: str) -> str:
+    if len(text) <= _OUTPUT_LIMIT:
+        return text
+    return text[:_OUTPUT_LIMIT] + "…"
+
 
 def _cron_next_run(cron: str) -> str:
     """Return the next scheduled datetime string for a cron expression, or ''."""

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -295,12 +295,23 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
         await orch.init()
         app.state.orch = orch
         worker = asyncio.create_task(_worker_loop(orch))
+
+        from synthadoc.core.scheduler import run_scheduler_loop
+        audit_db = _AuditDB(wiki_root / ".synthadoc" / "audit.db")
+        await audit_db.init()
+        scheduler = asyncio.create_task(
+            run_scheduler_loop(wiki_root.name, wiki_root, audit_db)
+        )
+
         yield
+
         worker.cancel()
-        try:
-            await worker
-        except asyncio.CancelledError:
-            pass
+        scheduler.cancel()
+        for task in (worker, scheduler):
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     app = FastAPI(title="synthadoc", version=synthadoc.__version__, lifespan=lifespan)
     app.add_middleware(ContentSizeLimitMiddleware, max_bytes=max_body_bytes)

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -127,16 +127,19 @@ class AuditDB:
                     finished_at TEXT,
                     status      TEXT,
                     duration_s  REAL,
-                    error       TEXT
+                    error       TEXT,
+                    output      TEXT DEFAULT ''
                 )""")
-            # Migration: add entry_id to existing installs
-            try:
-                await db.execute(
-                    "ALTER TABLE scheduled_runs ADD COLUMN entry_id TEXT NOT NULL DEFAULT ''"
-                )
-                await db.commit()
-            except Exception:
-                pass  # column already exists
+            # Migrations for existing installs
+            for migration in (
+                "ALTER TABLE scheduled_runs ADD COLUMN entry_id TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE scheduled_runs ADD COLUMN output TEXT DEFAULT ''",
+            ):
+                try:
+                    await db.execute(migration)
+                    await db.commit()
+                except Exception:
+                    pass  # column already exists
             await db.commit()
 
     async def record_ingest(self, source_hash: str, source_size: int,
@@ -491,14 +494,16 @@ class AuditDB:
             await db.commit()
 
     async def record_scheduled_run_finish(
-        self, run_id: str, status: str, duration_s: float, error: Optional[str] = None
+        self, run_id: str, status: str, duration_s: float,
+        error: Optional[str] = None, output: str = "",
     ) -> None:
         ts = datetime.now(timezone.utc).isoformat()
         async with aiosqlite.connect(self._path) as db:
             await db.execute(
-                "UPDATE scheduled_runs SET finished_at=?, status=?, duration_s=?, error=?"
+                "UPDATE scheduled_runs"
+                " SET finished_at=?, status=?, duration_s=?, error=?, output=?"
                 " WHERE run_id=?",
-                (ts, status, round(duration_s, 2), error, run_id),
+                (ts, status, round(duration_s, 2), error, output, run_id),
             )
             await db.commit()
 
@@ -506,7 +511,8 @@ class AuditDB:
         async with aiosqlite.connect(self._path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT run_id,entry_id,op,wiki,started_at,finished_at,status,duration_s,error"
+                "SELECT run_id,entry_id,op,wiki,started_at,finished_at,"
+                "       status,duration_s,error,output"
                 " FROM scheduled_runs ORDER BY id DESC LIMIT ?",
                 (limit,),
             ) as cur:

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -120,6 +120,7 @@ class AuditDB:
                 CREATE TABLE IF NOT EXISTS scheduled_runs (
                     id          INTEGER PRIMARY KEY AUTOINCREMENT,
                     run_id      TEXT NOT NULL,
+                    entry_id    TEXT NOT NULL DEFAULT '',
                     op          TEXT NOT NULL,
                     wiki        TEXT NOT NULL,
                     started_at  TEXT NOT NULL,
@@ -128,6 +129,14 @@ class AuditDB:
                     duration_s  REAL,
                     error       TEXT
                 )""")
+            # Migration: add entry_id to existing installs
+            try:
+                await db.execute(
+                    "ALTER TABLE scheduled_runs ADD COLUMN entry_id TEXT NOT NULL DEFAULT ''"
+                )
+                await db.commit()
+            except Exception:
+                pass  # column already exists
             await db.commit()
 
     async def record_ingest(self, source_hash: str, source_size: int,
@@ -469,13 +478,15 @@ class AuditDB:
                 """, (keep_latest,))
             await db.commit()
 
-    async def record_scheduled_run_start(self, run_id: str, op: str, wiki: str) -> None:
+    async def record_scheduled_run_start(
+        self, run_id: str, op: str, wiki: str, entry_id: str = ""
+    ) -> None:
         ts = datetime.now(timezone.utc).isoformat()
         async with aiosqlite.connect(self._path) as db:
             await db.execute(
-                "INSERT INTO scheduled_runs (run_id,op,wiki,started_at,status)"
-                " VALUES (?,?,?,?,'running')",
-                (run_id, op, wiki, ts),
+                "INSERT INTO scheduled_runs (run_id,entry_id,op,wiki,started_at,status)"
+                " VALUES (?,?,?,?,?,'running')",
+                (run_id, entry_id, op, wiki, ts),
             )
             await db.commit()
 
@@ -495,9 +506,28 @@ class AuditDB:
         async with aiosqlite.connect(self._path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT run_id,op,wiki,started_at,finished_at,status,duration_s,error"
+                "SELECT run_id,entry_id,op,wiki,started_at,finished_at,status,duration_s,error"
                 " FROM scheduled_runs ORDER BY id DESC LIMIT ?",
                 (limit,),
             ) as cur:
                 rows = await cur.fetchall()
         return [dict(r) for r in rows]
+
+    async def get_last_run_per_entry(self) -> dict[str, dict]:
+        """Return {entry_id: {started_at, status}} for the most recent run per entry."""
+        async with aiosqlite.connect(self._path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT sr.entry_id, sr.started_at, sr.status
+                FROM scheduled_runs sr
+                INNER JOIN (
+                    SELECT entry_id, MAX(id) AS max_id
+                    FROM scheduled_runs
+                    WHERE entry_id != ''
+                    GROUP BY entry_id
+                ) latest ON sr.id = latest.max_id
+                """
+            ) as cur:
+                rows = await cur.fetchall()
+        return {r["entry_id"]: dict(r) for r in rows}

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -116,6 +116,18 @@ class AuditDB:
                     triggered_by TEXT NOT NULL,
                     timestamp    TEXT NOT NULL
                 )""")
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS scheduled_runs (
+                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id      TEXT NOT NULL,
+                    op          TEXT NOT NULL,
+                    wiki        TEXT NOT NULL,
+                    started_at  TEXT NOT NULL,
+                    finished_at TEXT,
+                    status      TEXT,
+                    duration_s  REAL,
+                    error       TEXT
+                )""")
             await db.commit()
 
     async def record_ingest(self, source_hash: str, source_size: int,
@@ -456,3 +468,36 @@ class AuditDB:
                     )
                 """, (keep_latest,))
             await db.commit()
+
+    async def record_scheduled_run_start(self, run_id: str, op: str, wiki: str) -> None:
+        ts = datetime.now(timezone.utc).isoformat()
+        async with aiosqlite.connect(self._path) as db:
+            await db.execute(
+                "INSERT INTO scheduled_runs (run_id,op,wiki,started_at,status)"
+                " VALUES (?,?,?,?,'running')",
+                (run_id, op, wiki, ts),
+            )
+            await db.commit()
+
+    async def record_scheduled_run_finish(
+        self, run_id: str, status: str, duration_s: float, error: Optional[str] = None
+    ) -> None:
+        ts = datetime.now(timezone.utc).isoformat()
+        async with aiosqlite.connect(self._path) as db:
+            await db.execute(
+                "UPDATE scheduled_runs SET finished_at=?, status=?, duration_s=?, error=?"
+                " WHERE run_id=?",
+                (ts, status, round(duration_s, 2), error, run_id),
+            )
+            await db.commit()
+
+    async def list_scheduled_runs(self, limit: int = 20) -> list[dict]:
+        async with aiosqlite.connect(self._path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT run_id,op,wiki,started_at,finished_at,status,duration_s,error"
+                " FROM scheduled_runs ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ) as cur:
+                rows = await cur.fetchall()
+        return [dict(r) for r in rows]

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -46,6 +46,9 @@ def test_schedule_list_shows_entries(tmp_path):
     entry.id = "sched-001"
     entry.cron = "0 * * * *"
     entry.op = "lint"
+    entry.next_run = "2026-05-31 02:00"
+    entry.last_run = "2026-05-30 02:00"
+    entry.last_result = "success"
     mock_sched = MagicMock()
     mock_sched.list.return_value = [entry]
     with patch("synthadoc.core.scheduler.Scheduler", return_value=mock_sched):

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
@@ -77,6 +78,23 @@ def test_schedule_remove_calls_scheduler(tmp_path):
     assert result.exit_code == 0, result.output
     assert "sched-001" in result.output
     mock_sched.remove.assert_called_once_with("sched-001")
+
+
+def test_schedule_run_uses_wiki_root_as_cwd(tmp_path):
+    """schedule run must set cwd=wiki_root so relative paths like raw_sources/ resolve correctly."""
+    wiki = _make_wiki(tmp_path)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return MagicMock(returncode=0)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        result = runner.invoke(app, [
+            "schedule", "run", "--op", "lint run", "--wiki", str(wiki),
+        ])
+    assert result.exit_code == 0, result.output
+    assert captured["cwd"] == str(wiki)
 
 
 def test_schedule_apply_registers_jobs(tmp_path):

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
-import platform
-import pytest
-from unittest.mock import MagicMock, patch
 from synthadoc.core.scheduler import Scheduler, ScheduleEntry
 
 
@@ -12,117 +9,15 @@ def test_schedule_entry_parses_cron():
     assert entry.cron == "0 3 * * 0"
 
 
-def test_scheduler_add_returns_id():
-    sched = Scheduler(wiki="research", wiki_root="/tmp/wiki")
-    with patch.object(sched, "_register_os_task", return_value="sched-001"):
-        entry_id = sched.add(op="lint", cron="0 3 * * 0")
-    assert entry_id.startswith("sched-")
-
-
-def test_scheduler_list_returns_registered_entries():
-    sched = Scheduler(wiki="research", wiki_root="/tmp/wiki")
-    with patch.object(sched, "_list_os_tasks", return_value=[
-        ScheduleEntry(id="s1", op="lint", cron="0 3 * * 0", wiki="research"),
-    ]):
-        entries = sched.list()
-    assert len(entries) == 1
-    assert entries[0].op == "lint"
-
-
-def test_scheduler_remove_calls_os():
-    sched = Scheduler(wiki="research", wiki_root="/tmp/wiki")
-    with patch.object(sched, "_remove_os_task") as mock_remove:
-        sched.remove("sched-001")
-    mock_remove.assert_called_once_with("sched-001")
-
-
-@pytest.mark.skipif(platform.system() != "Linux", reason="crontab only on Linux/macOS")
-def test_scheduler_linux_generates_crontab_entry(tmp_path):
-    sched = Scheduler(wiki="research", wiki_root=str(tmp_path))
-    line = sched._build_crontab_line(op="lint", cron="0 3 * * 0", entry_id="s1")
-    assert "0 3 * * 0" in line
-    assert "synthadoc" in line
-    assert "lint" in line
-    assert "# synthadoc:s1" in line
-
-
-@pytest.mark.skipif(platform.system() != "Windows", reason="schtasks only on Windows")
-def test_scheduler_windows_generates_schtasks_args(tmp_path):
-    sched = Scheduler(wiki="research", wiki_root=str(tmp_path))
-    args = sched._build_schtasks_args(op="lint", cron="0 3 * * 0", entry_id="s1")
-    assert "/TN" in args
-    assert "synthadoc-s1" in " ".join(args)
-
-
-_CRONTAB_OUTPUT = (
-    "# other line\n"
-    "0 2 * * * synthadoc -w my-wiki lint run # synthadoc:sched-abc123\n"
-    "30 14 * * * synthadoc -w my-wiki ingest run # synthadoc:sched-def456\n"
-)
-
-
-def test_list_crontab_parses_tagged_lines():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=_CRONTAB_OUTPUT)):
-        entries = sched._list_crontab()
-    assert len(entries) == 2
-    assert {e.id for e in entries} == {"sched-abc123", "sched-def456"}
-
-
-def test_list_crontab_empty_crontab():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("subprocess.run", return_value=MagicMock(returncode=1, stdout="")):
-        entries = sched._list_crontab()
-    assert entries == []
-
-
-def test_list_crontab_no_synthadoc_lines():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="0 5 * * * /usr/bin/backup\n")):
-        entries = sched._list_crontab()
-    assert entries == []
-
-
-_SCHTASKS_OUTPUT = (
-    "TaskName:                             \\synthadoc-sched-win1\n"
-    "Task To Run:                          synthadoc -w my-wiki lint run\n"
-    "\n"
-    "TaskName:                             \\other-task\n"
-    "Task To Run:                          notepad.exe\n"
-)
-
-
-def test_list_schtasks_parses_entries():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=_SCHTASKS_OUTPUT)):
-        entries = sched._list_schtasks()
-    assert len(entries) == 1
-    assert entries[0].id == "sched-win1"
-
-
-def test_add_crontab_entry_calls_subprocess():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    mock_run = MagicMock(return_value=MagicMock(returncode=0, stdout=""))
-    with patch("subprocess.run", mock_run):
-        sched._add_crontab_entry(op="lint run", cron="0 2 * * *", entry_id="sched-001")
-    assert mock_run.call_count == 2  # crontab -l, then crontab -
-
-
-def test_apply_returns_ids():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch.object(sched, "add", side_effect=lambda op, cron: f"sched-{op[:4]}"):
-        jobs = [
-            ScheduleEntry(op="lint run", cron="0 2 * * *", wiki="my-wiki"),
-            ScheduleEntry(op="ingest run", cron="0 3 * * *", wiki="my-wiki"),
-        ]
-        ids = sched.apply(jobs)
+def test_apply_returns_ids(tmp_path):
+    sched = Scheduler(wiki="my-wiki", wiki_root=str(tmp_path))
+    jobs = [
+        ScheduleEntry(op="lint run", cron="0 2 * * *", wiki="my-wiki"),
+        ScheduleEntry(op="ingest run", cron="0 3 * * *", wiki="my-wiki"),
+    ]
+    ids = sched.apply(jobs)
     assert len(ids) == 2
-
-
-def test_build_schtasks_args_zero_padded():
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    args = sched._build_schtasks_args(op="lint run", cron="5 9 * * *", entry_id="sched-001")
-    assert "09:05" in args
+    assert all(i.startswith("sched-") for i in ids)
 
 
 def test_scheduler_apply_from_config(tmp_path):

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -7,7 +7,6 @@ test suite, chosen to maximise statement coverage with minimal test complexity.
 """
 from __future__ import annotations
 
-import platform
 from pathlib import Path
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -53,68 +52,6 @@ def test_cost_guard_interactive_proceeds_on_y():
             CostEstimate(tokens=10000, cost_usd=1.00, operation="batch"),
             auto_confirm=False, interactive=True
         )
-
-
-# ── core/scheduler.py ─────────────────────────────────────────────────────────
-
-def test_scheduler_register_os_task_windows():
-    """_register_os_task routes to schtasks on Windows."""
-    from synthadoc.core.scheduler import Scheduler
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("platform.system", return_value="Windows"), \
-         patch.object(sched, "_build_schtasks_args", return_value=["arg"]) as mock_args, \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0)
-        sched._register_os_task(op="lint run", cron="0 3 * * 0", entry_id="s1")
-    mock_args.assert_called_once()
-    mock_run.assert_called_once()
-
-
-def test_scheduler_register_os_task_linux():
-    """_register_os_task routes to crontab on non-Windows."""
-    from synthadoc.core.scheduler import Scheduler
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("platform.system", return_value="Linux"), \
-         patch.object(sched, "_add_crontab_entry") as mock_cron:
-        sched._register_os_task(op="lint run", cron="0 3 * * 0", entry_id="s1")
-    mock_cron.assert_called_once_with(op="lint run", cron="0 3 * * 0", entry_id="s1")
-
-
-def test_scheduler_list_os_tasks_windows():
-    """_list_os_tasks routes to _list_schtasks on Windows."""
-    from synthadoc.core.scheduler import Scheduler
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("platform.system", return_value="Windows"), \
-         patch.object(sched, "_list_schtasks", return_value=[]) as mock_list:
-        sched._list_os_tasks()
-    mock_list.assert_called_once()
-
-
-def test_scheduler_remove_os_task_windows():
-    """_remove_os_task calls schtasks /Delete on Windows."""
-    from synthadoc.core.scheduler import Scheduler
-    import subprocess
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    with patch("platform.system", return_value="Windows"), \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0)
-        sched._remove_os_task("sched-win1")
-    call_args = mock_run.call_args[0][0]
-    assert "/Delete" in call_args
-    assert "synthadoc-sched-win1" in call_args
-
-
-def test_scheduler_remove_os_task_linux():
-    """_remove_os_task rewrites crontab on non-Windows."""
-    from synthadoc.core.scheduler import Scheduler
-    sched = Scheduler(wiki="my-wiki", wiki_root="/wikis/my-wiki")
-    existing = "0 2 * * * cmd # synthadoc:sched-001\n0 3 * * * other\n"
-    with patch("platform.system", return_value="Linux"), \
-         patch("subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout=existing)
-        sched._remove_os_task("sched-001")
-    # Second call writes new crontab (with the entry removed)
-    assert mock_run.call_count == 2
 
 
 # ── cli/ingest.py ─────────────────────────────────────────────────────────────

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,32 +1,23 @@
 # tests/test_schedule.py
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
-#
-# Platform markers:
-#   pytest -m windows   — run only on Windows
-#   pytest -m linux     — run only on Linux
-#   pytest -m macos     — run only on macOS
-#   pytest -m "not (windows or linux or macos)"  — cross-platform tests only
-import platform
+import json
 import pytest
+from datetime import datetime
 from pathlib import Path
 from synthadoc.storage.log import AuditDB
-from synthadoc.core.scheduler import _cron_next_run, _schtasks_time_to_cron, Scheduler
-
-windows = pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
-linux   = pytest.mark.skipif(platform.system() != "Linux",   reason="Linux only")
-macos   = pytest.mark.skipif(platform.system() != "Darwin",  reason="macOS only")
-posix   = pytest.mark.skipif(platform.system() == "Windows", reason="POSIX only")
+from synthadoc.core.scheduler import (
+    Scheduler, ScheduleEntry, _cron_next_run, _matches_cron,
+)
 
 
 # ------------------------------------------------------------------
-# Fix 1 helpers
+# _cron_next_run helpers
 # ------------------------------------------------------------------
 
 def test_cron_next_run_returns_future_datetime():
     result = _cron_next_run("0 2 * * *")
     assert result != ""
-    # Should be a date string like "2026-05-31 02:00"
     assert len(result) == 16
     assert ":" in result
 
@@ -35,24 +26,35 @@ def test_cron_next_run_invalid_returns_empty():
     assert _cron_next_run("not a cron") == ""
 
 
-def test_schtasks_time_to_cron_am():
-    assert _schtasks_time_to_cron("2:00:00 AM") == "0 2 * * *"
+# ------------------------------------------------------------------
+# _matches_cron
+# ------------------------------------------------------------------
+
+def test_matches_cron_true_at_scheduled_time():
+    # 0 2 * * * fires at 02:00 on any day
+    dt = datetime(2026, 5, 31, 2, 0, 0)
+    assert _matches_cron("0 2 * * *", dt) is True
 
 
-def test_schtasks_time_to_cron_pm():
-    assert _schtasks_time_to_cron("11:30:00 PM") == "30 23 * * *"
+def test_matches_cron_false_at_wrong_minute():
+    dt = datetime(2026, 5, 31, 2, 1, 0)
+    assert _matches_cron("0 2 * * *", dt) is False
 
 
-def test_schtasks_time_to_cron_24h():
-    assert _schtasks_time_to_cron("14:15:00") == "15 14 * * *"
+def test_matches_cron_false_at_wrong_hour():
+    dt = datetime(2026, 5, 31, 3, 0, 0)
+    assert _matches_cron("0 2 * * *", dt) is False
 
 
-def test_schtasks_time_to_cron_invalid_returns_empty():
-    assert _schtasks_time_to_cron("garbage") == ""
+def test_matches_cron_invalid_returns_false():
+    assert _matches_cron("not a cron", datetime.now()) is False
 
+
+# ------------------------------------------------------------------
+# ScheduleEntry defaults
+# ------------------------------------------------------------------
 
 def test_schedule_entry_defaults():
-    from synthadoc.core.scheduler import ScheduleEntry
     e = ScheduleEntry(op="lint run", cron="0 2 * * *", wiki="mywiki")
     assert e.next_run == ""
     assert e.last_run == ""
@@ -60,43 +62,89 @@ def test_schedule_entry_defaults():
     assert e.id.startswith("sched-")
 
 
-def test_build_run_cmd_uses_schedule_run(tmp_path):
+# ------------------------------------------------------------------
+# Scheduler — JSON storage
+# ------------------------------------------------------------------
+
+def test_scheduler_add_creates_json_entry(tmp_path):
     sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    cmd = sched._build_run_cmd("lint run")
-    assert "schedule run" in cmd
-    assert '--op "lint run"' in cmd
-    assert "-w mywiki" in cmd
+    entry_id = sched.add(op="lint run", cron="0 2 * * *")
+    assert entry_id.startswith("sched-")
+    data = json.loads((tmp_path / ".synthadoc" / "schedules.json").read_text())
+    assert len(data) == 1
+    assert data[0]["id"] == entry_id
+    assert data[0]["op"] == "lint run"
+    assert data[0]["cron"] == "0 2 * * *"
 
 
-def test_build_crontab_line_uses_schedule_run(tmp_path):
+def test_scheduler_add_multiple_entries(tmp_path):
     sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    line = sched._build_crontab_line("lint run", "0 2 * * *", "sched-abc")
-    assert "schedule run" in line
-    assert "0 2 * * *" in line
-    assert "sched-abc" in line
+    id1 = sched.add(op="lint run", cron="0 2 * * *")
+    id2 = sched.add(op="scaffold", cron="0 3 * * 0")
+    data = json.loads((tmp_path / ".synthadoc" / "schedules.json").read_text())
+    assert len(data) == 2
+    assert {d["id"] for d in data} == {id1, id2}
 
 
-def test_build_schtasks_args_uses_schedule_run(tmp_path):
+def test_scheduler_remove_deletes_entry(tmp_path):
     sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    args = sched._build_schtasks_args("lint run", "0 2 * * *", "sched-abc")
-    tr_idx = args.index("/TR")
-    cmd = args[tr_idx + 1]
-    assert "schedule run" in cmd
-    assert '--op "lint run"' in cmd
+    id1 = sched.add(op="lint run", cron="0 2 * * *")
+    id2 = sched.add(op="scaffold", cron="0 3 * * 0")
+    sched.remove(id1)
+    data = json.loads((tmp_path / ".synthadoc" / "schedules.json").read_text())
+    assert len(data) == 1
+    assert data[0]["id"] == id2
+
+
+def test_scheduler_remove_nonexistent_is_noop(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    sched.add(op="lint run", cron="0 2 * * *")
+    sched.remove("sched-doesnotexist")
+    data = json.loads((tmp_path / ".synthadoc" / "schedules.json").read_text())
+    assert len(data) == 1
+
+
+def test_scheduler_list_returns_entries_with_next_run(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    sched.add(op="lint run", cron="0 2 * * *")
+    entries = sched.list()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.op == "lint run"
+    assert e.cron == "0 2 * * *"
+    assert e.next_run != ""   # computed by croniter
+
+
+def test_scheduler_list_empty_without_file(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    assert sched.list() == []
+
+
+def test_scheduler_apply_adds_all_jobs(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    jobs = [
+        ScheduleEntry(op="lint run", cron="0 2 * * *", wiki="mywiki"),
+        ScheduleEntry(op="scaffold", cron="0 3 * * 0", wiki="mywiki"),
+    ]
+    ids = sched.apply(jobs)
+    assert len(ids) == 2
+    data = json.loads((tmp_path / ".synthadoc" / "schedules.json").read_text())
+    assert len(data) == 2
 
 
 # ------------------------------------------------------------------
-# Fix 3 — AuditDB scheduled_runs
+# AuditDB scheduled_runs
 # ------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_record_scheduled_run_start(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
-    await db.record_scheduled_run_start("run-abc", "lint run", "mywiki")
+    await db.record_scheduled_run_start("run-abc", "lint run", "mywiki", "sched-001")
     runs = await db.list_scheduled_runs()
     assert len(runs) == 1
     assert runs[0]["run_id"] == "run-abc"
+    assert runs[0]["entry_id"] == "sched-001"
     assert runs[0]["op"] == "lint run"
     assert runs[0]["status"] == "running"
     assert runs[0]["finished_at"] is None
@@ -106,7 +154,7 @@ async def test_record_scheduled_run_start(tmp_path):
 async def test_record_scheduled_run_finish_success(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
-    await db.record_scheduled_run_start("run-xyz", "lint run", "mywiki")
+    await db.record_scheduled_run_start("run-xyz", "lint run", "mywiki", "sched-001")
     await db.record_scheduled_run_finish("run-xyz", "success", 42.5)
     runs = await db.list_scheduled_runs()
     r = runs[0]
@@ -120,24 +168,22 @@ async def test_record_scheduled_run_finish_success(tmp_path):
 async def test_record_scheduled_run_finish_failed(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
-    await db.record_scheduled_run_start("run-fail", "lint run", "mywiki")
+    await db.record_scheduled_run_start("run-fail", "lint run", "mywiki", "sched-001")
     await db.record_scheduled_run_finish("run-fail", "failed", 3.2, "exit code 1")
     runs = await db.list_scheduled_runs()
-    r = runs[0]
-    assert r["status"] == "failed"
-    assert r["error"] == "exit code 1"
+    assert runs[0]["status"] == "failed"
+    assert runs[0]["error"] == "exit code 1"
 
 
 @pytest.mark.asyncio
 async def test_list_scheduled_runs_ordered_desc(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
-    await db.record_scheduled_run_start("run-1", "lint run", "mywiki")
-    await db.record_scheduled_run_start("run-2", "lint run", "mywiki")
-    await db.record_scheduled_run_start("run-3", "lint run", "mywiki")
+    for i in range(3):
+        await db.record_scheduled_run_start(f"run-{i}", "lint run", "mywiki", f"sched-{i:03d}")
     runs = await db.list_scheduled_runs()
-    assert runs[0]["run_id"] == "run-3"  # most recent first
-    assert runs[-1]["run_id"] == "run-1"
+    assert runs[0]["run_id"] == "run-2"
+    assert runs[-1]["run_id"] == "run-0"
 
 
 @pytest.mark.asyncio
@@ -145,131 +191,22 @@ async def test_list_scheduled_runs_respects_limit(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
     for i in range(5):
-        await db.record_scheduled_run_start(f"run-{i}", "lint run", "mywiki")
+        await db.record_scheduled_run_start(f"run-{i}", "lint run", "mywiki", f"sched-{i:03d}")
     runs = await db.list_scheduled_runs(limit=3)
     assert len(runs) == 3
 
 
-# ------------------------------------------------------------------
-# Platform-specific: Windows (schtasks)
-# Run with: pytest -m windows
-# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_get_last_run_per_entry(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_scheduled_run_start("run-1", "lint run", "mywiki", "sched-aaa")
+    await db.record_scheduled_run_finish("run-1", "success", 10.0)
+    await db.record_scheduled_run_start("run-2", "lint run", "mywiki", "sched-aaa")
+    await db.record_scheduled_run_finish("run-2", "failed", 1.0, "oops")
+    await db.record_scheduled_run_start("run-3", "scaffold", "mywiki", "sched-bbb")
+    await db.record_scheduled_run_finish("run-3", "success", 5.0)
 
-@windows
-def test_windows_build_schtasks_args_daily(tmp_path):
-    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    args = sched._build_schtasks_args("lint run", "0 2 * * *", "sched-test")
-    assert "/SC" in args
-    sc_idx = args.index("/SC")
-    assert args[sc_idx + 1] == "DAILY"
-    st_idx = args.index("/ST")
-    assert args[st_idx + 1] == "02:00"
-
-
-@windows
-def test_windows_schtasks_time_roundtrip():
-    assert _schtasks_time_to_cron("2:00:00 AM") == "0 2 * * *"
-    assert _schtasks_time_to_cron("11:45:00 PM") == "45 23 * * *"
-    assert _schtasks_time_to_cron("12:00:00 AM") == "0 0 * * *"
-
-
-@windows
-def test_windows_list_schtasks_parses_next_run(tmp_path, monkeypatch):
-    """_list_schtasks parses Next Run Time and Last Result from schtasks output."""
-    import subprocess
-    fake_output = (
-        "TaskName:                             \\synthadoc-sched-abc123\n"
-        "Next Run Time:                        5/31/2026 2:00:00 AM\n"
-        "Last Run Time:                        5/30/2026 2:00:00 AM\n"
-        "Last Result:                          0\n"
-        "Task To Run:                          synthadoc -w mywiki schedule run --op \"lint run\"\n"
-        "Start Time:                           2:00:00 AM\n"
-    )
-    mock_result = type("R", (), {"stdout": fake_output, "returncode": 0})()
-    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
-    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    entries = sched._list_schtasks()
-    assert len(entries) == 1
-    e = entries[0]
-    assert e.id == "sched-abc123"
-    assert e.op == "lint run"          # extracted from --op, not the full command
-    assert e.next_run == "5/31/2026 2:00:00 AM"
-    assert e.last_run == "5/30/2026 2:00:00 AM"
-    assert e.last_result == "success"
-    assert e.cron == "0 2 * * *"
-
-
-@windows
-def test_windows_list_schtasks_ignores_system_task_contamination(tmp_path, monkeypatch):
-    """Fields from non-synthadoc tasks must not contaminate a preceding synthadoc entry."""
-    import subprocess
-    fake_output = (
-        # synthadoc task
-        "TaskName:                             \\synthadoc-sched-abc123\n"
-        "Next Run Time:                        5/31/2026 10:00:00 PM\n"
-        "Last Run Time:                        N/A\n"
-        "Last Result:                          267011\n"
-        "Task To Run:                          synthadoc -w mywiki schedule run --op \"lint run\"\n"
-        "Start Time:                           10:00:00 PM\n"
-        # unrelated system task immediately after — should NOT bleed into our entry
-        "TaskName:                             \\Microsoft\\Windows\\SomeSystemTask\n"
-        "Task To Run:                          COM handler\n"
-        "Last Run Time:                        5/30/2026 11:32:01 AM\n"
-        "Last Result:                          0\n"
-        "Start Time:                           11:33:00 AM\n"
-    )
-    mock_result = type("R", (), {"stdout": fake_output, "returncode": 0})()
-    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
-    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    entries = sched._list_schtasks()
-    assert len(entries) == 1
-    e = entries[0]
-    assert e.cron == "0 22 * * *"           # Start Time 10:00:00 PM
-    assert e.op != "COM handler"
-    assert e.last_run == ""                 # N/A → cleared
-    assert e.last_result == "N/A"           # code 267011
-
-
-# ------------------------------------------------------------------
-# Platform-specific: Linux / macOS (crontab)
-# Run with: pytest -m posix
-# ------------------------------------------------------------------
-
-@posix
-def test_posix_crontab_line_format(tmp_path):
-    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    line = sched._build_crontab_line("lint run", "0 2 * * *", "sched-abc")
-    assert line.startswith("0 2 * * *")
-    assert 'schedule run --op "lint run"' in line
-    assert "# synthadoc:sched-abc" in line
-
-
-@posix
-def test_posix_list_crontab_parses_next_run(tmp_path, monkeypatch):
-    """_list_crontab parses entry and computes next_run via croniter."""
-    import subprocess
-    fake_crontab = (
-        '0 2 * * * synthadoc -w mywiki schedule run --op "lint run" # synthadoc:sched-xyz\n'
-    )
-    mock_result = type("R", (), {"stdout": fake_crontab, "returncode": 0})()
-    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
-    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
-    entries = sched._list_crontab()
-    assert len(entries) == 1
-    e = entries[0]
-    assert e.id == "sched-xyz"
-    assert e.op == "lint run"   # extracted from --op, not the full command
-    assert e.cron == "0 2 * * *"
-    assert e.next_run != ""     # croniter computed a future datetime
-    assert e.last_run == ""     # not available in crontab
-    assert e.last_result == ""  # not available in crontab
-
-
-@posix
-def test_posix_cron_next_run_is_future():
-    from datetime import datetime, timezone
-    result = _cron_next_run("0 2 * * *")
-    assert result != ""
-    dt = datetime.strptime(result, "%Y-%m-%d %H:%M")
-    # next run must be in the future relative to now
-    assert dt >= datetime.now().replace(second=0, microsecond=0)
+    last = await db.get_last_run_per_entry()
+    assert last["sched-aaa"]["status"] == "failed"   # most recent for aaa
+    assert last["sched-bbb"]["status"] == "success"

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from synthadoc.storage.log import AuditDB
 from synthadoc.core.scheduler import (
-    Scheduler, ScheduleEntry, _cron_next_run, _matches_cron,
+    Scheduler, ScheduleEntry, _cron_next_run, _matches_cron, _format_run_ts,
 )
 
 
@@ -24,6 +24,31 @@ def test_cron_next_run_returns_future_datetime():
 
 def test_cron_next_run_invalid_returns_empty():
     assert _cron_next_run("not a cron") == ""
+
+
+# ------------------------------------------------------------------
+# _format_run_ts
+# ------------------------------------------------------------------
+
+def test_format_run_ts_converts_utc_iso_to_local():
+    # UTC ISO string — must come back as YYYY-MM-DD HH:MM (16 chars, no tz suffix)
+    result = _format_run_ts("2026-05-31T03:04:00.014163+00:00")
+    assert len(result) == 16
+    assert "T" not in result
+    assert "+" not in result
+
+
+def test_format_run_ts_naive_iso_passthrough():
+    result = _format_run_ts("2026-05-30T22:04:00")
+    assert result == "2026-05-30 22:04"
+
+
+def test_format_run_ts_empty_returns_empty():
+    assert _format_run_ts("") == ""
+
+
+def test_format_run_ts_invalid_returns_original():
+    assert _format_run_ts("not-a-date") == "not-a-date"
 
 
 # ------------------------------------------------------------------

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from synthadoc.storage.log import AuditDB
 from synthadoc.core.scheduler import (
     Scheduler, ScheduleEntry, _cron_next_run, _matches_cron, _format_run_ts,
+    _truncate_output,
 )
 
 
@@ -180,13 +181,15 @@ async def test_record_scheduled_run_finish_success(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
     await db.record_scheduled_run_start("run-xyz", "lint run", "mywiki", "sched-001")
-    await db.record_scheduled_run_finish("run-xyz", "success", 42.5)
+    await db.record_scheduled_run_finish("run-xyz", "success", 42.5,
+                                         output="Checked 42 pages. 0 issues.")
     runs = await db.list_scheduled_runs()
     r = runs[0]
     assert r["status"] == "success"
     assert r["duration_s"] == 42.5
     assert r["error"] is None
     assert r["finished_at"] is not None
+    assert r["output"] == "Checked 42 pages. 0 issues."
 
 
 @pytest.mark.asyncio
@@ -194,10 +197,36 @@ async def test_record_scheduled_run_finish_failed(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()
     await db.record_scheduled_run_start("run-fail", "lint run", "mywiki", "sched-001")
-    await db.record_scheduled_run_finish("run-fail", "failed", 3.2, "exit code 1")
+    await db.record_scheduled_run_finish("run-fail", "failed", 3.2, "exit code 1",
+                                         output="partial stdout before crash")
     runs = await db.list_scheduled_runs()
     assert runs[0]["status"] == "failed"
     assert runs[0]["error"] == "exit code 1"
+    assert runs[0]["output"] == "partial stdout before crash"
+
+
+# ------------------------------------------------------------------
+# _truncate_output
+# ------------------------------------------------------------------
+
+def test_truncate_output_short_passthrough():
+    assert _truncate_output("short") == "short"
+
+
+def test_truncate_output_empty():
+    assert _truncate_output("") == ""
+
+
+def test_truncate_output_at_limit_exact():
+    text = "x" * 500
+    assert _truncate_output(text) == text
+
+
+def test_truncate_output_over_limit_appends_ellipsis():
+    text = "x" * 501
+    result = _truncate_output(text)
+    assert result.endswith("…")
+    assert len(result) == 501  # 500 chars + ellipsis
 
 
 @pytest.mark.asyncio

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,242 @@
+# tests/test_schedule.py
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+#
+# Platform markers:
+#   pytest -m windows   — run only on Windows
+#   pytest -m linux     — run only on Linux
+#   pytest -m macos     — run only on macOS
+#   pytest -m "not (windows or linux or macos)"  — cross-platform tests only
+import platform
+import pytest
+from pathlib import Path
+from synthadoc.storage.log import AuditDB
+from synthadoc.core.scheduler import _cron_next_run, _schtasks_time_to_cron, Scheduler
+
+windows = pytest.mark.skipif(platform.system() != "Windows", reason="Windows only")
+linux   = pytest.mark.skipif(platform.system() != "Linux",   reason="Linux only")
+macos   = pytest.mark.skipif(platform.system() != "Darwin",  reason="macOS only")
+posix   = pytest.mark.skipif(platform.system() == "Windows", reason="POSIX only")
+
+
+# ------------------------------------------------------------------
+# Fix 1 helpers
+# ------------------------------------------------------------------
+
+def test_cron_next_run_returns_future_datetime():
+    result = _cron_next_run("0 2 * * *")
+    assert result != ""
+    # Should be a date string like "2026-05-31 02:00"
+    assert len(result) == 16
+    assert ":" in result
+
+
+def test_cron_next_run_invalid_returns_empty():
+    assert _cron_next_run("not a cron") == ""
+
+
+def test_schtasks_time_to_cron_am():
+    assert _schtasks_time_to_cron("2:00:00 AM") == "0 2 * * *"
+
+
+def test_schtasks_time_to_cron_pm():
+    assert _schtasks_time_to_cron("11:30:00 PM") == "30 23 * * *"
+
+
+def test_schtasks_time_to_cron_24h():
+    assert _schtasks_time_to_cron("14:15:00") == "15 14 * * *"
+
+
+def test_schtasks_time_to_cron_invalid_returns_empty():
+    assert _schtasks_time_to_cron("garbage") == ""
+
+
+def test_schedule_entry_defaults():
+    from synthadoc.core.scheduler import ScheduleEntry
+    e = ScheduleEntry(op="lint run", cron="0 2 * * *", wiki="mywiki")
+    assert e.next_run == ""
+    assert e.last_run == ""
+    assert e.last_result == ""
+    assert e.id.startswith("sched-")
+
+
+def test_build_run_cmd_uses_schedule_run(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    cmd = sched._build_run_cmd("lint run")
+    assert "schedule run" in cmd
+    assert '--op "lint run"' in cmd
+    assert "-w mywiki" in cmd
+
+
+def test_build_crontab_line_uses_schedule_run(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    line = sched._build_crontab_line("lint run", "0 2 * * *", "sched-abc")
+    assert "schedule run" in line
+    assert "0 2 * * *" in line
+    assert "sched-abc" in line
+
+
+def test_build_schtasks_args_uses_schedule_run(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    args = sched._build_schtasks_args("lint run", "0 2 * * *", "sched-abc")
+    tr_idx = args.index("/TR")
+    cmd = args[tr_idx + 1]
+    assert "schedule run" in cmd
+    assert '--op "lint run"' in cmd
+
+
+# ------------------------------------------------------------------
+# Fix 3 — AuditDB scheduled_runs
+# ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_record_scheduled_run_start(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_scheduled_run_start("run-abc", "lint run", "mywiki")
+    runs = await db.list_scheduled_runs()
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == "run-abc"
+    assert runs[0]["op"] == "lint run"
+    assert runs[0]["status"] == "running"
+    assert runs[0]["finished_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_record_scheduled_run_finish_success(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_scheduled_run_start("run-xyz", "lint run", "mywiki")
+    await db.record_scheduled_run_finish("run-xyz", "success", 42.5)
+    runs = await db.list_scheduled_runs()
+    r = runs[0]
+    assert r["status"] == "success"
+    assert r["duration_s"] == 42.5
+    assert r["error"] is None
+    assert r["finished_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_record_scheduled_run_finish_failed(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_scheduled_run_start("run-fail", "lint run", "mywiki")
+    await db.record_scheduled_run_finish("run-fail", "failed", 3.2, "exit code 1")
+    runs = await db.list_scheduled_runs()
+    r = runs[0]
+    assert r["status"] == "failed"
+    assert r["error"] == "exit code 1"
+
+
+@pytest.mark.asyncio
+async def test_list_scheduled_runs_ordered_desc(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_scheduled_run_start("run-1", "lint run", "mywiki")
+    await db.record_scheduled_run_start("run-2", "lint run", "mywiki")
+    await db.record_scheduled_run_start("run-3", "lint run", "mywiki")
+    runs = await db.list_scheduled_runs()
+    assert runs[0]["run_id"] == "run-3"  # most recent first
+    assert runs[-1]["run_id"] == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_list_scheduled_runs_respects_limit(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    for i in range(5):
+        await db.record_scheduled_run_start(f"run-{i}", "lint run", "mywiki")
+    runs = await db.list_scheduled_runs(limit=3)
+    assert len(runs) == 3
+
+
+# ------------------------------------------------------------------
+# Platform-specific: Windows (schtasks)
+# Run with: pytest -m windows
+# ------------------------------------------------------------------
+
+@windows
+def test_windows_build_schtasks_args_daily(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    args = sched._build_schtasks_args("lint run", "0 2 * * *", "sched-test")
+    assert "/SC" in args
+    sc_idx = args.index("/SC")
+    assert args[sc_idx + 1] == "DAILY"
+    st_idx = args.index("/ST")
+    assert args[st_idx + 1] == "02:00"
+
+
+@windows
+def test_windows_schtasks_time_roundtrip():
+    assert _schtasks_time_to_cron("2:00:00 AM") == "0 2 * * *"
+    assert _schtasks_time_to_cron("11:45:00 PM") == "45 23 * * *"
+    assert _schtasks_time_to_cron("12:00:00 AM") == "0 0 * * *"
+
+
+@windows
+def test_windows_list_schtasks_parses_next_run(tmp_path, monkeypatch):
+    """_list_schtasks parses Next Run Time and Last Result from schtasks output."""
+    import subprocess
+    fake_output = (
+        "TaskName:                             \\synthadoc-sched-abc123\n"
+        "Next Run Time:                        5/31/2026 2:00:00 AM\n"
+        "Last Run Time:                        5/30/2026 2:00:00 AM\n"
+        "Last Result:                          0\n"
+        "Task To Run:                          synthadoc -w mywiki schedule run --op \"lint run\"\n"
+        "Start Time:                           2:00:00 AM\n"
+    )
+    mock_result = type("R", (), {"stdout": fake_output, "returncode": 0})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    entries = sched._list_schtasks()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.id == "sched-abc123"
+    assert e.next_run == "5/31/2026 2:00:00 AM"
+    assert e.last_run == "5/30/2026 2:00:00 AM"
+    assert e.last_result == "success"
+    assert e.cron == "0 2 * * *"
+
+
+# ------------------------------------------------------------------
+# Platform-specific: Linux / macOS (crontab)
+# Run with: pytest -m posix
+# ------------------------------------------------------------------
+
+@posix
+def test_posix_crontab_line_format(tmp_path):
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    line = sched._build_crontab_line("lint run", "0 2 * * *", "sched-abc")
+    assert line.startswith("0 2 * * *")
+    assert 'schedule run --op "lint run"' in line
+    assert "# synthadoc:sched-abc" in line
+
+
+@posix
+def test_posix_list_crontab_parses_next_run(tmp_path, monkeypatch):
+    """_list_crontab parses entry and computes next_run via croniter."""
+    import subprocess
+    fake_crontab = (
+        '0 2 * * * synthadoc -w mywiki schedule run --op "lint run" # synthadoc:sched-xyz\n'
+    )
+    mock_result = type("R", (), {"stdout": fake_crontab, "returncode": 0})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    entries = sched._list_crontab()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.id == "sched-xyz"
+    assert e.cron == "0 2 * * *"
+    assert e.next_run != ""  # croniter computed a future datetime
+    assert e.last_run == ""  # not available in crontab
+    assert e.last_result == ""  # not available in crontab
+
+
+@posix
+def test_posix_cron_next_run_is_future():
+    from datetime import datetime, timezone
+    result = _cron_next_run("0 2 * * *")
+    assert result != ""
+    dt = datetime.strptime(result, "%Y-%m-%d %H:%M")
+    # next run must be in the future relative to now
+    assert dt >= datetime.now().replace(second=0, microsecond=0)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -198,6 +198,37 @@ def test_windows_list_schtasks_parses_next_run(tmp_path, monkeypatch):
     assert e.cron == "0 2 * * *"
 
 
+@windows
+def test_windows_list_schtasks_ignores_system_task_contamination(tmp_path, monkeypatch):
+    """Fields from non-synthadoc tasks must not contaminate a preceding synthadoc entry."""
+    import subprocess
+    fake_output = (
+        # synthadoc task
+        "TaskName:                             \\synthadoc-sched-abc123\n"
+        "Next Run Time:                        5/31/2026 10:00:00 PM\n"
+        "Last Run Time:                        N/A\n"
+        "Last Result:                          267011\n"
+        "Task To Run:                          synthadoc -w mywiki schedule run --op \"lint run\"\n"
+        "Start Time:                           10:00:00 PM\n"
+        # unrelated system task immediately after — should NOT bleed into our entry
+        "TaskName:                             \\Microsoft\\Windows\\SomeSystemTask\n"
+        "Task To Run:                          COM handler\n"
+        "Last Run Time:                        5/30/2026 11:32:01 AM\n"
+        "Last Result:                          0\n"
+        "Start Time:                           11:33:00 AM\n"
+    )
+    mock_result = type("R", (), {"stdout": fake_output, "returncode": 0})()
+    monkeypatch.setattr(subprocess, "run", lambda *a, **kw: mock_result)
+    sched = Scheduler(wiki="mywiki", wiki_root=str(tmp_path))
+    entries = sched._list_schtasks()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.cron == "0 22 * * *"           # Start Time 10:00:00 PM
+    assert e.op != "COM handler"
+    assert e.last_run == ""                 # N/A → cleared
+    assert e.last_result == "N/A"           # code 267011
+
+
 # ------------------------------------------------------------------
 # Platform-specific: Linux / macOS (crontab)
 # Run with: pytest -m posix

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -192,6 +192,7 @@ def test_windows_list_schtasks_parses_next_run(tmp_path, monkeypatch):
     assert len(entries) == 1
     e = entries[0]
     assert e.id == "sched-abc123"
+    assert e.op == "lint run"          # extracted from --op, not the full command
     assert e.next_run == "5/31/2026 2:00:00 AM"
     assert e.last_run == "5/30/2026 2:00:00 AM"
     assert e.last_result == "success"
@@ -257,9 +258,10 @@ def test_posix_list_crontab_parses_next_run(tmp_path, monkeypatch):
     assert len(entries) == 1
     e = entries[0]
     assert e.id == "sched-xyz"
+    assert e.op == "lint run"   # extracted from --op, not the full command
     assert e.cron == "0 2 * * *"
-    assert e.next_run != ""  # croniter computed a future datetime
-    assert e.last_run == ""  # not available in crontab
+    assert e.next_run != ""     # croniter computed a future datetime
+    assert e.last_run == ""     # not available in crontab
     assert e.last_result == ""  # not available in crontab
 
 


### PR DESCRIPTION
What

Fills two gaps in the scheduler: schedule list now shows the full schedule and run history for each job, and a new schedule run command wraps any operation with audit-trail recording.

Why

Schedule list previously showed only the job ID and operation: no cron expression, no next/last run time, no last result. There was also no way to manually trigger a scheduled job or review past runs from the CLI.

Changes

Core scheduler (synthadoc/core/scheduler.py)
- ScheduleEntry gains next_run, last_run, last_result fields
- Windows: _list_schtasks() parses Next Run Time, Last Run Time, Last Result from schtasks /Query /FO LIST /V; maps result code "0" → "success"
- Linux/macOS: _list_crontab() computes next_run via croniter; helper _cron_next_run() returns formatted datetime string
- Helper _schtasks_time_to_cron() converts Windows "2:00:00 AM" format back to a cron expression
- All registered commands now use schedule run --op "..." as the task payload so runs are always audited

Audit DB (synthadoc/storage/log.py)
- New scheduled_runs table: run_id, op, wiki, started_at, finished_at, status, duration_s, error
- New methods: record_scheduled_run_start(), record_scheduled_run_finish(), list_scheduled_runs()

CLI (synthadoc/cli/schedule.py)
- schedule list: formatted table with ID, Schedule, Next Run, Last Run, Last Result, Command columns
- New schedule run --op "<cmd>": executes the operation as a subprocess and records start/finish in the audit DB
- New schedule history: displays recent runs from scheduled_runs with duration and error columns