### PR TITLE
[v0.8.0] feat(config): MiniMax M3 support with configurable thinking mode off

### DIFF
--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -33,6 +33,7 @@ default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}
 # default = {{ provider = "gemini",    model = "gemini-2.5-flash" }}         # free tier: 10 RPM / 250 RPD
 # default = {{ provider = "gemini",    model = "gemini-1.5-flash" }}         # free tier: 15 RPM / 1,500 RPD
 # default = {{ provider = "minimax",   model = "MiniMax-M2.5" }}             # paid, cheapest text-only ($0.15/M in)
+# default = {{ provider = "minimax",   model = "MiniMax-M3",  thinking = "disabled" }}  # paid, M3 with thinking off (faster, cheaper)
 # default = {{ provider = "groq",      model = "llama-3.3-70b-versatile" }}  # free tier, 100K tokens/day
 # default = {{ provider = "anthropic", model = "claude-sonnet-4-6" }}        # paid, highest quality
 # default = {{ provider = "deepseek",  model = "deepseek-chat" }}             # paid, very cheap ($0.14/M in); text-only, no vision
@@ -40,7 +41,7 @@ default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}
 # default = {{ provider = "claude-code" }}                                    # no API key — uses your Claude Code subscription
 # default = {{ provider = "opencode" }}                                       # no API key — uses your Opencode subscription
 #
-# LLM call timeout — useful for reasoning models (e.g. MiniMax-M2.5) that can
+# LLM call timeout — useful for reasoning models (e.g. MiniMax-M2.5, MiniMax-M3 with thinking enabled) that can
 # spend 2+ minutes on a single prompt and return an empty response instead of
 # raising an error.  Setting this causes synthadoc to fail fast with a clear
 # log message so you know to adjust the model or prompt size.

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -31,6 +31,7 @@ class AgentConfig:
     provider: str
     model: str
     base_url: str = ""
+    thinking: str = ""  # "disabled" | "enabled" | "adaptive" | "" (provider default)
 
 
 @dataclass
@@ -60,6 +61,7 @@ class AgentsConfig:
             provider=override.provider,
             model=override.model,
             base_url=override.base_url,
+            thinking=override.thinking,
         )
 
 
@@ -189,11 +191,21 @@ class Config:
 # ---------------------------------------------------------------------------
 
 
+_VALID_THINKING_VALUES = frozenset({"", "disabled", "enabled", "adaptive"})
+
+
 def _parse_agent(raw: dict) -> AgentConfig:
+    thinking = raw.get("thinking", "")
+    if thinking not in _VALID_THINKING_VALUES:
+        raise ValueError(
+            f"Invalid thinking value '{thinking}'. "
+            f"Must be one of: disabled, enabled, adaptive (or omit for provider default)."
+        )
     return AgentConfig(
         provider=raw["provider"],
         model=raw.get("model", ""),
         base_url=raw.get("base_url", ""),
+        thinking=thinking,
     )
 
 
@@ -270,6 +282,7 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
                 "provider": default_agent.provider,
                 "model": default_agent.model,
                 "base_url": default_agent.base_url,
+                "thinking": default_agent.thinking,
             }
             base_vals.update(a[name])
             parsed = _parse_agent(base_vals)

--- a/synthadoc/providers/__init__.py
+++ b/synthadoc/providers/__init__.py
@@ -45,6 +45,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
         cfg_with_url = AgentConfig(
             provider="gemini", model=agent_cfg.model,
             base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+            thinking=agent_cfg.thinking,
         )
         return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "groq":
@@ -53,6 +54,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
         cfg_with_url = AgentConfig(
             provider="groq", model=agent_cfg.model,
             base_url="https://api.groq.com/openai/v1",
+            thinking=agent_cfg.thinking,
         )
         return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "minimax":
@@ -61,6 +63,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
         cfg_with_url = AgentConfig(
             provider="minimax", model=agent_cfg.model,
             base_url="https://api.minimax.io/v1",
+            thinking=agent_cfg.thinking,
         )
         return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "deepseek":
@@ -69,6 +72,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
         cfg_with_url = AgentConfig(
             provider="deepseek", model=agent_cfg.model,
             base_url="https://api.deepseek.com/v1",
+            thinking=agent_cfg.thinking,
         )
         return OpenAIProvider(api_key=key, config=cfg_with_url, timeout=timeout)
     if name == "ollama":

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -42,6 +42,20 @@ _SERVER_ERROR_RETRY_DELAYS_S: tuple[int, ...] = (5, 15, 30)
 #   patch("synthadoc.providers.openai._sleep", new=AsyncMock())
 _sleep = asyncio.sleep
 
+_THINKING_EXTRA_BODY: dict[str, dict] = {
+    "disabled": {"thinking": {"type": "disabled"}},
+    "enabled":  {"thinking": {"type": "adaptive"}},
+    "adaptive": {"thinking": {"type": "adaptive"}},
+}
+
+
+def _build_extra_body(thinking: str) -> dict:
+    """Return the provider extra_body dict for the given thinking setting.
+
+    Empty string (unset) → no extra_body; provider default applies.
+    """
+    return _THINKING_EXTRA_BODY.get(thinking, {})
+
 
 def _extract_last_json(s: str) -> str:
     """Extract the last complete JSON object or array from s using brace matching.
@@ -100,6 +114,7 @@ class OpenAIProvider(LLMProvider):
         self._timeout: int | None = timeout if timeout > 0 else None
         base = str(config.base_url or "")
         self.supports_vision = not any(host in base for host in _NO_VISION_HOSTS)
+        self._extra_body: dict = _build_extra_body(config.thinking)
 
     @staticmethod
     def _to_openai_content(content):
@@ -154,6 +169,7 @@ class OpenAIProvider(LLMProvider):
                     model=self._config.model, messages=msgs,
                     temperature=temperature, max_tokens=max_tokens,
                     timeout=self._timeout,
+                    **({"extra_body": self._extra_body} if self._extra_body else {}),
                 )
             except _openai.APITimeoutError:
                 logger.error(
@@ -319,6 +335,7 @@ class OpenAIProvider(LLMProvider):
             model=self._config.model, messages=msgs,
             temperature=temperature, max_tokens=max_tokens,
             timeout=self._timeout, stream=True,
+            **({"extra_body": self._extra_body} if self._extra_body else {}),
         ):
             if chunk.choices and chunk.choices[0].finish_reason == "length":
                 logger.warning(

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -69,6 +69,83 @@ async def test_anthropic_provider_includes_system_message():
     assert captured.get("system") == "You are a helpful assistant."
 
 
+# ── thinking / extra_body tests ───────────────────────────────────────────────
+
+def _make_openai_provider(thinking: str = "") -> "OpenAIProvider":
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M3", thinking=thinking)
+    with patch("synthadoc.providers.openai.AsyncOpenAI"):
+        return OpenAIProvider(api_key="test-key", config=cfg)
+
+
+def test_openai_provider_extra_body_disabled():
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M3", thinking="disabled")
+    with patch("synthadoc.providers.openai.AsyncOpenAI"):
+        p = OpenAIProvider(api_key="test-key", config=cfg)
+    assert p._extra_body == {"thinking": {"type": "disabled"}}
+
+
+def test_openai_provider_extra_body_enabled():
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M3", thinking="enabled")
+    with patch("synthadoc.providers.openai.AsyncOpenAI"):
+        p = OpenAIProvider(api_key="test-key", config=cfg)
+    assert p._extra_body == {"thinking": {"type": "adaptive"}}
+
+
+def test_openai_provider_extra_body_empty_by_default():
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M3")
+    with patch("synthadoc.providers.openai.AsyncOpenAI"):
+        p = OpenAIProvider(api_key="test-key", config=cfg)
+    assert p._extra_body == {}
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_passes_extra_body_on_complete():
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M3", thinking="disabled")
+    with patch("synthadoc.providers.openai.AsyncOpenAI") as MockClient:
+        provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    captured: dict = {}
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(finish_reason="stop",
+                                   message=MagicMock(content="hello", model_extra={}))]
+    mock_resp.usage = MagicMock(prompt_tokens=5, completion_tokens=3)
+
+    async def capture(**kwargs):
+        captured.update(kwargs)
+        return mock_resp
+
+    provider._client.chat.completions.create = capture
+    await provider.complete(messages=[Message(role="user", content="hi")])
+    assert captured.get("extra_body") == {"thinking": {"type": "disabled"}}
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_omits_extra_body_when_empty():
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="minimax", model="MiniMax-M3")  # thinking unset
+    with patch("synthadoc.providers.openai.AsyncOpenAI"):
+        provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    captured: dict = {}
+    mock_resp = MagicMock()
+    mock_resp.choices = [MagicMock(finish_reason="stop",
+                                   message=MagicMock(content="hello", model_extra={}))]
+    mock_resp.usage = MagicMock(prompt_tokens=5, completion_tokens=3)
+
+    async def capture(**kwargs):
+        captured.update(kwargs)
+        return mock_resp
+
+    provider._client.chat.completions.create = capture
+    await provider.complete(messages=[Message(role="user", content="hi")])
+    assert "extra_body" not in captured
+
+
 @pytest.mark.asyncio
 async def test_anthropic_provider_retries_on_internal_server_error():
     """InternalServerError is retried; a subsequent success must be returned."""

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -419,6 +419,20 @@ def test_make_provider_minimax_uses_openai_provider_with_base_url(monkeypatch):
     assert provider.supports_vision is True   # M2.5 is natively multimodal
 
 
+def test_make_provider_minimax_propagates_thinking(monkeypatch):
+    """thinking=disabled must survive the cfg_with_url rebind in make_provider."""
+    from synthadoc.config import Config, AgentsConfig, AgentConfig
+    from synthadoc.providers import make_provider
+    from synthadoc.providers.openai import OpenAIProvider
+    monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
+    cfg = Config(agents=AgentsConfig(
+        default=AgentConfig(provider="minimax", model="MiniMax-M3", thinking="disabled")
+    ))
+    provider = make_provider("default", cfg)
+    assert isinstance(provider, OpenAIProvider)
+    assert provider._extra_body == {"thinking": {"type": "disabled"}}
+
+
 def test_make_provider_gemini_uses_openai_provider_with_base_url(monkeypatch):
     from synthadoc.providers import make_provider
     from synthadoc.providers.openai import OpenAIProvider

--- a/tests/providers/test_streaming.py
+++ b/tests/providers/test_streaming.py
@@ -28,6 +28,7 @@ async def test_openai_provider_complete_stream_yields_tokens():
     provider = OpenAIProvider.__new__(OpenAIProvider)
     provider._config = cfg
     provider._timeout = None
+    provider._extra_body = {}
 
     chunk1 = MagicMock(); chunk1.choices = [MagicMock(delta=MagicMock(content="Hello"))]
     chunk2 = MagicMock(); chunk2.choices = [MagicMock(delta=MagicMock(content=" world"))]
@@ -60,6 +61,7 @@ async def test_openai_provider_complete_stream_strips_think_blocks():
     provider = OpenAIProvider.__new__(OpenAIProvider)
     provider._config = cfg
     provider._timeout = None
+    provider._extra_body = {}
 
     # Simulate MiniMax streaming: think block split across tokens
     raw_tokens = ["<think>", "some reasoning", "</think>", "\n\nThe answer is 42."]
@@ -109,6 +111,7 @@ async def test_openai_provider_complete_stream_strips_inline_think_blocks():
     provider = OpenAIProvider.__new__(OpenAIProvider)
     provider._config = cfg
     provider._timeout = None
+    provider._extra_body = {}
 
     # Streaming only produces "synthadoc" (truncated) — complete() gives the full answer
     raw_tokens = ["<think>initial reasoning</think>", "synthadoc"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,42 @@ def test_agent_override_inherits_default(tmp_path):
     assert lint.model == "claude-haiku-4-5"
 
 
+def test_agent_thinking_disabled_parsed(tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text(
+        '[agents]\ndefault = { provider = "minimax", model = "MiniMax-M3", thinking = "disabled" }\n'
+    )
+    cfg = load_config(project_config=cfg_file)
+    assert cfg.agents.default.thinking == "disabled"
+
+
+def test_agent_thinking_defaults_to_empty(tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('[agents]\ndefault = { provider = "minimax", model = "MiniMax-M3" }\n')
+    cfg = load_config(project_config=cfg_file)
+    assert cfg.agents.default.thinking == ""
+
+
+def test_agent_thinking_invalid_value_raises(tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text(
+        '[agents]\ndefault = { provider = "minimax", model = "MiniMax-M3", thinking = "always" }\n'
+    )
+    with pytest.raises(Exception, match="Invalid thinking value"):
+        load_config(project_config=cfg_file)
+
+
+def test_agent_thinking_propagates_through_resolve(tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text(
+        '[agents]\ndefault = { provider = "minimax", model = "MiniMax-M3", thinking = "disabled" }\n'
+        'query = { model = "MiniMax-M3" }\n'
+    )
+    cfg = load_config(project_config=cfg_file)
+    resolved = cfg.agents.resolve("query")
+    assert resolved.thinking == "disabled"
+
+
 def test_cost_defaults():
     cfg = load_config()
     assert cfg.cost.soft_warn_usd == 0.50


### PR DESCRIPTION
What

  Adds a thinking field to AgentConfig so providers that support reasoning control (e.g. MiniMax M3) can have it configured in config.toml, and fixes a bug where that field was silently dropped when building provider instances.

Why

  MiniMax M3 defaults to thinking-enabled mode, which causes the streaming fallback to fire and the entire response to appear at once. Users need to be able to set thinking = "disabled" to get true token-by-token streaming and lower latency/cost.

Changes

  - synthadoc/config.py:  adds thinking: str = "" to AgentConfig; validates against {"", "disabled", "enabled", "adaptive"}; propagates through the agent override merge loop and AgentsConfig.resolve()
  - synthadoc/providers/openai.py: adds _build_extra_body() helper and _THINKING_EXTRA_BODY map; passes extra_body to both complete() and complete_stream() when set
  - synthadoc/providers/__init__.py: fixes make_provider() to propagate thinking=agent_cfg.thinking to the cfg_with_url rebind for minimax, gemini, groq,  and deepseek (was silently dropped, causing streaming fallback for M3)
  - synthadoc/cli/_init.py: adds commented-out MiniMax-M3 entry with thinking = "disabled" to the config.toml template
  - tests/test_config.py: 4 new tests: parsing, default, invalid value, and propagation through resolve()
  - tests/providers/test_providers.py: 5 new tests: extra_body construction, complete() pass-through, omission when empty, and thinking propagation through make_provider()
  - tests/providers/test_streaming.py: adds provider._extra_body = {} to 3 tests that bypass __init__ via __new__