### PR TITLE
fix(test): suppress PytestUnhandledThreadExceptionWarning from aiosql…

### DIFF
--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -128,6 +128,7 @@ class Orchestrator:
 
     async def close(self) -> None:
         await self._cache.close()
+        await asyncio.sleep(0)  # drain pending aiosqlite thread callbacks before loop teardown
 
     async def _run_vector_migration(self) -> None:
         """Embed all existing wiki pages not yet in embeddings.db (background task)."""

--- a/tests/core/test_orchestrator_cost.py
+++ b/tests/core/test_orchestrator_cost.py
@@ -152,9 +152,12 @@ async def test_orchestrator_ingest_sets_nonzero_cost_for_known_model(tmp_wiki):
     cfg = _cfg("anthropic", "claude-haiku-4-5-20251001")
     orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
     await orch.init()
-    cost = await _run_and_capture_ingest_cost(orch, input_tokens=1000, output_tokens=500)
-    assert cost is not None, "queue.complete() must be called with cost_usd"
-    assert cost > 0.0, "Known paid model must produce non-zero ingest cost"
+    try:
+        cost = await _run_and_capture_ingest_cost(orch, input_tokens=1000, output_tokens=500)
+        assert cost is not None, "queue.complete() must be called with cost_usd"
+        assert cost > 0.0, "Known paid model must produce non-zero ingest cost"
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -163,8 +166,11 @@ async def test_orchestrator_ingest_sets_zero_cost_for_ollama(tmp_wiki):
     cfg = _cfg("ollama", "llama3")
     orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
     await orch.init()
-    cost = await _run_and_capture_ingest_cost(orch, input_tokens=1000, output_tokens=500)
-    assert cost == 0.0, "Ollama must record $0.00 ingest cost"
+    try:
+        cost = await _run_and_capture_ingest_cost(orch, input_tokens=1000, output_tokens=500)
+        assert cost == 0.0, "Ollama must record $0.00 ingest cost"
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…ite teardown

Orchestrator.close() now yields to the event loop (asyncio.sleep(0)) so any in-flight aiosqlite background-thread callbacks can deliver before pytest closes the loop. The two ingest-cost tests that hit this race wrap the work in try/finally and call orch.close(), ensuring the drain runs even on assertion failure.