### PR TITLE
docs: add multi-platform media index and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1197,7 +1197,7 @@ For full examples, API signatures, and intent-dispatch config see [docs/design.m
 
 ## Links
 
-- Blogs: [forem.com](https://forem.com/paul_chen_90371fe7426cb44)
+- Blogs & Media: [docs/media/](docs/media/README.md) — DEV.to, Medium, Coderlegion, YouTube
 - Design document: [docs/design.md](docs/design.md)
 - Quick-Start Guide: [docs/user-quick-start-guide.md](docs/user-quick-start-guide.md)
 - Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -1,34 +1,8 @@
 # Synthadoc — Blogs & Media
 
-Articles, tutorials, and videos about Synthadoc across all platforms.
-
 | Platform | Content |
 |---|---|
-| [DEV.to](#devto) | Architecture and release posts |
-| [Medium](#medium) | Long-form tutorials and deep dives |
-| [Coderlegion](#coderlegion) | Architecture and design pattern posts |
-| [YouTube](#youtube) | Video walkthroughs and demos |
-
----
-
-## DEV.to
-
-All Synthadoc posts on DEV.to: [forem.com/paul_chen_90371fe7426cb44](https://forem.com/paul_chen_90371fe7426cb44)
-
----
-
-## Medium
-
-See [medium.md](medium.md) for the full list.
-
----
-
-## Coderlegion
-
-See [coderlegion.md](coderlegion.md) for the full list.
-
----
-
-## YouTube
-
-Synthadoc channel: [youtube.com/channel/UCz62fdGOkka3EGP7AEb_ntw](https://www.youtube.com/channel/UCz62fdGOkka3EGP7AEb_ntw)
+| [DEV.to](https://forem.com/paul_chen_90371fe7426cb44) | Architecture, use cases and design posts |
+| [Medium](medium.md) | Long-form tutorials and deep dives |
+| [Coderlegion](coderlegion.md) | Architecture and design pattern posts |
+| [YouTube](https://www.youtube.com/channel/UCz62fdGOkka3EGP7AEb_ntw) | Video walkthroughs and demos |

--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -1,0 +1,34 @@
+# Synthadoc — Blogs & Media
+
+Articles, tutorials, and videos about Synthadoc across all platforms.
+
+| Platform | Content |
+|---|---|
+| [DEV.to](#devto) | Architecture and release posts |
+| [Medium](#medium) | Long-form tutorials and deep dives |
+| [Coderlegion](#coderlegion) | Architecture and design pattern posts |
+| [YouTube](#youtube) | Video walkthroughs and demos |
+
+---
+
+## DEV.to
+
+All Synthadoc posts on DEV.to: [forem.com/paul_chen_90371fe7426cb44](https://forem.com/paul_chen_90371fe7426cb44)
+
+---
+
+## Medium
+
+See [medium.md](medium.md) for the full list.
+
+---
+
+## Coderlegion
+
+See [coderlegion.md](coderlegion.md) for the full list.
+
+---
+
+## YouTube
+
+Synthadoc channel: [youtube.com/channel/UCz62fdGOkka3EGP7AEb_ntw](https://www.youtube.com/channel/UCz62fdGOkka3EGP7AEb_ntw)

--- a/docs/media/coderlegion.md
+++ b/docs/media/coderlegion.md
@@ -1,0 +1,7 @@
+# Synthadoc on Coderlegion
+
+All Synthadoc-related articles published on Coderlegion.
+
+- [Four Interfaces, One Knowledge Layer: A Design Pattern for AI Knowledge Systems](https://coderlegion.com/21092/four-interfaces-one-knowledge-layer-a-design-pattern-for-ai-knowledge-systems)
+- [Synthadoc: Your Coding Tool Is Now Your Wiki Brain](https://coderlegion.com/16865/synthadoc-your-coding-tool-is-now-your-wiki-brain)
+- [Synthadoc: Beyond Keyword Search — How It Combines BM25 + Vector Search to Build a Smarter Domain Wiki](https://coderlegion.com/16864/synthadoc-beyond-keyword-search-how-combines-bm25-vector-search-build-smarter-domain-wiki)

--- a/docs/media/medium.md
+++ b/docs/media/medium.md
@@ -1,0 +1,6 @@
+# Synthadoc on Medium
+
+All Synthadoc-related articles published on Medium.
+
+- [From YouTube to Wiki: How Synthadoc v0.3.0 Turns Any Content into Structured Knowledge](https://medium.com/@chenp02/from-youtube-to-wiki-how-synthadoc-v0-3-0-turns-any-content-into-structured-knowledge-13e7430ca4d9)
+- [Why LLM Wiki Beats RAG for Domain Expertise (and How We Built It)](https://medium.com/@chenp02/why-llm-wiki-beats-rag-for-domain-expertise-and-how-we-built-it-2039d7435d69)

--- a/docs/media/medium.md
+++ b/docs/media/medium.md
@@ -2,5 +2,5 @@
 
 All Synthadoc-related articles published on Medium.
 
-- [From YouTube to Wiki: How Synthadoc v0.3.0 Turns Any Content into Structured Knowledge](https://medium.com/@chenp02/from-youtube-to-wiki-how-synthadoc-v0-3-0-turns-any-content-into-structured-knowledge-13e7430ca4d9)
 - [Why LLM Wiki Beats RAG for Domain Expertise (and How We Built It)](https://medium.com/@chenp02/why-llm-wiki-beats-rag-for-domain-expertise-and-how-we-built-it-2039d7435d69)
+- [From YouTube to Wiki: How Synthadoc v0.3.0 Turns Any Content into Structured Knowledge](https://medium.com/@chenp02/from-youtube-to-wiki-how-synthadoc-v0-3-0-turns-any-content-into-structured-knowledge-13e7430ca4d9)


### PR DESCRIPTION
Replaces the single DEV.to blog link in the README with a structured media index under docs/media/.