### PR TITLE
docs: document schedule apply in README and design guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,10 @@ synthadoc schedule add --op "ingest --batch raw_sources/" --cron "0 2 * * *" -w 
 # Weekly lint
 synthadoc schedule add --op "lint run" --cron "0 3 * * 0" -w my-wiki
 
+# Bulk-register all jobs declared in [[schedule.jobs]] in config.toml (alternative to schedule add)
+# See docs/design.md § "schedule sub-commands" for the config.toml format
+synthadoc schedule apply -w my-wiki
+
 # List scheduled jobs (shows schedule, next run, last run, last result)
 synthadoc schedule list -w my-wiki
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -843,6 +843,33 @@ synthadoc
 
 `synthadoc status -w <wiki>` now shows a per-state page count breakdown alongside the existing page total and job counts.
 
+### `schedule` sub-commands
+
+| Command | Description |
+|---|---|
+| `schedule add --op "<cmd>" --cron "<expr>"` | Register a single recurring job with the scheduler |
+| `schedule apply` | Bulk-register all jobs declared in `[[schedule.jobs]]` in `config.toml`; idempotent alternative to running `schedule add` once per job |
+| `schedule list` | List all registered jobs with their cron expression, next run time, last run time, and last result |
+| `schedule remove <id>` | Remove a registered job by ID |
+| `schedule run --op "<cmd>"` | Execute an operation immediately and record the result in the audit trail |
+| `schedule history` | Show recent scheduled run history from the audit trail |
+
+`schedule apply` is the recommended setup path when jobs are declared in `config.toml`. It reads the `[[schedule.jobs]]` array and registers every entry in one command, making schedule configuration reproducible and version-controllable:
+
+```bash
+# Declare jobs in .synthadoc/config.toml
+# [[schedule.jobs]]
+# op   = "ingest --batch raw_sources/"
+# cron = "0 2 * * *"
+#
+# [[schedule.jobs]]
+# op   = "lint run"
+# cron = "0 3 * * 0"
+
+# Register all declared jobs at once
+synthadoc schedule apply -w my-wiki
+```
+
 ### `query` options
 
 | Flag | Default | Description |


### PR DESCRIPTION
Add schedule apply to the README command block with a comment pointing to docs/design.md for the config.toml format. Add a dedicated schedule sub-commands section to design.md covering all six commands, with a prose explanation of apply and a config + CLI example showing the recommended declarative setup.