### PR TITLE
[v0.9.0] feat(okf): OKF type and resource fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ A 3-layer cache (embedding, LLM response, provider prompt cache) means repeated 
 
 Every page is a plain Markdown file with YAML frontmatter. No proprietary format. Open the folder in any editor, put it in git, sync it with any cloud drive.
 
+Synthadoc wikis are also aligned with Google's [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md). Each page carries a `type` field (`concept`, `person`, `technology`, `event`, …) and a `resource` field (primary source URL) that OKF agents can consume directly — no conversion step needed.
+
 ### 7. Wiki structure decays as content grows; Synthadoc regenerates it
 
 As the wiki accumulates pages the `index.md` table of contents, domain scope (`purpose.md`), and LLM behaviour guidelines (`AGENTS.md`) can drift out of sync with actual content. The `scaffold` command re-generates all three from the current wiki state using the LLM — creating category-aware index entries, refreshed scope boundaries, and updated terminology guidelines — without touching pages already linked in the index. Run it once after initial install to get a rich scaffold, then schedule it weekly as the wiki grows.

--- a/docs/design.md
+++ b/docs/design.md
@@ -90,9 +90,11 @@ A Markdown file in `wiki/` with YAML frontmatter:
 ---
 title: Alan Turing
 tags: [computer-science, cryptography, turing-test]
+type: person            # OKF knowledge type — set by IngestAgent during compilation
 status: active          # active | contradicted | archived
 confidence: high        # high | medium | low
 created: '2026-04-10'
+resource: https://example.com/turing-bio  # OKF primary source URL (URL sources only)
 sources:
   - file: turing-biography.pdf
     hash: sha256:abc123…
@@ -104,6 +106,10 @@ sources:
 
 Content with [[wikilinks]] to related pages…
 ```
+
+**`type` values** _(added in v0.9.0, OKF-required field)_: `concept` (default), `person`, `organization`, `technology`, `event`, `location`, `product`. Set automatically by IngestAgent during the analysis pass; absent on pages ingested before v0.9.0.
+
+**`resource`** _(added in v0.9.0, OKF-optional field)_: the primary source URL for pages ingested from a URL source. Absent for local file sources and pre-v0.9.0 pages.
 
 **`status` values:**
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -111,6 +111,17 @@ Content with [[wikilinks]] to related pages…
 
 **`resource`** _(added in v0.9.0, OKF-optional field)_: the primary source URL for pages ingested from a URL source. Absent for local file sources and pre-v0.9.0 pages.
 
+`resource` and `sources` are complementary, not duplicates:
+
+| | `resource` | `sources` |
+|---|---|---|
+| Purpose | OKF external citation — one clean URL for agents and humans to follow | Synthadoc internal provenance — full audit record per contributing file |
+| Cardinality | Single string (or absent) | Array — grows as more files are ingested into the same page |
+| Contents | URL only | File path, SHA-256 hash, byte size, ingestion timestamp |
+| Used for | OKF compatibility; agent consumption without Synthadoc-specific knowledge | Dedup, stale detection, cost audit trail |
+| Local file sources | Absent | Present (file path + hash) |
+| URL sources | Set to the source URL | Also present (URL + hash of URL string) |
+
 **`status` values:**
 
 | Value | Meaning |

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -221,6 +221,31 @@ history-of-computing/
 | `AGENTS.md`           | Domain-specific guidelines the LLM reads on every ingest          |
 | `wiki/purpose.md`     | In-scope / out-of-scope definition for History of Computing       |
 
+### dashboard.md — what each section shows
+
+`wiki/dashboard.md` contains four live Dataview tables. Open it in Obsidian (Reading View) after installing the Dataview plugin to see them update automatically as you work through this guide.
+
+| Section | What it shows | Powered by |
+|---------|--------------|------------|
+| **Contradicted pages** | Pages whose sources conflict — need manual resolution | `status = "contradicted"` |
+| **Orphan pages** | Pages with no inbound `[[wikilinks]]` — run lint first to populate | `orphan = true` (set by lint) |
+| **Recently added** | The 10 most recently created pages, newest first | `created` frontmatter field |
+| **Recently updated** | Pages that have been re-ingested with new source material since their initial creation | `updated` frontmatter field — only present after a re-ingest |
+| **Recently archived** | Pages currently in `archived` state — retired from active use | `status = "archived"` |
+
+**Recently added vs. Recently updated** — these are intentionally separate:
+
+- **Recently added** lists every page by its `created` date. A freshly installed demo wiki shows all pages here because they were all created at install time.
+- **Recently updated** only appears for pages that have been re-ingested after their initial creation. The `updated` field is written by the ingest engine when it merges new source material into an existing page — it is absent on first creation. This means the table starts empty in a fresh install and grows as you re-ingest sources with `--force` or ingest new files that map to existing pages.
+
+**Recently archived** — to restore a page from this list, change its `status` back to `active` in Obsidian's Properties panel, or use the CLI:
+
+```bash
+synthadoc lifecycle restore <slug> --reason "source re-added"
+```
+
+> **Dataview cache:** If a table disagrees with `synthadoc status` or `synthadoc lint report`, drop the cache: `Ctrl/Cmd+P` → **Dataview: Drop all cached file metadata**, then reopen `dashboard.md`. The CLI is always authoritative.
+
 ---
 
 <a name="query-wiki"></a>

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -348,6 +348,15 @@ Every page compiled by Synthadoc also carries two fields that align with Google'
 
 These fields make Synthadoc wikis directly consumable by any OKF-aware agent without an export step. Pages ingested from local files have no `resource` field.
 
+**`resource` vs `sources` — what's the difference?**
+
+Both point at source material, but for different audiences:
+
+- **`sources`** is Synthadoc's internal audit record — an array that grows as more files are ingested into the same page, storing the file path, SHA-256 hash, byte size, and ingestion timestamp. Used for dedup, stale detection, and cost tracking.
+- **`resource`** is the OKF citation — a single URL that any agent or human can follow to the original source, without needing to understand Synthadoc's schema.
+
+For URL sources both refer to the same URL; for local files only `sources` is present.
+
 **Migrating pages created before v0.9.0** — older pages have no `type` field. Force re-ingest to backfill it:
 
 ```bash

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -195,7 +195,7 @@ Open the vault explorer. The key files and folders:
 history-of-computing/
   wiki/                   ← compiled Markdown pages (open these in Obsidian)
     index.md              ← table of contents with [[wikilinks]] to every page
-    dashboard.md          ← live Dataview tables — orphans, contradictions, recent pages
+    dashboard.md          ← live Dataview tables — contradictions, orphans, recently added/updated/archived
     purpose.md            ← scope definition — what belongs in this wiki and what to skip
     overview.md           ← LLM-generated 2-paragraph summary of the entire wiki
     alan-turing.md        ← example pre-built topic page
@@ -216,7 +216,7 @@ history-of-computing/
 | File                  | What to look at                                                   |
 | --------------------- | ----------------------------------------------------------------- |
 | `wiki/index.md`       | Pre-generated category structure with`[[wikilinks]]` to each page |
-| `wiki/dashboard.md`   | Live Dataview tables — will populate after Steps 6–8            |
+| `wiki/dashboard.md`   | Live Dataview tables — contradictions, orphans, recently added / updated / archived |
 | `wiki/alan-turing.md` | YAML frontmatter:`status`, `confidence`, `tags`, `sources[]`      |
 | `AGENTS.md`           | Domain-specific guidelines the LLM reads on every ingest          |
 | `wiki/purpose.md`     | In-scope / out-of-scope definition for History of Computing       |

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -346,7 +346,17 @@ Every page compiled by Synthadoc also carries two fields that align with Google'
 | `type` | Knowledge classifier: `concept`, `person`, `technology`, `event`, `organization`, `location`, or `product` | Ingest — LLM classifies during the analysis pass |
 | `resource` | Primary source URL (only present for URL-sourced pages) | Ingest — auto-populated from the URL |
 
-These fields make Synthadoc wikis directly consumable by any OKF-aware agent without an export step. Pages ingested from local files have no `resource` field. Pages ingested before v0.9.0 have no `type` field — re-ingest them to add it.
+These fields make Synthadoc wikis directly consumable by any OKF-aware agent without an export step. Pages ingested from local files have no `resource` field.
+
+**Migrating pages created before v0.9.0** — older pages have no `type` field. Force re-ingest to backfill it:
+
+```bash
+synthadoc ingest path/to/source.pdf --force
+# or for a URL source
+synthadoc ingest "https://example.com/article" --force
+```
+
+The `--force` flag skips the duplicate check and re-runs the analysis pass, which classifies the knowledge type and writes it to the page's frontmatter. Existing content is appended to, not replaced. If `type` is already set, it is not overwritten.
 
 ---
 

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -337,6 +337,17 @@ synthadoc query "What did Turing contribute to computing?"
 Aliases are matched case-insensitively. Longest match wins — so if two pages each define
 an alias and one is a longer substring of the query, the longer one takes precedence.
 
+### OKF compatibility fields
+
+Every page compiled by Synthadoc also carries two fields that align with Google's [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):
+
+| Field | What it contains | Set by |
+|-------|-----------------|--------|
+| `type` | Knowledge classifier: `concept`, `person`, `technology`, `event`, `organization`, `location`, or `product` | Ingest — LLM classifies during the analysis pass |
+| `resource` | Primary source URL (only present for URL-sourced pages) | Ingest — auto-populated from the URL |
+
+These fields make Synthadoc wikis directly consumable by any OKF-aware agent without an export step. Pages ingested from local files have no `resource` field. Pages ingested before v0.9.0 have no `type` field — re-ingest them to add it.
+
 ---
 
 <a name="batch-ingest"></a>

--- a/obsidian-plugin/package-lock.json
+++ b/obsidian-plugin/package-lock.json
@@ -617,14 +617,14 @@
       "peer": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -636,9 +636,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -646,9 +646,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -680,9 +680,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -697,9 +697,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -714,9 +714,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -799,9 +799,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -816,9 +816,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -850,9 +850,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -886,9 +886,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1780,7 +1780,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1789,13 +1789,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.130.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1805,21 +1805,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.1",
-        "@rolldown/binding-darwin-arm64": "1.0.1",
-        "@rolldown/binding-darwin-x64": "1.0.1",
-        "@rolldown/binding-freebsd-x64": "1.0.1",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-        "@rolldown/binding-linux-arm64-musl": "1.0.1",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-gnu": "1.0.1",
-        "@rolldown/binding-linux-x64-musl": "1.0.1",
-        "@rolldown/binding-openharmony-arm64": "1.0.1",
-        "@rolldown/binding-wasm32-wasi": "1.0.1",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-        "@rolldown/binding-win32-x64-msvc": "1.0.1"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/semver": {
@@ -1905,9 +1905,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1961,17 +1961,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.1",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"

--- a/synthadoc/agents/hints.json
+++ b/synthadoc/agents/hints.json
@@ -24,6 +24,8 @@
       "Which pages are marked stale?",
       "What pages are orphan pages?",
       "Show me pages with contradictions",
+      "Show me recently updated wiki pages",
+      "Show me recently archived wiki pages",
       "Which pages have adversarial warnings?",
       "How do I run a lint check?",
       "Run lint with auto-resolve enabled",
@@ -33,6 +35,8 @@
       "What changed in the wiki this week?",
       "What changed in the wiki this month?",
       "What pages were added this year?",
+      "Show me recently updated wiki pages",
+      "Show me recently archived wiki pages",
       "Which pages have adversarial warnings?",
       "What pages are orphan pages?",
       "Run Synthadoc status",
@@ -76,8 +80,10 @@
       ]
     },
     {
-      "keywords": ["lifecycle", "active", "archive", "draft", "restore", "activate"],
+      "keywords": ["lifecycle", "active", "archive", "archived", "draft", "restore", "activate"],
       "hints": [
+        "Show me recently updated wiki pages",
+        "Show me recently archived wiki pages",
         "Activate a draft page",
         "Archive a stale page",
         "Restore an archived page to draft",
@@ -142,10 +148,12 @@
       ]
     },
     {
-      "keywords": ["changed", "updated", "ingested", "added", "recently", "this week", "this month", "this year"],
+      "keywords": ["changed", "updated", "re-ingested", "ingested", "added", "archived", "recently", "this week", "this month", "this year"],
       "hints": [
         "What changed in the wiki this week?",
         "What changed in the wiki this month?",
+        "Show me recently updated wiki pages",
+        "Show me recently archived wiki pages",
         "What pages were added in the last 3 months?",
         "What pages were added this year?"
       ]

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -45,8 +45,12 @@ class IngestResult:
 _ANALYSIS_PROMPT = (
     "Analyse the source text below. Return ONLY valid JSON with no markdown fences:\n"
     '{"entities": [...], "tags": [...], "summary": "One to three sentences describing '
-    'the main topic, key claims, and relevance.", "relevant": true}\n\n'
-    "Keep entities and tags under 10 items each.\n\n"
+    'the main topic, key claims, and relevance.", '
+    '"type": "concept|person|technology|event|organization|location|product", "relevant": true}\n\n'
+    "Keep entities and tags under 10 items each.\n"
+    'For "type", pick exactly one label: "person" for individuals, "organization" for companies/institutions, '
+    '"technology" for tools/systems/algorithms/standards, "event" for occurrences, '
+    '"location" for places, "product" for commercial products, "concept" for abstract ideas (default).\n\n'
 )
 
 _ENTITY_PROMPT = (
@@ -92,6 +96,7 @@ _OVERVIEW_PROMPT = (
 )
 
 CITATION_PASS4_CACHE_VERSION = "v1"
+ANALYSIS_CACHE_VERSION = "v2"  # bumped to include OKF type field
 _CITATION_EXCERPT_LEN = 100
 _CITATION_RE = re.compile(r'\^\[([^\]:]+):(\d+)-(\d+)\]')
 
@@ -324,9 +329,9 @@ class IngestAgent:
         return result[0] if result else next(iter(ri.branches))
 
     async def _analyse(self, text: str, bust_cache: bool = False) -> dict:
-        """Step 1 — analysis pass: entity extraction + summary. Cached by content hash."""
+        """Step 1 — analysis pass: entity extraction + summary + OKF type. Cached by content hash."""
         text_hash = hashlib.sha256(text.encode()).hexdigest()
-        ck = make_cache_key("analyse-v1", {"text_hash": text_hash}, version=self._cache_version)
+        ck = make_cache_key("analyse-v1", {"text_hash": text_hash}, version=ANALYSIS_CACHE_VERSION)
         if not bust_cache:
             cached = await self._cache.get(ck)
             if cached:
@@ -769,6 +774,8 @@ class IngestAgent:
                             ingested=today,
                         )],
                         created=today,
+                        type=analysis.get("type") or None,
+                        resource=source if is_url(source) else None,
                     )
 
                     # Staging fork: route to candidates/ based on policy

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -115,6 +115,14 @@ _CITATION_PROMPT = (
 _CONFIDENCE_RANK = {"high": 3, "medium": 2, "low": 1}
 
 
+def _backfill_okf_fields(page: "WikiPage", analysis: dict, source: str) -> None:
+    """Backfill type and resource on pages that predate v0.9.0. Never overwrites existing values."""
+    if page.type is None:
+        page.type = analysis.get("type") or None
+    if page.resource is None and is_url(source):
+        page.resource = source
+
+
 def _confidence_passes_threshold(confidence: str, min_confidence: str) -> bool:
     return _CONFIDENCE_RANK.get(confidence, 0) >= _CONFIDENCE_RANK.get(min_confidence, 0)
 
@@ -687,11 +695,7 @@ class IngestAgent:
                         if page.status == LifecycleState.STALE:
                             page.status = LifecycleState.DRAFT
                             self._stale_to_draft_slug = target
-                        # Backfill OKF fields added in v0.9.0 if absent on older pages
-                        if page.type is None:
-                            page.type = analysis.get("type") or None
-                        if page.resource is None and is_url(source):
-                            page.resource = source
+                        _backfill_okf_fields(page, analysis, source)
                         if extracted.metadata.get("has_summary"):
                             section = extracted.text
                         elif update_content:
@@ -740,11 +744,7 @@ class IngestAgent:
                             if page.status == LifecycleState.STALE:
                                 page.status = LifecycleState.DRAFT
                                 self._stale_to_draft_slug = slug
-                            # Backfill OKF fields added in v0.9.0 if absent on older pages
-                            if page.type is None:
-                                page.type = analysis.get("type") or None
-                            if page.resource is None and is_url(source):
-                                page.resource = source
+                            _backfill_okf_fields(page, analysis, source)
                             if extracted.metadata.get("has_summary"):
                                 section = extracted.text
                             else:

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -687,6 +687,11 @@ class IngestAgent:
                         if page.status == LifecycleState.STALE:
                             page.status = LifecycleState.DRAFT
                             self._stale_to_draft_slug = target
+                        # Backfill OKF fields added in v0.9.0 if absent on older pages
+                        if page.type is None:
+                            page.type = analysis.get("type") or None
+                        if page.resource is None and is_url(source):
+                            page.resource = source
                         if extracted.metadata.get("has_summary"):
                             section = extracted.text
                         elif update_content:
@@ -735,6 +740,11 @@ class IngestAgent:
                             if page.status == LifecycleState.STALE:
                                 page.status = LifecycleState.DRAFT
                                 self._stale_to_draft_slug = slug
+                            # Backfill OKF fields added in v0.9.0 if absent on older pages
+                            if page.type is None:
+                                page.type = analysis.get("type") or None
+                            if page.resource is None and is_url(source):
+                                page.resource = source
                             if extracted.metadata.get("has_summary"):
                                 section = extracted.text
                             else:

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -696,6 +696,7 @@ class IngestAgent:
                             page.status = LifecycleState.DRAFT
                             self._stale_to_draft_slug = target
                         _backfill_okf_fields(page, analysis, source)
+                        page.updated = date.today().isoformat()
                         if extracted.metadata.get("has_summary"):
                             section = extracted.text
                         elif update_content:
@@ -745,6 +746,7 @@ class IngestAgent:
                                 page.status = LifecycleState.DRAFT
                                 self._stale_to_draft_slug = slug
                             _backfill_okf_fields(page, analysis, source)
+                            page.updated = date.today().isoformat()
                             if extracted.metadata.get("has_summary"):
                                 section = extracted.text
                             else:

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -822,7 +822,10 @@ class QueryAgent:
 
         citations = [r.slug for r in candidates]
         _purpose_ctx = self._load_purpose_context()
-        _system_ctx = self._get_relevant_system_pages(question)
+        # Use retrieval_question (history-enriched) for keyword/trigger matching so
+        # follow-up messages like "check it again" resolve to the correct live data
+        # and system knowledge. The synthesis prompt still shows the original question.
+        _system_ctx = self._get_relevant_system_pages(retrieval_question)
         _pages_ctx = "\n\n".join(
             f"### {p.title}\n{p.content[:1000]}"
             for r in candidates
@@ -832,7 +835,7 @@ class QueryAgent:
         if _purpose_ctx:
             _ctx_parts.append(_purpose_ctx)
         _is_live_data = False
-        _live_data = await self._fetch_live_wiki_data(question)
+        _live_data = await self._fetch_live_wiki_data(retrieval_question)
         if _system_ctx:
             # System knowledge matched: answer from help pages only; wiki pages are irrelevant noise
             _ctx_parts.append(f"## Synthadoc Help\n{_system_ctx}")
@@ -856,7 +859,7 @@ class QueryAgent:
 
         if _system_ctx or _live_data:
             _gap = False
-        if _gap and _is_introspective(question):
+        if _gap and _is_introspective(retrieval_question):
             _gap = False
 
         synthesis_prompt = self._build_synthesis_prompt(

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -154,6 +154,35 @@ WHERE file.name != "index" AND file.name != "dashboard" AND file.name != "purpos
 SORT created DESC
 LIMIT 10
 ```
+
+---
+
+## Recently updated
+
+```dataview
+TABLE dateformat(date(updated), "MMM dd, yyyy HH:mm:ss") AS "Updated", status, confidence
+FROM "wiki"
+WHERE updated
+  AND file.name != "index" AND file.name != "dashboard" AND file.name != "purpose"
+SORT date(updated) DESC
+LIMIT 10
+```
+
+*Pages that have been re-ingested with new source material since their initial creation.*
+
+---
+
+## Recently archived
+
+```dataview
+TABLE dateformat(file.mtime, "MMM dd, yyyy HH:mm:ss") AS "Archived", confidence
+FROM "wiki"
+WHERE status = "archived"
+SORT file.mtime DESC
+LIMIT 10
+```
+
+*Pages retired from active use. To restore a page, change `status` back to `active`.*
 """
 
 

--- a/synthadoc/cli/demo.py
+++ b/synthadoc/cli/demo.py
@@ -28,10 +28,15 @@ def list_demos():
 def sync_demo(
     name: str = typer.Argument(..., help="Installed wiki name to sync (e.g. history-of-computing)"),
 ) -> None:
-    """Copy any new source files from the bundled demo into an existing installed wiki.
+    """Sync an installed demo wiki with the latest bundled template.
 
-    Additive only — never overwrites existing files. Use this after upgrading Synthadoc
-    to pick up new demo source files without reinstalling.
+    - raw_sources/: copies new files only (additive, never overwrites).
+    - wiki/dashboard.md: updates the Dataview body to the current template
+      while preserving the installed frontmatter (Obsidian-managed fields).
+    - wiki/mechanical-computing.md, wiki/early-neural-networks.md and other
+      new template wiki pages: copied if not already present.
+
+    Use this after upgrading Synthadoc to pick up new features without reinstalling.
     """
     registry = _read_registry()
     entry = registry.get(name)
@@ -46,10 +51,12 @@ def sync_demo(
         typer.echo(f"No bundled demo template found for '{name}'")
         raise typer.Exit(1)
 
-    demo_sources = demo_template / "raw_sources"
-    installed_sources = Path(entry["path"]) / "raw_sources"
+    installed_root = Path(entry["path"])
+    updated: list[str] = []
 
-    copied: list[Path] = []
+    # ── 1. raw_sources: additive copy ─────────────────────────────────────────
+    demo_sources = demo_template / "raw_sources"
+    installed_sources = installed_root / "raw_sources"
     for src in demo_sources.rglob("*"):
         if not src.is_file():
             continue
@@ -58,10 +65,53 @@ def sync_demo(
         if not dest.exists():
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dest)
-            copied.append(relative)
+            updated.append(f"  + raw_sources/{relative}")
 
-    if copied:
-        for rel in sorted(copied):
-            typer.echo(f"  + {rel}")
+    # ── 2. wiki/dashboard.md: replace body, preserve installed frontmatter ────
+    template_dash = demo_template / "wiki" / "dashboard.md"
+    installed_dash = installed_root / "wiki" / "dashboard.md"
+    if template_dash.exists() and installed_dash.exists():
+        tmpl_raw = template_dash.read_text(encoding="utf-8")
+        inst_raw = installed_dash.read_text(encoding="utf-8")
+        tmpl_body = _extract_body(tmpl_raw)
+        inst_fm = _extract_frontmatter_block(inst_raw)
+        new_content = f"---{inst_fm}---\n{tmpl_body}"
+        if new_content.rstrip() != inst_raw.rstrip():
+            installed_dash.write_text(new_content, encoding="utf-8", newline="\n")
+            updated.append("  ~ wiki/dashboard.md  (Dataview sections updated)")
+
+    # ── 3. wiki/: copy new template pages that don't exist yet ────────────────
+    demo_wiki = demo_template / "wiki"
+    installed_wiki = installed_root / "wiki"
+    _SKIP_WIKI = {"index.md", "dashboard.md", "purpose.md"}  # user-authored or handled above
+    for src in demo_wiki.glob("*.md"):
+        if src.name in _SKIP_WIKI:
+            continue
+        dest = installed_wiki / src.name
+        if not dest.exists():
+            shutil.copy2(src, dest)
+            updated.append(f"  + wiki/{src.name}")
+
+    if updated:
+        for line in sorted(updated):
+            typer.echo(line)
     else:
-        typer.echo("Already up to date — no new files to copy.")
+        typer.echo("Already up to date — nothing to sync.")
+
+
+def _extract_body(text: str) -> str:
+    """Return everything after the closing '---' of a YAML frontmatter block."""
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            return parts[2]
+    return "\n" + text
+
+
+def _extract_frontmatter_block(text: str) -> str:
+    """Return the YAML between '---' markers, normalized to exactly one leading/trailing newline."""
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            return "\n" + parts[1].strip() + "\n"
+    return ""

--- a/synthadoc/demos/ai-research/wiki/dashboard.md
+++ b/synthadoc/demos/ai-research/wiki/dashboard.md
@@ -38,3 +38,32 @@ WHERE file.name != "index" AND file.name != "dashboard" AND file.name != "purpos
 SORT created DESC
 LIMIT 10
 ```
+
+---
+
+## Recently Updated
+
+```dataview
+TABLE dateformat(date(updated), "MMM dd, yyyy") AS "Updated", status, confidence
+FROM "wiki"
+WHERE updated
+  AND file.name != "index" AND file.name != "dashboard" AND file.name != "purpose"
+SORT date(updated) DESC
+LIMIT 10
+```
+
+*Pages that have been re-ingested with new source material since their initial creation.*
+
+---
+
+## Recently Archived
+
+```dataview
+TABLE dateformat(file.mtime, "MMM dd, yyyy") AS "Archived", confidence
+FROM "wiki"
+WHERE status = "archived"
+SORT file.mtime DESC
+LIMIT 10
+```
+
+*Pages retired from active use. To restore a page, change `status` back to `active`.*

--- a/synthadoc/demos/ai-research/wiki/early-neural-networks.md
+++ b/synthadoc/demos/ai-research/wiki/early-neural-networks.md
@@ -1,0 +1,27 @@
+---
+title: Early Neural Networks
+tags: [neural-networks, perceptron, history, deep-learning]
+status: archived
+confidence: medium
+created: 2026-05-09
+sources:
+  - file: ai-fundamentals-overview.md
+    hash: a3f8c2d1e4b9071652340abc98def765a3f8c2d1e4b9071652340abc98def765
+    size: 3847
+    ingested: '2026-05-09'
+aliases: []
+---
+
+# Early Neural Networks
+
+Early neural network research spans from McCulloch and Pitts's formal neuron model (1943) through the Perceptron (Rosenblatt, 1957), the first AI winter triggered by Minsky and Papert's *Perceptrons* critique (1969), Hopfield networks (1982), and the backpropagation revival (Rumelhart, Hinton & Williams, 1986).
+
+## The Perceptron
+
+Rosenblatt's Perceptron was the first trainable single-layer network. It could classify linearly separable patterns but failed on XOR — a limitation Minsky and Papert formalised, triggering a decade-long funding freeze.
+
+## The Backpropagation Revival
+
+The 1986 paper by Rumelhart, Hinton, and Williams demonstrated that multi-layer networks trained with backpropagation could learn internal representations, reigniting interest. [[geoffrey-hinton]] continued this line of work through the deep learning breakthroughs of the 2010s.
+
+> **Archived:** This page was an initial survey. The modern continuation of this work — [[attention-mechanisms]], [[transformer-architecture]], and [[training-techniques]] — is now covered by dedicated pages.

--- a/synthadoc/demos/ai-research/wiki/large-language-models.md
+++ b/synthadoc/demos/ai-research/wiki/large-language-models.md
@@ -4,6 +4,7 @@ tags: [llm, transformers, gpt, language-models]
 status: active
 confidence: high
 created: 2026-05-09
+updated: '2026-05-21'
 sources:
   - file: ai-fundamentals-overview.md
     hash: a3f8c2d1e4b9071652340abc98def765a3f8c2d1e4b9071652340abc98def765

--- a/synthadoc/demos/history-of-computing/wiki/dashboard.md
+++ b/synthadoc/demos/history-of-computing/wiki/dashboard.md
@@ -51,3 +51,32 @@ WHERE file.name != "index" AND file.name != "dashboard" AND file.name != "purpos
 SORT created DESC
 LIMIT 10
 ```
+
+---
+
+## Recently updated
+
+```dataview
+TABLE dateformat(date(updated), "MMM dd, yyyy HH:mm:ss") AS "Updated", status, confidence
+FROM "wiki"
+WHERE updated
+  AND file.name != "index" AND file.name != "dashboard" AND file.name != "purpose"
+SORT date(updated) DESC
+LIMIT 10
+```
+
+*Pages that have been re-ingested with new source material since their initial creation.*
+
+---
+
+## Recently archived
+
+```dataview
+TABLE dateformat(file.mtime, "MMM dd, yyyy HH:mm:ss") AS "Archived", confidence
+FROM "wiki"
+WHERE status = "archived"
+SORT file.mtime DESC
+LIMIT 10
+```
+
+*Pages retired from active use. To restore a page, change `status` back to `active`.*

--- a/synthadoc/demos/history-of-computing/wiki/grace-hopper.md
+++ b/synthadoc/demos/history-of-computing/wiki/grace-hopper.md
@@ -4,6 +4,7 @@ tags: [biography, compilers, cobol, navy]
 status: active
 confidence: high
 created: 2026-04-09
+updated: '2026-04-22'
 sources:
   - file: public-domain/hopper-biography-usn.txt
     hash: placeholder

--- a/synthadoc/demos/history-of-computing/wiki/mechanical-computing.md
+++ b/synthadoc/demos/history-of-computing/wiki/mechanical-computing.md
@@ -1,0 +1,25 @@
+---
+title: Mechanical Computing
+tags: [history, mechanical, babbage, pre-electronic]
+status: archived
+confidence: medium
+created: 2026-04-08
+sources:
+  - file: public-domain/babbage-analytical-engine-notes.txt
+    hash: placeholder
+    size: 0
+    ingested: 2026-04-08
+aliases: []
+---
+
+# Mechanical Computing
+
+Mechanical computing refers to information processing performed by physical gear and lever mechanisms, predating electronic computers by more than a century. The tradition runs from Wilhelm Schickard's calculating clock (1623) through Blaise Pascal's Pascaline (1642) to Charles Babbage's Analytical Engine designs (1837).
+
+## Babbage's Analytical Engine
+
+Babbage designed a general-purpose mechanical computer with a *store* (memory), a *mill* (arithmetic unit), and a card-reader for programs — an architecture that anticipates [[von-neumann-architecture]] by over a century. The machine was never completed in his lifetime due to manufacturing tolerances and funding difficulties.
+
+Ada Lovelace translated and expanded Menabrea's account of the Engine in 1843, adding her own notes that contained what is often called the first algorithm intended for machine execution. See [[alan-turing]] for how her work fits into the theoretical lineage of computing.
+
+> **Archived:** This page was an early draft. The topics it covered are now integrated into [[alan-turing]], [[von-neumann-architecture]], and [[programming-languages-overview]]. Kept for reference.

--- a/synthadoc/storage/wiki.py
+++ b/synthadoc/storage/wiki.py
@@ -12,7 +12,8 @@ import yaml
 from filelock import FileLock
 
 _FRONTMATTER_FIELDS = ("title", "tags", "status", "confidence", "created", "sources", "orphan", "categories",
-                       "aliases", "contradiction_note", "unresolved_note", "lint_warnings")
+                       "aliases", "contradiction_note", "unresolved_note", "lint_warnings",
+                       "type", "resource")
 
 
 class LifecycleState:
@@ -62,6 +63,8 @@ class WikiPage:
     contradiction_note: Optional[str] = None   # why this page was flagged during ingest
     unresolved_note: Optional[str] = None      # why auto-resolve could not fix it
     lint_warnings: list[dict] = field(default_factory=list)
+    type: Optional[str] = None                 # OKF knowledge type: concept|person|technology|event|…
+    resource: Optional[str] = None             # OKF primary source URL (URL sources only)
 
 
 def _sources_to_dicts(sources: list[SourceRef]) -> list[dict]:
@@ -132,6 +135,10 @@ class WikiStorage:
                 fm["unresolved_note"] = page.unresolved_note
             if page.lint_warnings:
                 fm["lint_warnings"] = page.lint_warnings
+            if page.type:
+                fm["type"] = page.type
+            if page.resource:
+                fm["resource"] = page.resource
             body = page.content
         else:
             fm = frontmatter or {}
@@ -179,6 +186,8 @@ class WikiStorage:
             contradiction_note=fm.get("contradiction_note") or None,
             unresolved_note=fm.get("unresolved_note") or None,
             lint_warnings=lint_warnings,
+            type=fm.get("type") or None,
+            resource=fm.get("resource") or None,
         )
 
     def page_exists(self, slug: str) -> bool:

--- a/synthadoc/storage/wiki.py
+++ b/synthadoc/storage/wiki.py
@@ -11,8 +11,8 @@ from typing import Optional
 import yaml
 from filelock import FileLock
 
-_FRONTMATTER_FIELDS = ("title", "tags", "status", "confidence", "created", "sources", "orphan", "categories",
-                       "aliases", "contradiction_note", "unresolved_note", "lint_warnings",
+_FRONTMATTER_FIELDS = ("title", "tags", "status", "confidence", "created", "updated", "sources", "orphan",
+                       "categories", "aliases", "contradiction_note", "unresolved_note", "lint_warnings",
                        "type", "resource")
 
 
@@ -63,6 +63,7 @@ class WikiPage:
     contradiction_note: Optional[str] = None   # why this page was flagged during ingest
     unresolved_note: Optional[str] = None      # why auto-resolve could not fix it
     lint_warnings: list[dict] = field(default_factory=list)
+    updated: Optional[str] = None               # ISO date of last re-ingest; absent on initial creation
     type: Optional[str] = None                 # OKF knowledge type: concept|person|technology|event|…
     resource: Optional[str] = None             # OKF primary source URL (URL sources only)
 
@@ -135,6 +136,8 @@ class WikiStorage:
                 fm["unresolved_note"] = page.unresolved_note
             if page.lint_warnings:
                 fm["lint_warnings"] = page.lint_warnings
+            if page.updated:
+                fm["updated"] = page.updated
             if page.type:
                 fm["type"] = page.type
             if page.resource:
@@ -186,6 +189,7 @@ class WikiStorage:
             contradiction_note=fm.get("contradiction_note") or None,
             unresolved_note=fm.get("unresolved_note") or None,
             lint_warnings=lint_warnings,
+            updated=fm.get("updated") or None,
             type=fm.get("type") or None,
             resource=fm.get("resource") or None,
         )

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -415,6 +415,48 @@ async def test_ingest_resource_set_for_url_source(tmp_wiki, cache):
 
 
 @pytest.mark.asyncio
+async def test_force_reingest_backfills_okf_fields(tmp_wiki, cache):
+    """Force re-ingest of an existing page backfills type/resource when they are absent."""
+    from unittest.mock import AsyncMock
+    import itertools
+    p = AsyncMock()
+    _entity_with_type = CompletionResponse(
+        text='{"entities":["Alan Turing"],"tags":["biography"],"type":"person","relevant":true}',
+        input_tokens=100, output_tokens=50,
+    )
+    _decision_update = CompletionResponse(
+        text='{"action":"update","target":"alan-turing","new_slug":"","update_content":"## Extra\\n\\nMore info."}',
+        input_tokens=100, output_tokens=50,
+    )
+    p.complete.side_effect = itertools.cycle([_entity_with_type, _decision_update])
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    # Pre-existing page with no type (simulates page created before v0.9.0)
+    from synthadoc.storage.wiki import WikiPage
+    store.write_page("alan-turing", WikiPage(
+        title="Alan Turing", tags=["biography"], content="# Alan Turing\n\nMathematician.",
+        status="active", confidence="high", sources=[], created="2026-01-01",
+    ))
+    assert store.read_page("alan-turing").type is None
+
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    source = tmp_wiki / "raw_sources" / "turing.md"
+    source.write_text("Alan Turing biography.", encoding="utf-8")
+
+    agent = IngestAgent(provider=p, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15)
+    result = await agent.ingest(str(source), force=True)
+
+    assert "alan-turing" in result.pages_updated
+    page = store.read_page("alan-turing")
+    assert page.type == "person"
+
+
+@pytest.mark.asyncio
 async def test_ingest_resource_none_for_local_file(tmp_wiki, mock_provider, cache):
     """resource field is None for local file sources."""
     store = WikiStorage(tmp_wiki / "wiki")

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -457,6 +457,69 @@ async def test_force_reingest_backfills_okf_fields(tmp_wiki, cache):
 
 
 @pytest.mark.asyncio
+async def test_update_action_stamps_updated_field(tmp_wiki, cache):
+    """Re-ingesting an existing page via update action sets the updated field to today."""
+    from unittest.mock import AsyncMock
+    import itertools
+    from datetime import date
+    p = AsyncMock()
+    _entity = CompletionResponse(
+        text='{"entities":["Alan Turing"],"tags":["biography"],"type":"person","relevant":true}',
+        input_tokens=100, output_tokens=50,
+    )
+    _decision = CompletionResponse(
+        text='{"action":"update","target":"alan-turing","new_slug":"","update_content":"## Extra\\n\\nMore info."}',
+        input_tokens=100, output_tokens=50,
+    )
+    p.complete.side_effect = itertools.cycle([_entity, _decision])
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("alan-turing", WikiPage(
+        title="Alan Turing", tags=["biography"], content="# Alan Turing\n\nMathematician.",
+        status="active", confidence="high", sources=[], created="2026-01-01",
+    ))
+    assert store.read_page("alan-turing").updated is None
+
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    source = tmp_wiki / "raw_sources" / "turing-extra.md"
+    source.write_text("More about Turing.", encoding="utf-8")
+
+    agent = IngestAgent(provider=p, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15)
+    result = await agent.ingest(str(source), force=True)
+
+    assert "alan-turing" in result.pages_updated
+    page = store.read_page("alan-turing")
+    assert page.updated == date.today().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_create_action_leaves_updated_none(tmp_wiki, mock_provider, cache):
+    """Initial ingest (create action) must NOT set the updated field."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    source = tmp_wiki / "raw_sources" / "new.md"
+    source.write_text("# New Topic\nSome brand new content.", encoding="utf-8")
+
+    agent = IngestAgent(provider=mock_provider, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15)
+    result = await agent.ingest(str(source))
+
+    assert result.pages_created
+    page = store.read_page(result.pages_created[0])
+    assert page is not None
+    assert page.updated is None
+
+
+@pytest.mark.asyncio
 async def test_ingest_resource_none_for_local_file(tmp_wiki, mock_provider, cache):
     """resource field is None for local file sources."""
     store = WikiStorage(tmp_wiki / "wiki")

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -333,6 +333,109 @@ async def test_ingest_updates_existing_page(tmp_wiki, cache):
     assert "New detail." in page.content
 
 
+# ── OKF type + resource fields ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_ingest_populates_okf_type(tmp_wiki, cache):
+    """type field from analysis LLM response is written to the created page."""
+    from unittest.mock import AsyncMock
+    import itertools
+    p = AsyncMock()
+    _entity = CompletionResponse(
+        text='{"entities":["Alan Turing"],"tags":["biography"],"type":"person","relevant":true}',
+        input_tokens=100, output_tokens=50,
+    )
+    _decision = CompletionResponse(
+        text='{"action":"create","target":"","new_slug":"alan-turing","update_content":"","page_content":"# Alan Turing\\n\\nBiography."}',
+        input_tokens=100, output_tokens=50,
+    )
+    p.complete.side_effect = itertools.cycle([_entity, _decision])
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    source = tmp_wiki / "raw_sources" / "turing.md"
+    source.write_text("# Alan Turing\nBritish mathematician.", encoding="utf-8")
+
+    agent = IngestAgent(provider=p, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15)
+    result = await agent.ingest(str(source))
+
+    assert result.pages_created
+    page = store.read_page(result.pages_created[0])
+    assert page is not None
+    assert page.type == "person"
+
+
+@pytest.mark.asyncio
+async def test_ingest_resource_set_for_url_source(tmp_wiki, cache):
+    """resource field is auto-populated from the source URL when ingesting a URL."""
+    from unittest.mock import AsyncMock, patch
+    import itertools
+    p = AsyncMock()
+    _entity = CompletionResponse(
+        text='{"entities":["Python"],"tags":["programming"],"type":"technology","relevant":true}',
+        input_tokens=100, output_tokens=50,
+    )
+    _decision = CompletionResponse(
+        text='{"action":"create","target":"","new_slug":"python-lang","update_content":"","page_content":"# Python\\n\\nA programming language."}',
+        input_tokens=100, output_tokens=50,
+    )
+    p.complete.side_effect = itertools.cycle([_entity, _decision])
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    from synthadoc.skills.base import ExtractedContent
+    mock_extracted = ExtractedContent(
+        text="Python is a programming language.",
+        source_path="https://example.com/python",
+        metadata={},
+    )
+
+    agent = IngestAgent(provider=p, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15,
+                        wiki_root=tmp_wiki)
+    with patch.object(agent._skill_agent, "extract", return_value=mock_extracted), \
+         patch.object(agent._skill_agent, "detect_skill") as mock_detect:
+        from synthadoc.skills.base import SkillMeta
+        mock_detect.return_value = SkillMeta(name="url", description="URL skill")
+        result = await agent.ingest("https://example.com/python")
+
+    assert result.pages_created
+    page = store.read_page(result.pages_created[0])
+    assert page is not None
+    assert page.resource == "https://example.com/python"
+
+
+@pytest.mark.asyncio
+async def test_ingest_resource_none_for_local_file(tmp_wiki, mock_provider, cache):
+    """resource field is None for local file sources."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    source = tmp_wiki / "raw_sources" / "local.md"
+    source.write_text("# Local Doc\nSome local content.", encoding="utf-8")
+
+    agent = IngestAgent(provider=mock_provider, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15)
+    result = await agent.ingest(str(source))
+
+    assert result.pages_created
+    page = store.read_page(result.pages_created[0])
+    assert page is not None
+    assert page.resource is None
+
+
 @pytest.mark.asyncio
 async def test_ingest_hash_size_mismatch_warns_and_proceeds(tmp_wiki, mock_provider, caplog, cache):
     """Hash match + size differs → log warning, treat as new source (not a skip)."""

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -2294,3 +2294,65 @@ async def test_run_stream_history_injected_into_synthesis_prompt(tmp_wiki):
     assert captured_messages, "complete_stream was never called"
     prompt_text = captured_messages[0].content
     assert "Conversation so far" in prompt_text and "what about earlier?" in prompt_text
+
+
+@pytest.mark.asyncio
+async def test_run_stream_followup_uses_rewritten_question_for_live_data(tmp_wiki):
+    """Ambiguous follow-up ('check it again') must not trigger a gap when
+    RewriteAgent resolves it to a job-status query.
+
+    Regression: live-data and system-knowledge lookups used the original question;
+    context-dependent phrases like 'check it again' have no live-data triggers,
+    so _live_data was empty → gap fired. Fix: use retrieval_question for lookups.
+    """
+    from unittest.mock import MagicMock
+    sd = tmp_wiki / ".synthadoc"
+    sd.mkdir(parents=True, exist_ok=True)
+    audit = AuditDB(sd / "audit.db")
+    await audit.init()
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+
+    provider = AsyncMock()
+    provider.complete.return_value = CompletionResponse(
+        text='["check job status a95c6a33"]', input_tokens=5, output_tokens=5
+    )
+    async def _fake_stream(**kw):
+        yield "Job a95c6a33 is now running."
+    provider.complete_stream = _fake_stream
+
+    mock_job = MagicMock()
+    mock_job.status = MagicMock()
+    mock_job.status.value = "running"
+    mock_job.operation = "lint"
+    mock_job.retries = 0
+    mock_job.error = None
+    mock_job.created_at = "2026-06-16T14:11:16"
+
+    mock_queue = AsyncMock()
+    mock_queue.get_job.return_value = mock_job
+
+    mock_orchestrator = MagicMock()
+    mock_orchestrator._queue = mock_queue
+
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=2.0, orchestrator=mock_orchestrator)
+
+    history = [
+        {"role": "user", "content": "Job ID: a95c6a33"},
+        {"role": "assistant", "content": "Job a95c6a33 is pending."},
+    ]
+
+    with patch("synthadoc.agents.query_agent.RewriteAgent") as mock_rw_cls, \
+         patch("synthadoc.agents.query_agent.ActionAgent") as mock_action_cls:
+        mock_rw_cls.return_value.rewrite = AsyncMock(return_value="check job status a95c6a33")
+        mock_action_cls.return_value.detect.return_value = False
+
+        events = await _collect_events(agent.run_stream("check it again", history=history))
+
+    done_ev = next(e for e in events if e["event"] == "done")
+    assert done_ev["data"].get("gap", False) is False, (
+        "Knowledge Gap must not fire for a job follow-up resolved via retrieval_question"
+    )
+    mock_queue.get_job.assert_called_once_with("a95c6a33")

--- a/tests/cli/test_demo_sync.py
+++ b/tests/cli/test_demo_sync.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from synthadoc.cli.demo import _extract_body, _extract_frontmatter_block, sync_demo
+
+
+# ── helper tests ────────────────────────────────────────────────────────────
+
+def test_extract_body_with_frontmatter():
+    text = "---\ntitle: Test\n---\n\n# Hello\n"
+    assert _extract_body(text) == "\n\n# Hello\n"
+
+
+def test_extract_body_no_frontmatter():
+    text = "# No frontmatter\n"
+    body = _extract_body(text)
+    assert "# No frontmatter" in body
+
+
+def test_extract_frontmatter_block_returns_normalized_yaml():
+    text = "---\ntitle: Test\nstatus: active\n---\n\n# Body\n"
+    fm = _extract_frontmatter_block(text)
+    assert fm == "\ntitle: Test\nstatus: active\n"
+    assert fm.startswith("\n")
+    assert fm.endswith("\n")
+
+
+def test_extract_frontmatter_block_normalizes_double_newline():
+    """If the installed file already has a spurious blank line, it must be stripped."""
+    text = "---\n\ntitle: Test\nstatus: active\n---\n\n# Body\n"
+    fm = _extract_frontmatter_block(text)
+    assert fm == "\ntitle: Test\nstatus: active\n"
+
+
+def test_extract_frontmatter_block_no_frontmatter():
+    text = "# No frontmatter\n"
+    assert _extract_frontmatter_block(text) == ""
+
+
+# ── sync_demo integration tests ─────────────────────────────────────────────
+
+def _make_template(tmp_path: Path, name: str) -> Path:
+    """Create a minimal demo template directory."""
+    tmpl = tmp_path / "templates" / name
+    (tmpl / "raw_sources").mkdir(parents=True)
+    (tmpl / "wiki").mkdir(parents=True)
+
+    (tmpl / "raw_sources" / "source_a.txt").write_text("Source A\n", encoding="utf-8")
+    (tmpl / "wiki" / "dashboard.md").write_text(
+        "---\ntitle: Dashboard\n---\n\n## Section\nNew body.\n",
+        encoding="utf-8",
+    )
+    (tmpl / "wiki" / "new-page.md").write_text(
+        "---\ntitle: New Page\n---\n\nContent.\n",
+        encoding="utf-8",
+    )
+    return tmpl
+
+
+def _make_installed(tmp_path: Path, name: str) -> Path:
+    """Create a minimal installed wiki directory."""
+    inst = tmp_path / "installed" / name
+    (inst / "raw_sources").mkdir(parents=True)
+    (inst / "wiki").mkdir(parents=True)
+
+    (inst / "raw_sources" / "source_a.txt").write_text("Source A\n", encoding="utf-8")
+    (inst / "wiki" / "dashboard.md").write_text(
+        "---\naliases: []\ncategories:\n- Overview\ntitle: Dashboard\n---\n\n## Old Section\nOld body.\n",
+        encoding="utf-8",
+    )
+    return inst
+
+
+def test_sync_copies_new_raw_sources(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+    (tmpl / "raw_sources" / "source_b.txt").write_text("Source B\n", encoding="utf-8")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        result = CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+
+    assert result.exit_code == 0
+    assert (inst / "raw_sources" / "source_b.txt").exists()
+
+
+def test_sync_does_not_overwrite_existing_raw_sources(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+    (inst / "raw_sources" / "source_a.txt").write_text("User edited\n", encoding="utf-8")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+
+    assert (inst / "raw_sources" / "source_a.txt").read_text() == "User edited\n"
+
+
+def test_sync_updates_dashboard_body_preserves_frontmatter(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+
+    result = (inst / "wiki" / "dashboard.md").read_text(encoding="utf-8")
+    assert "aliases: []" in result
+    assert "categories:" in result
+    assert "Overview" in result
+    assert "New body." in result
+    assert "Old body." not in result
+
+
+def test_sync_dashboard_frontmatter_no_double_newline(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+
+    content = (inst / "wiki" / "dashboard.md").read_text(encoding="utf-8")
+    assert not content.startswith("---\n\n"), "No blank line after opening ---"
+
+
+def test_sync_is_idempotent(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    from typer.testing import CliRunner
+    from synthadoc.cli.demo import demo_app
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+        after_first = (inst / "wiki" / "dashboard.md").read_text(encoding="utf-8")
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        result = CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+        after_second = (inst / "wiki" / "dashboard.md").read_text(encoding="utf-8")
+
+    assert after_first == after_second
+    assert "Already up to date" in result.output
+
+
+def test_sync_copies_new_wiki_pages(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+
+    assert (inst / "wiki" / "new-page.md").exists()
+
+
+def test_sync_skips_protected_wiki_pages(tmp_path):
+    tmpl = _make_template(tmp_path, "test-wiki")
+    inst = _make_installed(tmp_path, "test-wiki")
+    (tmpl / "wiki" / "index.md").write_text("Template index\n", encoding="utf-8")
+    (inst / "wiki" / "index.md").write_text("User index\n", encoding="utf-8")
+
+    registry = {"test-wiki": {"path": str(inst)}}
+    demos = {"test-wiki": tmpl}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        CliRunner().invoke(demo_app, ["sync", "test-wiki"])
+
+    assert (inst / "wiki" / "index.md").read_text() == "User index\n"
+
+
+def test_sync_unknown_wiki_exits_nonzero(tmp_path):
+    registry = {}
+    demos = {}
+
+    with patch("synthadoc.cli.demo._read_registry", return_value=registry), \
+         patch("synthadoc.cli.demo._DEMOS", demos):
+        from typer.testing import CliRunner
+        from synthadoc.cli.demo import demo_app
+        result = CliRunner().invoke(demo_app, ["sync", "does-not-exist"])
+
+    assert result.exit_code != 0

--- a/tests/storage/test_wiki.py
+++ b/tests/storage/test_wiki.py
@@ -237,3 +237,50 @@ def test_lint_warnings_null_claim_round_trip(tmp_wiki):
     assert loaded is not None
     assert loaded.lint_warnings[0]["claim"] is None
     assert "rate limit" in loaded.lint_warnings[0]["concern"]
+
+
+# ── OKF fields ──────────────────────────────────────────────────────────────
+
+def test_type_resource_roundtrip(tmp_wiki):
+    """type and resource fields must survive a write/read cycle."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    page = WikiPage(title="Alan Turing", tags=[], content="Body.",
+                    status="active", confidence="high", sources=[],
+                    type="person", resource="https://example.com/turing")
+    store.write_page("alan-turing", page)
+    loaded = store.read_page("alan-turing")
+    assert loaded is not None
+    assert loaded.type == "person"
+    assert loaded.resource == "https://example.com/turing"
+
+
+def test_type_none_omitted_from_yaml(tmp_wiki):
+    """type=None must not emit a 'type:' key in the YAML frontmatter."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("no-type", WikiPage(title="X", tags=[], content="body",
+                     status="active", confidence="medium", sources=[]))
+    raw = (tmp_wiki / "wiki" / "no-type.md").read_text()
+    assert "type:" not in raw
+
+
+def test_resource_none_omitted_from_yaml(tmp_wiki):
+    """resource=None must not emit a 'resource:' key in the YAML frontmatter."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("no-resource", WikiPage(title="X", tags=[], content="body",
+                     status="active", confidence="medium", sources=[]))
+    raw = (tmp_wiki / "wiki" / "no-resource.md").read_text()
+    assert "resource:" not in raw
+
+
+def test_type_resource_missing_defaults_to_none(tmp_wiki):
+    """Pages written without type/resource fields must read back as None (backward compat)."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    (tmp_wiki / "wiki").mkdir(parents=True, exist_ok=True)
+    (tmp_wiki / "wiki" / "old-page.md").write_text(
+        "---\ntitle: Old\ntags: []\nstatus: active\nconfidence: high\nsources: []\n---\n\nbody",
+        encoding="utf-8"
+    )
+    loaded = store.read_page("old-page")
+    assert loaded is not None
+    assert loaded.type is None
+    assert loaded.resource is None

--- a/tests/storage/test_wiki.py
+++ b/tests/storage/test_wiki.py
@@ -284,3 +284,39 @@ def test_type_resource_missing_defaults_to_none(tmp_wiki):
     assert loaded is not None
     assert loaded.type is None
     assert loaded.resource is None
+
+
+# ── updated field ─────────────────────────────────────────────────────────────
+
+def test_updated_roundtrip(tmp_wiki):
+    """updated field must survive a write/read cycle."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    page = WikiPage(title="Test", tags=[], content="body",
+                    status="active", confidence="high", sources=[],
+                    updated="2026-06-01")
+    store.write_page("test-updated", page)
+    loaded = store.read_page("test-updated")
+    assert loaded is not None
+    assert loaded.updated == "2026-06-01"
+
+
+def test_updated_none_omitted_from_yaml(tmp_wiki):
+    """updated=None must not emit an 'updated:' key in YAML frontmatter."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("no-updated", WikiPage(title="X", tags=[], content="body",
+                     status="active", confidence="medium", sources=[]))
+    raw = (tmp_wiki / "wiki" / "no-updated.md").read_text()
+    assert "updated:" not in raw
+
+
+def test_updated_missing_defaults_to_none(tmp_wiki):
+    """Pages written without updated field must read back as None (backward compat)."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    (tmp_wiki / "wiki").mkdir(parents=True, exist_ok=True)
+    (tmp_wiki / "wiki" / "legacy.md").write_text(
+        "---\ntitle: Legacy\ntags: []\nstatus: active\nconfidence: high\nsources: []\n---\n\nbody",
+        encoding="utf-8"
+    )
+    loaded = store.read_page("legacy")
+    assert loaded is not None
+    assert loaded.updated is None


### PR DESCRIPTION
What

  Adds OKF v0.1 compliance fields (type, resource) to every wiki page.


Why

  Google's Open Knowledge Format v0.1 defines two fields that Synthadoc didn't yet emit,  type (the only required OKF field, classifying knowledge kind) and resource (optional primary source URL). Adding them makes every Synthadoc wiki directly consumable by OKF-aware agents without a conversion step.  


Changes

i. OKF fields (feat + fix):
  - WikiPage dataclass gains type: Optional[str] and resource: Optional[str]; both are omitted from YAML when None — backward compatible with existing wikis
  - _ANALYSIS_PROMPT extended to ask the LLM to classify the knowledge type (concept, person, technology, event, organization, location, product); analysis cache bumped to v2 so old entries are transparently superseded
  - resource auto-populated from the source URL on URL ingests; absent for local file sources
  - Both fields backfilled on force re-ingest of existing pages (when currently None) — migration path for pre-v0.9.0 pages
  - 8 new tests across storage and ingest layers; coverage stays at 91%

ii. Docs:
  - design.md: frontmatter example updated; resource vs sources distinction documented with comparison table
  - README.md: OKF alignment paragraph added
  - user-quick-start-guide.md: OKF compatibility fields section with migration instructions and resource vs sources explanation