### PR TITLE
fix(cache): cache clear now wipes query_cache in addition to response…

### DIFF
--- a/synthadoc/core/cache.py
+++ b/synthadoc/core/cache.py
@@ -64,11 +64,12 @@ class CacheManager:
             await db.commit()
 
     async def clear(self) -> int:
-        """Delete all cached entries. Returns the number of rows removed."""
+        """Delete all cached entries (both response and query caches). Returns total rows removed."""
         async with aiosqlite.connect(self._path) as db:
-            cur = await db.execute("DELETE FROM response_cache")
+            cur1 = await db.execute("DELETE FROM response_cache")
+            cur2 = await db.execute("DELETE FROM query_cache")
             await db.commit()
-            return cur.rowcount
+            return cur1.rowcount + cur2.rowcount
 
     async def get_query(self, key: str) -> Optional[Any]:
         async with aiosqlite.connect(self._path) as db:

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -57,6 +57,20 @@ async def test_clear_on_empty_cache_returns_zero(tmp_wiki):
 
 
 @pytest.mark.asyncio
+async def test_clear_also_wipes_query_cache(tmp_wiki):
+    cache = CacheManager(tmp_wiki / ".synthadoc" / "cache.db")
+    await cache.init()
+    await cache.set("r1", {"v": 1})
+    await cache.set_query("q1", epoch=1, result={"answer": "x"})
+    await cache.set_query("q2", epoch=1, result={"answer": "y"})
+    removed = await cache.clear()
+    assert removed == 3
+    assert await cache.get("r1") is None
+    assert await cache.get_query("q1") is None
+    assert await cache.get_query("q2") is None
+
+
+@pytest.mark.asyncio
 async def test_get_query_returns_none_on_miss(tmp_path):
     """get_query returns None when no matching entry exists."""
     from synthadoc.core.cache import CacheManager


### PR DESCRIPTION
…_cache

synthadoc cache clear previously only deleted rows from response_cache, leaving query_cache entries untouched. Users expecting a full cache flush to force fresh query results got no effect on streamed/cached answers.

Fix: CacheManager.clear() now deletes from both tables and returns the combined row count. Add test_clear_also_wipes_query_cache to cover this.