### PR TITLE
fix(scaffold): move scaffold LLM call to server side; CLI polls for completion

### DIFF
--- a/synthadoc/agents/scaffold_agent.py
+++ b/synthadoc/agents/scaffold_agent.py
@@ -19,6 +19,36 @@ _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
 _FM_STRIP_RE = re.compile(r"^---\s*\n.*?\n---\s*\n+", re.DOTALL)
 _H1_STRIP_RE = re.compile(r"^#[^#][^\n]*\n+")
 
+
+def _parse_scaffold_json(raw: str) -> dict | None:
+    """Try progressively looser strategies to extract the scaffold JSON object."""
+    # 1. Direct parse
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    # 2. Find the outermost {...} block
+    m = re.search(r"\{.*\}", raw, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except json.JSONDecodeError:
+            pass
+    # 3. Fix the most common MiniMax JSON defect: missing comma between adjacent
+    #    array objects ("} {" → "}, {") then retry
+    fixed = re.sub(r"}\s*\n(\s*){", r"},\n\1{", raw)
+    try:
+        return json.loads(fixed)
+    except json.JSONDecodeError:
+        pass
+    m = re.search(r"\{.*\}", fixed, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except json.JSONDecodeError:
+            pass
+    return None
+
 _SYSTEM_PROMPT = (
     "You are a knowledge management assistant helping to set up a domain-specific wiki. "
     "Return ONLY valid JSON — no markdown fences, no explanation."
@@ -136,25 +166,43 @@ class ScaffoldAgent:
             slugs_instruction=slugs_instruction,
         )
 
-        resp = await self._provider.complete(
-            messages=[Message(role="user", content=prompt)],
-            system=_SYSTEM_PROMPT,
-            temperature=0.3,
-            max_tokens=self._max_tokens,
-        )
+        messages: list[Message] = [Message(role="user", content=prompt)]
+        data: dict | None = None
+        last_exc: Exception | None = None
 
-        raw = resp.text.strip()
-        # Strip markdown fences if present
-        m = _FENCE_RE.search(raw)
-        if m:
-            raw = m.group(1)
+        for attempt in range(2):
+            resp = await self._provider.complete(
+                messages=messages,
+                system=_SYSTEM_PROMPT,
+                temperature=0.3,
+                max_tokens=self._max_tokens,
+            )
+            raw = resp.text.strip()
+            m = _FENCE_RE.search(raw)
+            if m:
+                raw = m.group(1)
 
-        try:
-            data = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"ScaffoldAgent: LLM returned unparseable scaffold JSON: {exc}"
-            ) from exc
+            data = _parse_scaffold_json(raw)
+            if data is not None:
+                break
+
+            # First attempt failed — ask the model to fix its own output
+            logger.warning(
+                "ScaffoldAgent: JSON parse failed on attempt %d — asking model to self-correct",
+                attempt + 1,
+            )
+            logger.debug("ScaffoldAgent: malformed raw response: %.500s", raw)
+            messages = messages + [
+                Message(role="assistant", content=resp.text),
+                Message(role="user", content=(
+                    "The JSON you returned is not valid. "
+                    "Return ONLY the corrected JSON with no additional text."
+                )),
+            ]
+            last_exc = ValueError(f"ScaffoldAgent: unparseable scaffold JSON after {attempt + 1} attempt(s)")
+
+        if data is None:
+            raise last_exc or ValueError("ScaffoldAgent: unparseable scaffold JSON")
 
         return ScaffoldResult(
             index_md=self._build_index_md(domain, data),

--- a/synthadoc/cli/scaffold.py
+++ b/synthadoc/cli/scaffold.py
@@ -47,6 +47,29 @@ def scaffold_cmd(
                     f"Scaffold request failed: {exc}",
                     "Is `synthadoc serve` running?")
 
+    import time
     job_id = result.get("job_id", "?")
     typer.echo(f"Scaffold job queued: {job_id}")
-    typer.echo("Monitor progress with: synthadoc jobs")
+    typer.echo("Waiting for scaffold to complete…")
+
+    while True:
+        time.sleep(2)
+        try:
+            job = get(wiki, f"/jobs/{job_id}")
+        except Exception:
+            typer.echo("Monitor progress with: synthadoc jobs")
+            break
+        status = job.get("status", "")
+        if status == "completed":
+            cats = (job.get("result") or {}).get("categories_updated", 0)
+            typer.echo("Scaffold complete.")
+            typer.echo("  index.md    updated")
+            typer.echo("  AGENTS.md   updated")
+            typer.echo("  purpose.md  updated")
+            typer.echo(f"  categories  stamped on {cats} page(s)")
+            break
+        if status in ("failed", "dead"):
+            error = job.get("error") or "unknown error"
+            E.cli_error(E.AGENT_FAILED, f"Scaffold failed: {error}",
+                        "Check `synthadoc jobs` for details.")
+            break

--- a/synthadoc/cli/scaffold.py
+++ b/synthadoc/cli/scaffold.py
@@ -2,92 +2,12 @@
 # Copyright (C) 2026 Paul Chen / axoviq.com
 from __future__ import annotations
 
-import re
-from pathlib import Path
 from typing import Optional
 
 import typer
 
 from synthadoc.cli.main import app
-from synthadoc.cli.install import resolve_wiki_path
 from synthadoc import errors as E
-
-_WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:\|[^\]]*)?\]\]")
-
-
-def _apply_categories(dest: Path, index_md: str) -> int:
-    """Parse index.md section headings and stamp categories on each linked page.
-
-    A page linked under multiple headings gets all of them in its categories list.
-    Returns the number of pages updated.
-    """
-    from synthadoc.storage.wiki import WikiStorage
-    store = WikiStorage(dest / "wiki")
-    # Build slug → [categories] map from the index markdown
-    slug_cats: dict[str, list[str]] = {}
-    current_section: str | None = None
-    for line in index_md.splitlines():
-        h2 = re.match(r"^## (.+)", line)
-        if h2:
-            current_section = h2.group(1).strip()
-            continue
-        if current_section:
-            for m in _WIKILINK_RE.finditer(line):
-                slug = m.group(1).strip()
-                slug_cats.setdefault(slug, [])
-                if current_section not in slug_cats[slug]:
-                    slug_cats[slug].append(current_section)
-
-    updated = 0
-    for slug, cats in slug_cats.items():
-        if store.page_exists(slug):
-            store.set_page_categories(slug, cats)
-            updated += 1
-    return updated
-
-
-def _protected_slugs(wiki_dir: Path) -> list[str]:
-    """Return slugs linked from index.md that have a corresponding wiki page."""
-    index_path = wiki_dir / "wiki" / "index.md"
-    if not index_path.exists():
-        return []
-    text = index_path.read_text(encoding="utf-8")
-    slugs = []
-    for m in _WIKILINK_RE.finditer(text):
-        slug = m.group(1).strip()
-        if (wiki_dir / "wiki" / f"{slug}.md").exists():
-            slugs.append(slug)
-    return slugs
-
-
-def _run_scaffold(dest: Path, domain: str, protected_slugs: Optional[list[str]] = None):
-    """Run ScaffoldAgent. Returns ScaffoldResult or None if no API key is set.
-
-    Raises on LLM/agent errors so callers can distinguish key-missing (None)
-    from LLM failure (exception).
-    """
-    import asyncio
-    import os
-    from synthadoc.config import load_config
-    from synthadoc.providers import make_provider
-
-    cfg = load_config(project_config=dest / ".synthadoc" / "config.toml")
-    provider_name = cfg.agents.resolve("ingest").provider
-
-    _KEY_ENV = {
-        "anthropic": "ANTHROPIC_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "gemini": "GEMINI_API_KEY",
-        "groq": "GROQ_API_KEY",
-    }
-    env_var = _KEY_ENV.get(provider_name)
-    if env_var and not os.environ.get(env_var, "").strip():
-        return None
-
-    provider = make_provider("ingest", cfg)
-    from synthadoc.agents.scaffold_agent import ScaffoldAgent
-    agent = ScaffoldAgent(provider=provider, max_tokens=cfg.agents.scaffold_max_tokens)
-    return asyncio.run(agent.scaffold(domain=domain, protected_slugs=protected_slugs))
 
 
 @app.command("scaffold")
@@ -97,8 +17,8 @@ def scaffold_cmd(
     """Re-generate domain-specific scaffold files for an existing wiki.
 
     Rewrites index.md, AGENTS.md, and purpose.md using the LLM.
-    Pages linked from index.md that have existing wiki files are
-    preserved as protected slugs. config.toml is never modified.
+    The LLM call runs on the server — no API key needed on the client.
+    Monitor progress with: synthadoc jobs
 
     Examples:
 
@@ -107,64 +27,26 @@ def scaffold_cmd(
       synthadoc scaffold -w ~/wikis/my-research
     """
     from synthadoc.cli._wiki import resolve_wiki
+    from synthadoc.cli._http import get, post
+
     wiki = resolve_wiki(wiki)
 
-    dest = resolve_wiki_path(wiki)
-
-    if not dest.exists():
-        E.cli_error(
-            E.WIKI_NOT_FOUND,
-            f"Wiki directory not found: {dest}",
-            "Check the wiki name or path.",
-        )
-
-    cfg_path = dest / ".synthadoc" / "config.toml"
-    if not cfg_path.exists():
-        E.cli_error(
-            E.CFG_NOT_FOUND,
-            f"No config found at {cfg_path}",
-            "Is this a valid synthadoc wiki directory?",
-        )
-
-    from synthadoc.config import load_config
-    cfg = load_config(project_config=cfg_path)
-    domain = cfg.wiki.domain
-
-    slugs = _protected_slugs(dest)
-    if slugs:
-        typer.echo(f"Preserving {len(slugs)} protected page(s): {', '.join(slugs)}")
-
-    typer.echo(f"Generating scaffold for domain: {domain}...")
     try:
-        result = _run_scaffold(dest, domain, protected_slugs=slugs if slugs else None)
+        cfg_info = get(wiki, "/config")
+        domain = cfg_info.get("domain", "General")
     except Exception as exc:
-        import logging
-        logging.getLogger(__name__).warning("Scaffold LLM call failed: %s", exc)
-        E.cli_error(
-            E.AGENT_FAILED,
-            f"Scaffold failed: {exc}",
-            "Check your LLM provider configuration and try again.",
-        )
+        E.cli_error(E.SERVER_NOT_RUNNING,
+                    f"Cannot reach server: {exc}",
+                    "Run `synthadoc serve` first.")
 
-    if result is None:
-        E.cli_error(
-            E.CFG_MISSING_API_KEY,
-            "Scaffold failed: no LLM API key found.",
-            "Set your API key (e.g. ANTHROPIC_API_KEY) and try again.",
-        )
+    typer.echo(f"Queuing scaffold for domain: {domain}…")
+    try:
+        result = post(wiki, "/jobs/scaffold", {"domain": domain})
+    except Exception as exc:
+        E.cli_error(E.AGENT_FAILED,
+                    f"Scaffold request failed: {exc}",
+                    "Is `synthadoc serve` running?")
 
-    from synthadoc.agents.scaffold_agent import preserve_user_zone
-    index_path = dest / "wiki" / "index.md"
-    existing = index_path.read_text(encoding="utf-8") if index_path.exists() else ""
-    final_index = preserve_user_zone(existing, result.index_md)
-    index_path.write_text(final_index, encoding="utf-8", newline="\n")
-    (dest / "AGENTS.md").write_text(result.agents_md, encoding="utf-8", newline="\n")
-    (dest / "wiki" / "purpose.md").write_text(result.purpose_md, encoding="utf-8", newline="\n")
-
-    updated = _apply_categories(dest, result.index_md)
-
-    typer.echo("Scaffold complete.")
-    typer.echo(f"  index.md    updated")
-    typer.echo(f"  AGENTS.md   updated")
-    typer.echo(f"  purpose.md  updated")
-    typer.echo(f"  categories  stamped on {updated} page(s)")
+    job_id = result.get("job_id", "?")
+    typer.echo(f"Scaffold job queued: {job_id}")
+    typer.echo("Monitor progress with: synthadoc jobs")

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -422,7 +422,9 @@ class Orchestrator:
         return await self._queue.enqueue("lint", {"scope": scope, "auto_resolve": auto_resolve})
 
     async def _run_scaffold(self, job_id: str, domain: str) -> None:
-        from synthadoc.agents.scaffold_agent import ScaffoldAgent
+        from synthadoc.agents.scaffold_agent import ScaffoldAgent, preserve_user_zone
+        import re as _re
+        _WIKILINK_RE = _re.compile(r"\[\[([^\]|#]+?)(?:\|[^\]]*)?\]\]")
         try:
             wiki_dir = self._root / "wiki"
             protected_slugs = [p.stem for p in wiki_dir.glob("*.md")]
@@ -430,15 +432,39 @@ class Orchestrator:
                 provider=make_provider("ingest", self._cfg),
                 max_tokens=self._cfg.agents.scaffold_max_tokens,
             ).scaffold(domain=domain, protected_slugs=protected_slugs or None)
-            (self._root / "wiki" / "index.md").write_text(
-                result.index_md, encoding="utf-8", newline="\n")
+
+            index_path = self._root / "wiki" / "index.md"
+            existing = index_path.read_text(encoding="utf-8") if index_path.exists() else ""
+            final_index = preserve_user_zone(existing, result.index_md)
+            index_path.write_text(final_index, encoding="utf-8", newline="\n")
             (self._root / "AGENTS.md").write_text(
                 result.agents_md, encoding="utf-8", newline="\n")
             (self._root / "wiki" / "purpose.md").write_text(
                 result.purpose_md, encoding="utf-8", newline="\n")
+
+            # Stamp categories from index.md section headings onto linked pages
+            slug_cats: dict[str, list[str]] = {}
+            current_section: str | None = None
+            for line in result.index_md.splitlines():
+                h2 = _re.match(r"^## (.+)", line)
+                if h2:
+                    current_section = h2.group(1).strip()
+                    continue
+                if current_section:
+                    for m in _WIKILINK_RE.finditer(line):
+                        slug = m.group(1).strip()
+                        slug_cats.setdefault(slug, [])
+                        if current_section not in slug_cats[slug]:
+                            slug_cats[slug].append(current_section)
+            categories_updated = 0
+            for slug, cats in slug_cats.items():
+                if self._store.page_exists(slug):
+                    self._store.set_page_categories(slug, cats)
+                    categories_updated += 1
+
             await self._queue.complete(job_id, result={
                 "domain": domain,
-                "categories": len(result.index_md.splitlines()),
+                "categories_updated": categories_updated,
             })
         except Exception as e:
             await self._queue.fail(job_id, str(e))

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -365,6 +365,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
     @app.get("/config")
     async def config_info():
         return {
+            "domain": cfg.wiki.domain,
             "check_url_availability": cfg.lint.check_url_availability,
         }
 

--- a/tests/cli/test_scaffold_cli.py
+++ b/tests/cli/test_scaffold_cli.py
@@ -1,175 +1,73 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
+from __future__ import annotations
+
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from typer.testing import CliRunner
 from synthadoc.cli.main import app
 
 runner = CliRunner()
 
 
-def _make_wiki(tmp_path, domain="Robotics"):
-    """Create a minimal wiki directory layout."""
-    wiki_dir = tmp_path / "my-wiki"
-    (wiki_dir / "wiki").mkdir(parents=True)
-    (wiki_dir / ".synthadoc").mkdir()
-    (wiki_dir / ".synthadoc" / "config.toml").write_text(
-        f'[wiki]\ndomain = "{domain}"\n[server]\nport = 7070\n',
-        encoding="utf-8",
-    )
-    (wiki_dir / "wiki" / "index.md").write_text(
-        "# Index\n\n## Key Concepts\n<!-- desc -->\n",
-        encoding="utf-8",
-    )
-    (wiki_dir / "wiki" / "purpose.md").write_text(
-        f"# Wiki Purpose\n\nThis wiki covers: {domain}.\n",
-        encoding="utf-8",
-    )
-    (wiki_dir / "AGENTS.md").write_text(
-        f"# AGENTS.md — {domain} Wiki\n",
-        encoding="utf-8",
-    )
-    return wiki_dir
+def _mock_http(domain: str = "Robotics", job_id: str = "abc-123"):
+    """Return (get_mock, post_mock) pre-configured for scaffold tests."""
+    get_mock = MagicMock(return_value={"domain": domain})
+    post_mock = MagicMock(return_value={"job_id": job_id})
+    return get_mock, post_mock
 
 
-def test_scaffold_command_writes_files(tmp_path):
-    """scaffold rewrites index.md, AGENTS.md, and purpose.md from LLM output."""
-    from synthadoc.agents.scaffold_agent import ScaffoldResult
-    wiki_dir = _make_wiki(tmp_path)
+def _invoke_scaffold(wiki: str = "my-wiki", get_mock=None, post_mock=None):
+    with patch("synthadoc.cli._http.get", get_mock), \
+         patch("synthadoc.cli._http.post", post_mock), \
+         patch("synthadoc.cli._wiki.resolve_wiki", return_value=wiki):
+        return runner.invoke(app, ["scaffold", "--wiki", wiki])
 
-    mock_result = ScaffoldResult(
-        index_md="---\ntitle: Index\n---\n# Robotics — Index\n",
-        agents_md="# AGENTS.md — Robotics Wiki\n",
-        purpose_md="# Wiki Purpose\nThis wiki covers: Robotics.\n",
-        dashboard_intro="A wiki tracking Robotics knowledge.",
-    )
 
-    with patch("synthadoc.cli.scaffold._run_scaffold", return_value=mock_result):
-        result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
+def test_scaffold_queues_job_on_server():
+    """scaffold_cmd posts to /jobs/scaffold and exits zero."""
+    get_mock, post_mock = _mock_http(domain="Robotics", job_id="job-xyz")
+    result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code == 0, result.output
-    assert (wiki_dir / "wiki" / "index.md").read_text(encoding="utf-8") == mock_result.index_md
-    assert (wiki_dir / "AGENTS.md").read_text(encoding="utf-8") == mock_result.agents_md
-    assert (wiki_dir / "wiki" / "purpose.md").read_text(encoding="utf-8") == mock_result.purpose_md
+    post_mock.assert_called_once()
+    call_args = post_mock.call_args
+    assert call_args[0][1] == "/jobs/scaffold"
+    assert call_args[0][2]["domain"] == "Robotics"
 
 
-def test_scaffold_detects_protected_slugs(tmp_path):
-    """scaffold passes slugs of existing linked pages to the LLM call."""
-    from synthadoc.agents.scaffold_agent import ScaffoldResult
-    wiki_dir = _make_wiki(tmp_path)
-
-    # Create a real page that is linked from index.md
-    (wiki_dir / "wiki" / "neural-networks.md").write_text("# Neural Networks\n", encoding="utf-8")
-    (wiki_dir / "wiki" / "index.md").write_text(
-        "# Index\n\n## Key Concepts\n[[neural-networks]]\n",
-        encoding="utf-8",
-    )
-
-    mock_result = ScaffoldResult(
-        index_md="---\ntitle: Index\n---\n# Robotics — Index\n",
-        agents_md="# AGENTS.md\n",
-        purpose_md="# Purpose\n",
-        dashboard_intro="desc",
-    )
-
-    captured_slugs = []
-
-    def _capture_scaffold(dest, domain, protected_slugs=None):
-        captured_slugs.extend(protected_slugs or [])
-        return mock_result
-
-    with patch("synthadoc.cli.scaffold._run_scaffold", side_effect=_capture_scaffold):
-        result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
+def test_scaffold_shows_job_id_in_output():
+    """scaffold_cmd prints the returned job_id."""
+    get_mock, post_mock = _mock_http(job_id="job-xyz-456")
+    result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code == 0, result.output
-    assert "neural-networks" in captured_slugs
+    assert "job-xyz-456" in result.output
 
 
-def test_scaffold_does_not_touch_config(tmp_path):
-    """scaffold must never modify .synthadoc/config.toml."""
-    from synthadoc.agents.scaffold_agent import ScaffoldResult
-    wiki_dir = _make_wiki(tmp_path)
-    config_path = wiki_dir / ".synthadoc" / "config.toml"
-    original_config = config_path.read_text(encoding="utf-8")
-
-    mock_result = ScaffoldResult(
-        index_md="# Index\n",
-        agents_md="# AGENTS\n",
-        purpose_md="# Purpose\n",
-        dashboard_intro="desc",
-    )
-
-    with patch("synthadoc.cli.scaffold._run_scaffold", return_value=mock_result):
-        result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
+def test_scaffold_uses_domain_from_server_config():
+    """scaffold_cmd reads domain from GET /config, not the local filesystem."""
+    get_mock, post_mock = _mock_http(domain="AI Research")
+    result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code == 0, result.output
-    assert config_path.read_text(encoding="utf-8") == original_config
+    assert "AI Research" in result.output
 
 
-def test_scaffold_exits_when_scaffold_fails(tmp_path):
-    """scaffold exits non-zero when the LLM call returns None (no API key)."""
-    wiki_dir = _make_wiki(tmp_path)
-
-    with patch("synthadoc.cli.scaffold._run_scaffold", return_value=None):
-        result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
+def test_scaffold_exits_nonzero_when_server_unreachable():
+    """scaffold_cmd exits non-zero when the server cannot be reached."""
+    get_mock = MagicMock(side_effect=Exception("Connection refused"))
+    post_mock = MagicMock()
+    result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code != 0
+    post_mock.assert_not_called()
 
 
-def test_scaffold_missing_wiki_dir_exits(tmp_path):
-    """scaffold exits non-zero when the wiki directory does not exist."""
-    nonexistent = tmp_path / "no-such-wiki"
-    result = runner.invoke(app, ["scaffold", "--wiki", str(nonexistent)])
+def test_scaffold_exits_nonzero_when_enqueue_fails():
+    """scaffold_cmd exits non-zero when POST /jobs/scaffold raises."""
+    get_mock, _ = _mock_http()
+    post_mock = MagicMock(side_effect=Exception("Server error"))
+    result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
+
     assert result.exit_code != 0
-
-
-def test_scaffold_missing_config_exits(tmp_path):
-    """scaffold exits non-zero when config.toml is absent."""
-    wiki_dir = tmp_path / "bare-wiki"
-    (wiki_dir / "wiki").mkdir(parents=True)
-    result = runner.invoke(app, ["scaffold", "--wiki", str(wiki_dir)])
-    assert result.exit_code != 0
-
-
-def test_protected_slugs_returns_linked_existing_pages(tmp_path):
-    """_protected_slugs includes slugs that are both linked from index.md and have a wiki file."""
-    from synthadoc.cli.scaffold import _protected_slugs
-    (tmp_path / "wiki").mkdir()
-    (tmp_path / "wiki" / "index.md").write_text(
-        "# Index\n\n[[neural-networks]] and [[robotics]]\n",
-        encoding="utf-8",
-    )
-    (tmp_path / "wiki" / "neural-networks.md").write_text("# NN\n", encoding="utf-8")
-    # robotics.md does not exist — must not be included
-    slugs = _protected_slugs(tmp_path)
-    assert "neural-networks" in slugs
-    assert "robotics" not in slugs
-
-
-def test_protected_slugs_empty_when_no_index(tmp_path):
-    """_protected_slugs returns [] when index.md is absent."""
-    from synthadoc.cli.scaffold import _protected_slugs
-    (tmp_path / "wiki").mkdir()
-    slugs = _protected_slugs(tmp_path)
-    assert slugs == []
-
-
-def test_apply_categories_stamps_headings_on_pages(tmp_path):
-    """_apply_categories reads H2 headings from index.md and stamps categories on linked pages."""
-    from synthadoc.cli.scaffold import _apply_categories
-    from synthadoc.storage.wiki import WikiStorage
-
-    wiki_dir = tmp_path / "wiki"
-    wiki_dir.mkdir()
-    (wiki_dir / "neural-networks.md").write_text(
-        "---\ntitle: Neural Networks\ntags: []\nstatus: active\n"
-        "confidence: high\ncreated: '2026-01-01'\nsources: []\n---\nContent.",
-        encoding="utf-8",
-    )
-    index_md = "# Index\n\n## Key Concepts\n- [[neural-networks]]\n"
-    updated = _apply_categories(tmp_path, index_md)
-    assert updated >= 1
-    store = WikiStorage(wiki_dir)
-    page = store.read_page("neural-networks")
-    assert page is not None
-    assert "Key Concepts" in (page.categories or [])

--- a/tests/cli/test_scaffold_cli.py
+++ b/tests/cli/test_scaffold_cli.py
@@ -10,23 +10,32 @@ from synthadoc.cli.main import app
 runner = CliRunner()
 
 
-def _mock_http(domain: str = "Robotics", job_id: str = "abc-123"):
-    """Return (get_mock, post_mock) pre-configured for scaffold tests."""
-    get_mock = MagicMock(return_value={"domain": domain})
-    post_mock = MagicMock(return_value={"job_id": job_id})
-    return get_mock, post_mock
+def _make_get_mock(domain: str = "Robotics", job_id: str = "abc-123",
+                   final_status: str = "completed", categories: int = 3):
+    """Return a get mock: /config → domain, /jobs/{id} → completed job."""
+    completed_job = {"status": final_status, "result": {"categories_updated": categories},
+                     "error": None}
+    def _get(wiki, path, **kw):
+        if path == "/config":
+            return {"domain": domain}
+        if path.startswith("/jobs/"):
+            return completed_job
+        return {}
+    return MagicMock(side_effect=_get)
 
 
 def _invoke_scaffold(wiki: str = "my-wiki", get_mock=None, post_mock=None):
     with patch("synthadoc.cli._http.get", get_mock), \
          patch("synthadoc.cli._http.post", post_mock), \
-         patch("synthadoc.cli._wiki.resolve_wiki", return_value=wiki):
+         patch("synthadoc.cli._wiki.resolve_wiki", return_value=wiki), \
+         patch("time.sleep"):  # skip the 2-second poll delay
         return runner.invoke(app, ["scaffold", "--wiki", wiki])
 
 
 def test_scaffold_queues_job_on_server():
     """scaffold_cmd posts to /jobs/scaffold and exits zero."""
-    get_mock, post_mock = _mock_http(domain="Robotics", job_id="job-xyz")
+    get_mock = _make_get_mock(domain="Robotics", job_id="job-xyz")
+    post_mock = MagicMock(return_value={"job_id": "job-xyz"})
     result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code == 0, result.output
@@ -36,18 +45,23 @@ def test_scaffold_queues_job_on_server():
     assert call_args[0][2]["domain"] == "Robotics"
 
 
-def test_scaffold_shows_job_id_in_output():
-    """scaffold_cmd prints the returned job_id."""
-    get_mock, post_mock = _mock_http(job_id="job-xyz-456")
+def test_scaffold_shows_completion_summary():
+    """scaffold_cmd prints index/AGENTS/purpose updated and category count."""
+    get_mock = _make_get_mock(categories=7)
+    post_mock = MagicMock(return_value={"job_id": "job-1"})
     result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code == 0, result.output
-    assert "job-xyz-456" in result.output
+    assert "index.md" in result.output
+    assert "AGENTS.md" in result.output
+    assert "purpose.md" in result.output
+    assert "7" in result.output
 
 
 def test_scaffold_uses_domain_from_server_config():
     """scaffold_cmd reads domain from GET /config, not the local filesystem."""
-    get_mock, post_mock = _mock_http(domain="AI Research")
+    get_mock = _make_get_mock(domain="AI Research")
+    post_mock = MagicMock(return_value={"job_id": "job-2"})
     result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code == 0, result.output
@@ -55,7 +69,7 @@ def test_scaffold_uses_domain_from_server_config():
 
 
 def test_scaffold_exits_nonzero_when_server_unreachable():
-    """scaffold_cmd exits non-zero when the server cannot be reached."""
+    """scaffold_cmd exits non-zero when GET /config fails."""
     get_mock = MagicMock(side_effect=Exception("Connection refused"))
     post_mock = MagicMock()
     result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
@@ -66,8 +80,24 @@ def test_scaffold_exits_nonzero_when_server_unreachable():
 
 def test_scaffold_exits_nonzero_when_enqueue_fails():
     """scaffold_cmd exits non-zero when POST /jobs/scaffold raises."""
-    get_mock, _ = _mock_http()
+    get_mock = _make_get_mock()
     post_mock = MagicMock(side_effect=Exception("Server error"))
     result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
 
     assert result.exit_code != 0
+
+
+def test_scaffold_exits_nonzero_when_job_fails():
+    """scaffold_cmd exits non-zero when the job ends in failed status."""
+    get_mock = _make_get_mock(final_status="failed")
+    # Patch error field too
+    def _get(wiki, path, **kw):
+        if path == "/config":
+            return {"domain": "Robotics"}
+        return {"status": "failed", "result": None, "error": "LLM timeout"}
+    get_mock = MagicMock(side_effect=_get)
+    post_mock = MagicMock(return_value={"job_id": "job-3"})
+    result = _invoke_scaffold(get_mock=get_mock, post_mock=post_mock)
+
+    assert result.exit_code != 0
+    assert "LLM timeout" in result.output

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -251,39 +251,6 @@ def test_patch_toml_section_ends_before_next_section(tmp_path):
     assert "port = 7070" in content
 
 
-# ── cli/scaffold.py — _run_scaffold() ─────────────────────────────────────────
-
-def test_run_scaffold_returns_none_when_no_api_key(tmp_path):
-    """_run_scaffold returns None when the required API env var is unset."""
-    from synthadoc.cli.scaffold import _run_scaffold
-    sd = tmp_path / ".synthadoc"
-    sd.mkdir()
-    (sd / "config.toml").write_text(
-        '[agents]\ndefault = { provider = "gemini", model = "gemini-2.5-flash" }\n',
-        encoding="utf-8",
-    )
-    with patch.dict("os.environ", {"GEMINI_API_KEY": ""}, clear=False):
-        result = _run_scaffold(tmp_path, "test domain")
-    assert result is None
-
-
-def test_run_scaffold_raises_on_llm_exception(tmp_path):
-    """_run_scaffold propagates LLM exceptions so callers show a specific error."""
-    from synthadoc.cli.scaffold import _run_scaffold
-    sd = tmp_path / ".synthadoc"
-    sd.mkdir()
-    (sd / "config.toml").write_text(
-        '[agents]\ndefault = { provider = "gemini", model = "gemini-2.5-flash" }\n',
-        encoding="utf-8",
-    )
-    with patch.dict("os.environ", {"GEMINI_API_KEY": "fake-key"}, clear=False), \
-         patch("synthadoc.providers.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.scaffold_agent.ScaffoldAgent") as MockAgent:
-        MockAgent.return_value.scaffold = AsyncMock(side_effect=RuntimeError("LLM failed"))
-        with pytest.raises(RuntimeError, match="LLM failed"):
-            _run_scaffold(tmp_path, "test domain")
-
-
 def test_install_run_scaffold_returns_none_when_no_api_key(tmp_path):
     """install._run_scaffold returns None when the required API env var is unset."""
     from synthadoc.cli.install import _run_scaffold
@@ -1269,27 +1236,22 @@ def test_setup_logging_with_none_cfg_uses_defaults(tmp_path):
             h.close()
 
 
-# ── cli/scaffold.py — exception path in scaffold_cmd ─────────────────────────
+# ── cli/scaffold.py — server error path in scaffold_cmd ──────────────────────
 
-def test_scaffold_cmd_llm_exception_shows_agent_failed_error(tmp_path):
-    """scaffold command shows ERR-AGENT-001 when LLM raises an exception."""
+def test_scaffold_cmd_server_error_shows_agent_failed_error(tmp_path):
+    """scaffold command exits non-zero when POST /jobs/scaffold raises."""
+    from unittest.mock import MagicMock
     from typer.testing import CliRunner
     from synthadoc.cli.main import app
     runner = CliRunner()
 
-    (tmp_path / "wiki").mkdir()
-    sd = tmp_path / ".synthadoc"
-    sd.mkdir()
-    (sd / "config.toml").write_text(
-        '[wiki]\ndomain = "Test Domain"\n'
-        '[agents]\ndefault = { provider = "gemini", model = "gemini-2.5-flash" }\n',
-        encoding="utf-8",
-    )
+    get_mock = MagicMock(return_value={"domain": "Test Domain"})
+    post_mock = MagicMock(side_effect=RuntimeError("Server error"))
 
-    with patch("synthadoc.cli.scaffold._run_scaffold",
-               side_effect=RuntimeError("LLM error")), \
-         patch("synthadoc.cli._wiki.resolve_wiki", return_value=str(tmp_path)):
-        result = runner.invoke(app, ["scaffold", "--wiki", str(tmp_path)])
+    with patch("synthadoc.cli._http.get", get_mock), \
+         patch("synthadoc.cli._http.post", post_mock), \
+         patch("synthadoc.cli._wiki.resolve_wiki", return_value="test-wiki"):
+        result = runner.invoke(app, ["scaffold", "--wiki", "test-wiki"])
 
     assert result.exit_code != 0
 


### PR DESCRIPTION
Description:

The synthadoc scaffold command was invoking ScaffoldAgent directly on the CLI client, requiring the LLM API key to be set in the client environment. Like ingest and lint, the LLM work should run on the server.

Changes:

cli/scaffold.py: remove all client-side agent code (_run_scaffold, _protected_slugs, _apply_categories); replace with:
1. GET /config to read the domain from the running server
2. POST /jobs/scaffold to enqueue the job
3. Poll GET /jobs/{id} every 2 seconds until completion, then print the same summary as before (index.md, AGENTS.md, purpose.md updated, categories stamped on N pages). Exits non-zero and shows the server error message if the job fails. 

core/orchestrator.py _run_scaffold - add the two steps that were previously only done on the client:
- preserve_user_zone when writing index.md (protects user-edited sections)
- Category stamping from index.md H2 headings onto linked pages

http_server.py /config: expose domain field so the CLI can read it without a local config file.