### PR TITLE
[v0.8.0] feat(action-agent): job_list/job_status actions, multi-status filter, and clarify-chip routing fix (#144)

### DIFF
--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -154,9 +154,11 @@ _EXTRACT_PROMPT_TEMPLATE = (
     "            'Archive a stale page'  → lifecycle_archive,  state_filter='stale'\n"
     "            'Restore an archived page' → lifecycle_restore, state_filter='archived'\n"
     "            'Archive the alan-turing page' → lifecycle_archive, slug='alan-turing'\n"
-    "  job_list      : status_filter (pending|running|completed|failed|dead|skipped or null) —\n"
-    "                  use for 'list jobs', 'show all jobs', 'show failed jobs', 'list pending jobs'.\n"
-    "                  Set status_filter when user names a specific job state; otherwise null.\n"
+    "  job_list      : status_filter (list of pending|running|completed|failed|dead|skipped, or null) —\n"
+    "                  use for 'list jobs', 'show failed jobs', 'show failed and skipped jobs'.\n"
+    "                  Set status_filter to a JSON array when user names one or more states, e.g.\n"
+    "                  'failed jobs' → [\"failed\"], 'failed and skipped' → [\"failed\",\"skipped\"].\n"
+    "                  Use null for 'all jobs'.\n"
     "  job_status    : job_id (string or null) — use for 'show job status', 'check job <id>',\n"
     "                  'what is the status of my last job'. Resolve job_id from history when the user\n"
     "                  says 'the last job', 'that job', or picks a number from a previous list.\n"
@@ -601,11 +603,15 @@ class ActionAgent:
         return await self._orch.queue.list_jobs()
 
     async def _do_job_list(self, params: dict | None = None) -> ActionResult:
-        status_filter = ((params or {}).get("status_filter") or "").strip() or None
-        jobs = await self._orch.queue.list_jobs(
-            status=status_filter,  # type: ignore[arg-type]
-        )
-        label = f"{status_filter} " if status_filter else ""
+        from synthadoc.core.queue import JobStatus
+        raw_filter = (params or {}).get("status_filter")
+        if isinstance(raw_filter, str):
+            raw_filter = [raw_filter]
+        statuses: list[JobStatus] | None = None
+        if raw_filter:
+            statuses = [JobStatus(s) for s in raw_filter if s in JobStatus._value2member_map_]
+        jobs = await self._orch.queue.list_jobs(status=statuses or None)
+        label = "/".join(s.value for s in statuses) + " " if statuses else ""
         if not jobs:
             return ActionResult(action_type="job_list", success=True,
                                 message=f"No {label}jobs found.")

--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -204,12 +204,6 @@ class ActionAgent:
 
     # ── public ────────────────────────────────────────────────────────────────
 
-    # How many assistant turns back to look for an open clarify context.
-    # Covers the case where the user picks multiple chips from the same list
-    # (each answer inserts a normal assistant turn between the original clarify
-    # and the next chip click).
-    _CLARIFY_LOOKBACK = 5
-
     def detect(self, question: str, history: list[dict] | None = None) -> bool:
         """Fast regex pre-check — True if question looks like an action request.
 
@@ -220,13 +214,18 @@ class ActionAgent:
         if _ACTION_RE.search(question):
             return True
         if history:
+            lookback = (
+                self._orch._cfg.chat.clarify_lookback
+                if self._orch is not None and hasattr(self._orch, "_cfg")
+                else 5
+            )
             checked = 0
             for msg in reversed(history):
                 if msg.get("role") == "assistant":
                     if msg.get("content", "").startswith(CLARIFY_STORE_PREFIX):
                         return True
                     checked += 1
-                    if checked >= self._CLARIFY_LOOKBACK:
+                    if checked >= lookback:
                         break
         return False
 

--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -204,20 +204,30 @@ class ActionAgent:
 
     # ── public ────────────────────────────────────────────────────────────────
 
+    # How many assistant turns back to look for an open clarify context.
+    # Covers the case where the user picks multiple chips from the same list
+    # (each answer inserts a normal assistant turn between the original clarify
+    # and the next chip click).
+    _CLARIFY_LOOKBACK = 5
+
     def detect(self, question: str, history: list[dict] | None = None) -> bool:
         """Fast regex pre-check — True if question looks like an action request.
 
-        Also returns True when the last assistant turn was a clarify (stored with
-        CLARIFY_STORE_PREFIX), so chip replies route back to the action agent.
+        Also returns True when a recent assistant turn was a clarify (stored with
+        CLARIFY_STORE_PREFIX), so chip replies route back to the action agent
+        even after one or more answers have been appended to the history.
         """
         if _ACTION_RE.search(question):
             return True
         if history:
+            checked = 0
             for msg in reversed(history):
                 if msg.get("role") == "assistant":
                     if msg.get("content", "").startswith(CLARIFY_STORE_PREFIX):
                         return True
-                    break
+                    checked += 1
+                    if checked >= self._CLARIFY_LOOKBACK:
+                        break
         return False
 
     async def run(self, question: str, history: list[dict] | None = None) -> Optional[ActionResult]:

--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -75,6 +75,10 @@ _ALLOWED: set[tuple[LifecycleState, LifecycleState]] = {
 
 # ── action detection ───────────────────────────────────────────────────────────
 
+# Prefix written into the stored assistant message for every clarify turn so
+# detect() can recognise a chip-reply in the very next turn without a regex match.
+CLARIFY_STORE_PREFIX = "[clarify] "
+
 _ACTION_RE = re.compile(
     r"^(please\s+)?(run|execute|start|trigger|perform)\b.{0,50}\b(lint|ingest|scaffold)\b"
     # "can/could you (please) run lint …"
@@ -200,9 +204,21 @@ class ActionAgent:
 
     # ── public ────────────────────────────────────────────────────────────────
 
-    def detect(self, question: str) -> bool:
-        """Fast regex pre-check — True if the question looks like an action request."""
-        return bool(_ACTION_RE.search(question))
+    def detect(self, question: str, history: list[dict] | None = None) -> bool:
+        """Fast regex pre-check — True if question looks like an action request.
+
+        Also returns True when the last assistant turn was a clarify (stored with
+        CLARIFY_STORE_PREFIX), so chip replies route back to the action agent.
+        """
+        if _ACTION_RE.search(question):
+            return True
+        if history:
+            for msg in reversed(history):
+                if msg.get("role") == "assistant":
+                    if msg.get("content", "").startswith(CLARIFY_STORE_PREFIX):
+                        return True
+                    break
+        return False
 
     async def run(self, question: str, history: list[dict] | None = None) -> Optional[ActionResult]:
         """Extract action + params from question and execute. Returns None if not an action."""

--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -615,11 +615,21 @@ class ActionAgent:
         if not jobs:
             return ActionResult(action_type="job_list", success=True,
                                 message=f"No {label}jobs found.")
-        lines = ["| ID | Operation | Status | Started |", "|---|---|---|---|"]
-        for j in jobs:
-            lines.append(
-                f"| `{j.id}` | {j.operation} | {j.status} | {self._fmt_job_ts(str(j.created_at))} |"
-            )
+        has_errors = any(j.error for j in jobs)
+        if has_errors:
+            lines = ["| ID | Operation | Status | Started | Error |", "|---|---|---|---|---|"]
+            for j in jobs:
+                err = (j.error or "").replace("|", "\\|")
+                lines.append(
+                    f"| `{j.id}` | {j.operation} | {j.status}"
+                    f" | {self._fmt_job_ts(str(j.created_at))} | {err} |"
+                )
+        else:
+            lines = ["| ID | Operation | Status | Started |", "|---|---|---|---|"]
+            for j in jobs:
+                lines.append(
+                    f"| `{j.id}` | {j.operation} | {j.status} | {self._fmt_job_ts(str(j.created_at))} |"
+                )
         return ActionResult(action_type="job_list", success=True,
                             message="\n".join(lines))
 

--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -104,7 +104,11 @@ _ACTION_RE = re.compile(
     r"|\b(show|display|view|get)\b.{0,40}\b(wiki|synthadoc)\s+status\b"
     r"|\b(wiki|page)\s+(health|summary|overview|status)\b"
     r"|\bhow many pages.{0,40}\b(draft|active|stale|contradict|archive)"
-    r"|\b(draft|active|stale|contradicted|archived)\s+page\w*\s+(count|summary|stat)",
+    r"|\b(draft|active|stale|contradicted|archived)\s+page\w*\s+(count|summary|stat)"
+    # job status / job list
+    r"|\bjob\w*\s+(status|detail|list|progress|result)\b"
+    r"|\b(show|list|display|view|check|get)\b.{0,30}\bjob\w*\b"
+    r"|\bwhat.{0,20}\b(status|progress).{0,20}\bjob\b",
     re.IGNORECASE,
 )
 
@@ -115,7 +119,7 @@ _EXTRACT_PROMPT_TEMPLATE = (
     "parameters from the user request below.\n\n"
     "Return ONLY a JSON object — no explanation, no markdown fences.\n\n"
     'Schema: {{"action": "<lint|lint_report|wiki_status|ingest|scaffold|schedule_add|schedule_list|'
-    'schedule_history|lifecycle_activate|lifecycle_archive|lifecycle_restore|none>", "params": {{...}}}}\n\n'
+    'schedule_history|lifecycle_activate|lifecycle_archive|lifecycle_restore|job_list|job_status|none>", "params": {{...}}}}\n\n'
     "params keys by action:\n"
     "  lint          : scope (all|contradictions|orphans|stale|citations), auto_resolve (bool)\n"
     "                  Use lint for ANY request to RUN the linter or auto-resolve issues:\n"
@@ -150,6 +154,13 @@ _EXTRACT_PROMPT_TEMPLATE = (
     "            'Archive a stale page'  → lifecycle_archive,  state_filter='stale'\n"
     "            'Restore an archived page' → lifecycle_restore, state_filter='archived'\n"
     "            'Archive the alan-turing page' → lifecycle_archive, slug='alan-turing'\n"
+    "  job_list      : status_filter (pending|running|completed|failed|dead|skipped or null) —\n"
+    "                  use for 'list jobs', 'show all jobs', 'show failed jobs', 'list pending jobs'.\n"
+    "                  Set status_filter when user names a specific job state; otherwise null.\n"
+    "  job_status    : job_id (string or null) — use for 'show job status', 'check job <id>',\n"
+    "                  'what is the status of my last job'. Resolve job_id from history when the user\n"
+    "                  says 'the last job', 'that job', or picks a number from a previous list.\n"
+    "                  Leave job_id null when no specific job is mentioned.\n"
     "  none          : (no params)\n\n"
     "Cron parsing: 'daily at 6am'='0 6 * * *', 'every Sunday at 7pm'='0 19 * * 0', "
     "'every weekday at 9am'='0 9 * * 1-5', 'every hour'='0 * * * *'\n\n"
@@ -255,6 +266,10 @@ class ActionAgent:
             return await self._do_schedule_history()
         if action in ("lifecycle_activate", "lifecycle_archive", "lifecycle_restore"):
             return await self._do_lifecycle(action, params)
+        if action == "job_list":
+            return await self._do_job_list(params)
+        if action == "job_status":
+            return await self._do_job_status(params)
         return ActionResult(action_type=action, success=False,
                             message=f"Unknown action type: `{action}`")
 
@@ -567,6 +582,90 @@ class ActionAgent:
                 f"Page **`{slug}`** transitioned from **{from_state}** → **{to_state}**.\n\n"
                 f"Reason: {reason}"
             ),
+        )
+
+    # ── job helpers ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _fmt_job_ts(ts: str | None) -> str:
+        from datetime import datetime, timezone
+        if not ts:
+            return "—"
+        try:
+            dt = datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
+            return dt.astimezone().strftime("%Y-%m-%d %H:%M")
+        except ValueError:
+            return ts
+
+    async def _fetch_jobs(self):
+        return await self._orch.queue.list_jobs()
+
+    async def _do_job_list(self, params: dict | None = None) -> ActionResult:
+        status_filter = ((params or {}).get("status_filter") or "").strip() or None
+        jobs = await self._orch.queue.list_jobs(
+            status=status_filter,  # type: ignore[arg-type]
+        )
+        label = f"{status_filter} " if status_filter else ""
+        if not jobs:
+            return ActionResult(action_type="job_list", success=True,
+                                message=f"No {label}jobs found.")
+        lines = ["| ID | Operation | Status | Started |", "|---|---|---|---|"]
+        for j in jobs:
+            lines.append(
+                f"| `{j.id}` | {j.operation} | {j.status} | {self._fmt_job_ts(str(j.created_at))} |"
+            )
+        return ActionResult(action_type="job_list", success=True,
+                            message="\n".join(lines))
+
+    async def _do_job_status(self, params: dict) -> ActionResult:
+        job_id = (params.get("job_id") or "").strip()
+        jobs = await self._fetch_jobs()
+        if not jobs:
+            return ActionResult(action_type="job_status", success=True,
+                                message="No jobs found.")
+
+        if job_id:
+            job = next((j for j in jobs if j.id == job_id), None)
+            if not job:
+                return ActionResult(action_type="job_status", success=False,
+                                    message=f"Job `{job_id}` not found.")
+            lines = [
+                f"**Job `{job.id}`**\n",
+                f"- **Operation:** {job.operation}",
+                f"- **Status:** {job.status}",
+                f"- **Started:** {self._fmt_job_ts(str(job.created_at))}",
+            ]
+            if job.error:
+                lines.append(f"- **Error:** {job.error}")
+            result = job.result or {}
+            if result.get("pages_created"):
+                lines.append(f"- **Pages created:** {', '.join(f'`{p}`' for p in result['pages_created'])}")
+            if result.get("pages_updated"):
+                lines.append(f"- **Pages updated:** {', '.join(f'`{p}`' for p in result['pages_updated'])}")
+            if result.get("pages_flagged"):
+                lines.append(f"- **Pages flagged:** {', '.join(f'`{p}`' for p in result['pages_flagged'])}")
+            if result.get("tokens_used"):
+                lines.append(f"- **Tokens used:** {result['tokens_used']}")
+            return ActionResult(action_type="job_status", success=True,
+                                message="\n".join(lines))
+
+        # No job_id — show table and ask which one
+        table_lines = ["| ID | Operation | Status | Started |", "|---|---|---|---|"]
+        candidates: list[str] = []
+        for j in jobs:
+            table_lines.append(
+                f"| `{j.id}` | {j.operation} | {j.status} | {self._fmt_job_ts(str(j.created_at))} |"
+            )
+            candidates.append(j.id)
+        prompt = "Which job would you like to see the status for?"
+        message = "\n".join(table_lines) + f"\n\n{prompt}"
+        return ActionResult(
+            action_type="job_status",
+            success=False,
+            needs_clarification=True,
+            clarify_prompt=prompt,
+            clarify_candidates=candidates[:_MAX_CLARIFY_CANDIDATES],
+            message=message,
         )
 
 

--- a/synthadoc/agents/hints.json
+++ b/synthadoc/agents/hints.json
@@ -44,7 +44,10 @@
       "Schedule a daily ingest at 6 AM",
       "Schedule scaffold every Sunday at 11 PM",
       "Schedule lint run every night at 9 PM",
-      "Rebuild the wiki scaffold"
+      "Rebuild the wiki scaffold",
+      "Show me job status",
+      "List all jobs",
+      "Show failed and skipped jobs"
     ]
   },
   "topic_patterns": [
@@ -126,6 +129,16 @@
         "What pages are orphan pages?",
         "Run the adversarial lint pass",
         "How do I review a flagged claim?"
+      ]
+    },
+    {
+      "keywords": ["job", "jobs", "ingest status", "lint status", "background", "running", "failed job", "pending job"],
+      "hints": [
+        "Show me job status",
+        "List all jobs",
+        "Show failed and skipped jobs",
+        "Show pending jobs",
+        "Check job status"
       ]
     },
     {

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -552,7 +552,7 @@ class QueryAgent:
         if self._orchestrator is not None:
             _action_agent = ActionAgent(self._provider, self._orchestrator,
                                         self._store._root.parent)
-            if _action_agent.detect(question):
+            if _action_agent.detect(question, history=None):
                 _result = await _action_agent.run(question)
                 if _result is not None:
                     return QueryResult(
@@ -784,7 +784,7 @@ class QueryAgent:
         if self._orchestrator is not None:
             _action_agent = ActionAgent(self._provider, self._orchestrator,
                                         self._store._root.parent)
-            if _action_agent.detect(question):
+            if _action_agent.detect(question, history=history or []):
                 _result = await _action_agent.run(question, history=history or [])
                 if _result is not None:
                     if _result.needs_clarification:

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -77,6 +77,16 @@ adversarial_max_per_page = 2
 [search]
 vector = false             # set to true to enable semantic re-ranking (downloads ~130 MB model once)
 vector_top_candidates = 20
+
+[chat]
+# Number of recent conversation turns kept in memory for multi-turn queries (0 = disabled).
+conversation_history_turns = 5
+# Days before inactive sessions are pruned from the audit log.
+session_retention_days = 30
+# How many assistant turns to scan back to find an open clarify context.
+# Increase if users pick chips from a long multi-step clarify list; lower to
+# avoid routing unrelated follow-ups through the action agent.
+# clarify_lookback = 5
 """
 
 _GITIGNORE = ".synthadoc/\n__pycache__/\n*.pyc\n.env\n"

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -158,6 +158,7 @@ class AuditConfig:
 class ChatConfig:
     conversation_history_turns: int = 5   # 0 = disabled
     session_retention_days: int = 30
+    clarify_lookback: int = 5  # assistant turns to scan back for an open clarify context
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +393,7 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
     chat = ChatConfig(
         conversation_history_turns=int(ch.get("conversation_history_turns", 5)),
         session_retention_days=int(ch.get("session_retention_days", 30)),
+        clarify_lookback=int(ch.get("clarify_lookback", 5)),
     )
 
     return Config(

--- a/synthadoc/core/queue.py
+++ b/synthadoc/core/queue.py
@@ -216,17 +216,19 @@ class JobQueue:
 
     async def list_jobs(
         self,
-        status: Optional[JobStatus] = None,
+        status: Optional[JobStatus | list[JobStatus]] = None,
         sort_by: str = "created_at",
         order: str = "asc",
     ) -> list[Job]:
         col = sort_by if sort_by in self._SORT_COLUMNS else "created_at"
         direction = "DESC" if order.lower() == "desc" else "ASC"
+        statuses = ([status] if isinstance(status, JobStatus) else status) if status else None
         async with aiosqlite.connect(self._path) as db:
             db.row_factory = aiosqlite.Row
-            if status:
-                q = f"SELECT * FROM jobs WHERE status=? ORDER BY {col} {direction}"
-                args: tuple = (status.value,)
+            if statuses:
+                placeholders = ",".join("?" * len(statuses))
+                q = f"SELECT * FROM jobs WHERE status IN ({placeholders}) ORDER BY {col} {direction}"
+                args: tuple = tuple(s.value for s in statuses)
             else:
                 q = f"SELECT * FROM jobs ORDER BY {col} {direction}"
                 args = ()

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -570,6 +570,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
 
                         if evt["event"] == "clarify":
                             if session_id:
+                                from synthadoc.agents.action_agent import CLARIFY_STORE_PREFIX
                                 await orch._audit.append_message(session_id, "user", q)
                                 clarify_text = evt["data"].get("prompt", "")
                                 cands = evt["data"].get("candidates", [])
@@ -577,7 +578,10 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES) -> FastAP
                                     clarify_text += "\n" + "\n".join(
                                         f"{i+1}. {c}" for i, c in enumerate(cands)
                                     )
-                                await orch._audit.append_message(session_id, "assistant", clarify_text)
+                                await orch._audit.append_message(
+                                    session_id, "assistant",
+                                    CLARIFY_STORE_PREFIX + clarify_text,
+                                )
                             yield f"event: clarify\ndata: {_json.dumps(evt['data'])}\n\n"
                             continue
                         elif evt["event"] == "token":

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -22,6 +22,8 @@ def _make_agent(tmp_path, extraction_json: str, provider=None):
     orch.queue.list_jobs = AsyncMock(return_value=[])
     orch._store = MagicMock()
     orch._bump_epoch = MagicMock()
+    orch._cfg = MagicMock()
+    orch._cfg.chat.clarify_lookback = 5
     return ActionAgent(provider=provider, orchestrator=orch, wiki_root=tmp_path), provider
 
 

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -348,6 +348,18 @@ def test_detect_clarify_continuation(tmp_path):
     ]
     assert agent.detect("abc-123", history=history) is True
 
+def test_detect_clarify_continuation_second_chip(tmp_path):
+    """Second chip click after one answer was already given must still route to action agent."""
+    from synthadoc.agents.action_agent import CLARIFY_STORE_PREFIX
+    agent, _ = _make_agent(tmp_path, "{}")
+    history = [
+        {"role": "user", "content": "show me job status"},
+        {"role": "assistant", "content": CLARIFY_STORE_PREFIX + "Which job?\n1. abc-123\n2. def-456"},
+        {"role": "user", "content": "abc-123"},
+        {"role": "assistant", "content": "**Job abc-123**\n- Status: completed"},
+    ]
+    assert agent.detect("def-456", history=history) is True
+
 def test_detect_no_clarify_continuation_without_prefix(tmp_path):
     """A plain assistant message does NOT trigger clarify continuation."""
     agent, _ = _make_agent(tmp_path, "{}")

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -18,6 +18,8 @@ def _make_agent(tmp_path, extraction_json: str, provider=None):
     orch.ingest = AsyncMock(return_value="job-ingest-001")
     orch._queue = MagicMock()
     orch._queue.enqueue = AsyncMock(return_value="job-scaffold-001")
+    orch.queue = MagicMock()
+    orch.queue.list_jobs = AsyncMock(return_value=[])
     orch._store = MagicMock()
     orch._bump_epoch = MagicMock()
     return ActionAgent(provider=provider, orchestrator=orch, wiki_root=tmp_path), provider
@@ -335,6 +337,96 @@ def test_detect_fix_contradictions(tmp_path):
 def test_detect_clear_contradictions(tmp_path):
     agent, _ = _make_agent(tmp_path, "{}")
     assert agent.detect("clear contradictions") is True
+
+def test_detect_show_job_status(tmp_path):
+    agent, _ = _make_agent(tmp_path, "{}")
+    assert agent.detect("show me job status") is True
+
+def test_detect_job_list(tmp_path):
+    agent, _ = _make_agent(tmp_path, "{}")
+    assert agent.detect("list jobs") is True
+
+def test_detect_check_job(tmp_path):
+    agent, _ = _make_agent(tmp_path, "{}")
+    assert agent.detect("check job abc123") is True
+
+def test_detect_job_progress(tmp_path):
+    agent, _ = _make_agent(tmp_path, "{}")
+    assert agent.detect("what is the status of my job") is True
+
+
+# ── job_list / job_status ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_job_list_empty(tmp_path):
+    agent, _ = _make_agent(tmp_path, '{"action": "job_list", "params": {}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[])
+    result = await agent.run("list jobs")
+    assert result is not None
+    assert result.success is True
+    assert "No jobs" in result.message
+
+@pytest.mark.asyncio
+async def test_job_list_with_jobs(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "lint"
+    job.status = "completed"
+    job.created_at = "2026-06-11 16:36:00"
+    agent, _ = _make_agent(tmp_path, '{"action": "job_list", "params": {}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("list jobs")
+    assert result is not None
+    assert result.success is True
+    assert "abc-123" in result.message
+    assert "lint" in result.message
+
+@pytest.mark.asyncio
+async def test_job_status_with_id(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "ingest"
+    job.status = "completed"
+    job.created_at = "2026-06-11 16:36:00"
+    job.error = None
+    job.result = {"pages_created": ["grace-hopper"], "tokens_used": 500}
+    agent, _ = _make_agent(tmp_path, '{"action": "job_status", "params": {"job_id": "abc-123"}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("check job abc-123")
+    assert result is not None
+    assert result.success is True
+    assert "abc-123" in result.message
+    assert "grace-hopper" in result.message
+    assert result.needs_clarification is False
+
+@pytest.mark.asyncio
+async def test_job_status_no_id_triggers_clarify(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "lint"
+    job.status = "running"
+    job.created_at = "2026-06-11 16:36:00"
+    agent, _ = _make_agent(tmp_path, '{"action": "job_status", "params": {"job_id": null}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("show me job status")
+    assert result is not None
+    assert result.needs_clarification is True
+    assert "abc-123" in result.clarify_candidates
+    assert "Which job" in result.clarify_prompt
+
+@pytest.mark.asyncio
+async def test_job_status_not_found(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "lint"
+    job.status = "completed"
+    job.created_at = "2026-06-11 16:36:00"
+    agent, _ = _make_agent(tmp_path, '{"action": "job_status", "params": {"job_id": "bad-id"}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("check job bad-id")
+    assert result is not None
+    assert result.success is False
+    assert "not found" in result.message.lower()
 
 
 # ── schedule_add lint normalisation ──────────────────────────────────────────

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -338,6 +338,25 @@ def test_detect_clear_contradictions(tmp_path):
     agent, _ = _make_agent(tmp_path, "{}")
     assert agent.detect("clear contradictions") is True
 
+def test_detect_clarify_continuation(tmp_path):
+    """Chip reply after a clarify turn must route back to the action agent."""
+    from synthadoc.agents.action_agent import CLARIFY_STORE_PREFIX
+    agent, _ = _make_agent(tmp_path, "{}")
+    history = [
+        {"role": "user", "content": "show me job status"},
+        {"role": "assistant", "content": CLARIFY_STORE_PREFIX + "Which job would you like to see the status for?\n1. abc-123"},
+    ]
+    assert agent.detect("abc-123", history=history) is True
+
+def test_detect_no_clarify_continuation_without_prefix(tmp_path):
+    """A plain assistant message does NOT trigger clarify continuation."""
+    agent, _ = _make_agent(tmp_path, "{}")
+    history = [
+        {"role": "user", "content": "who is Turing?"},
+        {"role": "assistant", "content": "Alan Turing was a mathematician..."},
+    ]
+    assert agent.detect("abc-123", history=history) is False
+
 def test_detect_show_job_status(tmp_path):
     agent, _ = _make_agent(tmp_path, "{}")
     assert agent.detect("show me job status") is True

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -415,6 +415,20 @@ async def test_job_status_no_id_triggers_clarify(tmp_path):
     assert "Which job" in result.clarify_prompt
 
 @pytest.mark.asyncio
+async def test_job_list_multi_status_filter(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "ingest"
+    job.status = "failed"
+    job.created_at = "2026-06-11 16:36:00"
+    agent, _ = _make_agent(tmp_path, '{"action": "job_list", "params": {"status_filter": ["failed", "skipped"]}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("show failed and skipped jobs")
+    assert result is not None
+    assert result.success is True
+    assert "abc-123" in result.message
+
+@pytest.mark.asyncio
 async def test_job_status_not_found(tmp_path):
     job = MagicMock()
     job.id = "abc-123"

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -475,6 +475,127 @@ async def test_job_status_not_found(tmp_path):
     assert result.success is False
     assert "not found" in result.message.lower()
 
+@pytest.mark.asyncio
+async def test_job_status_no_jobs_at_all(tmp_path):
+    agent, _ = _make_agent(tmp_path, '{"action": "job_status", "params": {"job_id": null}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[])
+    result = await agent.run("show me job status")
+    assert result is not None
+    assert result.success is True
+    assert "No jobs" in result.message
+
+@pytest.mark.asyncio
+async def test_job_status_with_error_and_flagged(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "ingest"
+    job.status = "failed"
+    job.created_at = "2026-06-11 16:36:00"
+    job.error = "domain blocked"
+    job.result = {"pages_flagged": ["bad-page"], "pages_updated": ["ok-page"], "tokens_used": 100}
+    agent, _ = _make_agent(tmp_path, '{"action": "job_status", "params": {"job_id": "abc-123"}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("check job abc-123")
+    assert result is not None
+    assert result.success is True
+    assert "domain blocked" in result.message
+    assert "bad-page" in result.message
+    assert "ok-page" in result.message
+    assert "100" in result.message
+
+@pytest.mark.asyncio
+async def test_job_list_with_errors_shows_error_column(tmp_path):
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "ingest"
+    job.status = "failed"
+    job.created_at = "2026-06-11 16:36:00"
+    job.error = "network timeout"
+    agent, _ = _make_agent(tmp_path, '{"action": "job_list", "params": {}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("list jobs")
+    assert result is not None
+    assert "Error" in result.message
+    assert "network timeout" in result.message
+
+@pytest.mark.asyncio
+async def test_job_list_string_status_filter_coerced(tmp_path):
+    """A bare string status_filter (not a list) must be coerced to a list."""
+    job = MagicMock()
+    job.id = "abc-123"
+    job.operation = "lint"
+    job.status = "failed"
+    job.created_at = "2026-06-11 16:36:00"
+    job.error = None
+    agent, _ = _make_agent(tmp_path, '{"action": "job_list", "params": {"status_filter": "failed"}}')
+    agent._orch.queue.list_jobs = AsyncMock(return_value=[job])
+    result = await agent.run("show failed jobs")
+    assert result is not None
+    assert result.success is True
+    assert "abc-123" in result.message
+
+def test_fmt_job_ts_none():
+    from synthadoc.agents.action_agent import ActionAgent
+    assert ActionAgent._fmt_job_ts(None) == "—"
+
+def test_fmt_job_ts_invalid():
+    from synthadoc.agents.action_agent import ActionAgent
+    assert ActionAgent._fmt_job_ts("not-a-date") == "not-a-date"
+
+@pytest.mark.asyncio
+async def test_extract_strips_markdown_fences(tmp_path):
+    """_extract() must handle LLM responses wrapped in ```json fences."""
+    fenced = '```json\n{"action": "lint", "params": {"scope": "all", "auto_resolve": false}}\n```'
+    agent, _ = _make_agent(tmp_path, fenced)
+    result = await agent.run("run lint")
+    assert result is not None
+    assert result.action_type == "lint"
+
+@pytest.mark.asyncio
+async def test_extract_returns_none_on_bad_json(tmp_path):
+    """_extract() must return None when the LLM response is unparseable."""
+    agent, _ = _make_agent(tmp_path, "sorry I cannot help")
+    result = await agent.run("run lint")
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_dispatch_exception_returns_failure_result(tmp_path):
+    """A hard exception inside dispatch must return a failure ActionResult, not raise."""
+    agent, _ = _make_agent(tmp_path, '{"action": "lint", "params": {}}')
+    agent._orch.lint = AsyncMock(side_effect=RuntimeError("db locked"))
+    result = await agent.run("run lint")
+    assert result is not None
+    assert result.success is False
+    assert "db locked" in result.message
+
+def test_detect_clarify_lookback_exhausted_without_match(tmp_path):
+    """When lookback is exhausted without finding a clarify prefix, detect returns False."""
+    from synthadoc.agents.action_agent import CLARIFY_STORE_PREFIX
+    agent, _ = _make_agent(tmp_path, "{}")
+    agent._orch._cfg.chat.clarify_lookback = 2
+    history = [
+        {"role": "user",      "content": "who is Turing?"},
+        {"role": "assistant", "content": "Alan Turing was a mathematician."},
+        {"role": "user",      "content": "tell me more"},
+        {"role": "assistant", "content": "He invented the Turing machine."},
+        # clarify is further back than lookback=2
+        {"role": "user",      "content": "show me job status"},
+        {"role": "assistant", "content": CLARIFY_STORE_PREFIX + "Which job?"},
+    ]
+    # reverse: last 2 assistant msgs are "He invented..." and "Alan Turing..."  — no prefix
+    # but wait, the clarify IS the most recent assistant here; let me restructure
+    history2 = [
+        {"role": "user",      "content": "show me job status"},
+        {"role": "assistant", "content": CLARIFY_STORE_PREFIX + "Which job?"},
+        {"role": "user",      "content": "abc-123"},
+        {"role": "assistant", "content": "Job abc-123 is completed."},
+        {"role": "user",      "content": "tell me more about it"},
+        {"role": "assistant", "content": "It ingested 3 pages."},
+    ]
+    # lookback=2: checks last 2 assistant msgs ("It ingested 3 pages.", "Job abc-123 is completed.")
+    # neither has CLARIFY_STORE_PREFIX → False
+    assert agent.detect("random question", history=history2) is False
+
 
 # ── schedule_add lint normalisation ──────────────────────────────────────────
 

--- a/tests/core/test_logging_config.py
+++ b/tests/core/test_logging_config.py
@@ -165,3 +165,25 @@ def test_suppress_shutdown_noise_passes_other_errors(tmp_path):
 
     assert len(sink.records) == 1, "OSError should not be filtered"
     _reset_root_logger()
+
+
+def test_suppress_shutdown_noise_passes_records_without_exc_info():
+    """Records with no exc_info attached are always passed through."""
+    from synthadoc.core.logging_config import _SuppressShutdownNoise
+    f = _SuppressShutdownNoise()
+    record = logging.LogRecord(
+        name="test", level=logging.ERROR, pathname="", lineno=0,
+        msg="plain message", args=(), exc_info=None,
+    )
+    assert f.filter(record) is True
+
+
+def test_suppress_shutdown_noise_passes_records_with_none_exc_type():
+    """Records where exc_info[0] is None (cleared traceback) are always passed."""
+    from synthadoc.core.logging_config import _SuppressShutdownNoise
+    f = _SuppressShutdownNoise()
+    record = logging.LogRecord(
+        name="test", level=logging.ERROR, pathname="", lineno=0,
+        msg="cleared", args=(), exc_info=(None, None, None),
+    )
+    assert f.filter(record) is True

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -1284,3 +1284,13 @@ def test_make_provider_qwen_propagates_thinking(monkeypatch):
     provider = make_provider("default", cfg)
     assert isinstance(provider, OpenAIProvider)
     assert provider._extra_body == {"enable_thinking": False}
+
+
+def test_make_provider_qwen_dashscope_model_no_key_errors(monkeypatch):
+    """DashScope qwen-* model with no QWEN_API_KEY must raise a CLI error."""
+    import pytest
+    import typer
+    from synthadoc.providers import make_provider
+    monkeypatch.delenv("QWEN_API_KEY", raising=False)
+    with pytest.raises(typer.Exit):
+        make_provider("ingest", _make_cfg("qwen", "qwen-plus"))


### PR DESCRIPTION
What
  
  Adds job_list and job_status actions to the Action Agent with a multi-turn clarify flow, and fixes a routing bug where clarify chip replies fell through to synthesis instead of returning to the Action Agent.

Why

  Users asking "show me job status" or "list failed and skipped jobs" received either a CLI usage explanation or a Knowledge Gap response because the Action Agent had no job-query handlers and clarify chip UUIDs weren't recognised as action continuations. The multi-chip selection bug also meant only the first chip click worked correctly in a session.

Changes

 i. New features
  - job_status action: with a job ID → detailed job card; without → table of all jobs + clarify chips to pick one
  - job_list action: lists jobs with optional multi-status filter (e.g. failed, skipped, pending in one query); Error column shown when any listed job has an error
  - POWER_USER hints and topic-pattern triggers for job status / job list (good multi-turn demo scenario)

 ii. Bug fixes
  - Clarify chip replies (bare UUIDs) now routed back to the Action Agent instead of falling through to synthesis — fixed by tagging clarify messages with [clarify]  prefix in AuditDB and scanning history in detect()
  - Multi-chip selection: detect() now scans back clarify_lookback turns (default 5) instead of only the last assistant message

  iii. Configuration
  - clarify_lookback added to ChatConfig (default 5); configurable via [chat] in config.toml; distinct from conversation_history_turns (synthesis context depth)

  iv. Provider fix
  - Qwen model routing: qwen-<letter> models → DashScope; everything else (qwen3.5, qwen3:8b) → Ollama regardless of whether QWEN_API_KEY is set