### PR TITLE
fix(youtube): catch TranscriptsDisabled and skip gracefully

### DIFF
--- a/synthadoc/skills/youtube/scripts/main.py
+++ b/synthadoc/skills/youtube/scripts/main.py
@@ -109,6 +109,7 @@ class YoutubeSkill(BaseSkill):
         from youtube_transcript_api import (
             YouTubeTranscriptApi,
             NoTranscriptFound,
+            TranscriptsDisabled,
             VideoUnavailable,
         )
 
@@ -120,10 +121,10 @@ class YoutubeSkill(BaseSkill):
         api = YouTubeTranscriptApi()
         try:
             fetched = await asyncio.to_thread(api.fetch, video_id)
-        except NoTranscriptFound:
+        except (NoTranscriptFound, TranscriptsDisabled):
             logger.warning(
                 "youtube: no captions available for %s — "
-                "enable auto-generated captions or choose a different video",
+                "subtitles are disabled or unavailable for this video",
                 source,
             )
             return ExtractedContent(


### PR DESCRIPTION
Videos with subtitles explicitly disabled raised an unhandled TranscriptsDisabled exception, crashing the ingest worker with an ERROR log. Now treated identically to NoTranscriptFound, logged as a warning and the source is skipped cleanly.