### PR TITLE
fix(mcp): live test all 12 tools and fix 4 bugs found (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Synthadoc reads your raw source documents — PDFs, spreadsheets, PPTs, web page
 
 [![Watch the Synthadoc demo](https://img.youtube.com/vi/rIGO6zi9XQE/maxresdefault.jpg)](https://www.youtube.com/watch?v=rIGO6zi9XQE)
 
-▶ [From Documents to Wiki — demo walkthrough](https://www.youtube.com/watch?v=rIGO6zi9XQE) · [Four Interfaces: CLI, Obsidian, Web UI & MCP](https://youtu.be/ue_kHhG0iog)
+▶ [From Documents to Wiki — demo walkthrough](https://www.youtube.com/watch?v=rIGO6zi9XQE) · Also watch: [Four Interfaces: CLI, Obsidian, Web UI & MCP](https://youtu.be/ue_kHhG0iog)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Synthadoc reads your raw source documents — PDFs, spreadsheets, PPTs, web page
 
 [![Watch the Synthadoc demo](https://img.youtube.com/vi/rIGO6zi9XQE/maxresdefault.jpg)](https://www.youtube.com/watch?v=rIGO6zi9XQE)
 
-▶ [Watch the demo on YouTube](https://www.youtube.com/watch?v=rIGO6zi9XQE)
+▶ [From Documents to Wiki — demo walkthrough](https://www.youtube.com/watch?v=rIGO6zi9XQE) · [Four Interfaces: CLI, Obsidian, Web UI & MCP](https://youtu.be/ue_kHhG0iog)
 
 ---
 

--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -5,4 +5,4 @@
 | [DEV.to](https://forem.com/paul_chen_90371fe7426cb44) | Architecture, use cases and design posts |
 | [Medium](medium.md) | Long-form tutorials and deep dives |
 | [Coderlegion](coderlegion.md) | Architecture and design pattern posts |
-| [YouTube](https://www.youtube.com/channel/UCz62fdGOkka3EGP7AEb_ntw) | Video walkthroughs and demos |
+| [YouTube](youtube.md) | Video walkthroughs and demos |

--- a/docs/media/youtube.md
+++ b/docs/media/youtube.md
@@ -1,0 +1,6 @@
+# Synthadoc on YouTube
+
+All Synthadoc video walkthroughs and demos.
+
+- [Four Interfaces: CLI, Obsidian, Web UI & MCP](https://youtu.be/ue_kHhG0iog) — how to interact with your wiki across four surfaces, 5-state lifecycle in action, multi-turn conversation, and OKF export
+- [From Documents to Wiki — demo walkthrough](https://www.youtube.com/watch?v=rIGO6zi9XQE) — end-to-end ingest of PDFs, web pages, and YouTube transcripts into a structured, self-maintaining wiki

--- a/synthadoc/integration/mcp_server.py
+++ b/synthadoc/integration/mcp_server.py
@@ -32,7 +32,9 @@ def create_mcp_server(orchestrator):
     @mcp.tool()
     async def synthadoc_ingest(source: str) -> dict:
         """Ingest a source document or URL into the wiki."""
-        job_id = await orchestrator.ingest(source, auto_confirm=True)
+        if not source or not source.strip():
+            return {"error": "source must not be empty"}
+        job_id = await orchestrator.ingest(source)
         return {"job_id": job_id, "source": source}
 
     @mcp.tool()
@@ -124,6 +126,8 @@ def create_mcp_server(orchestrator):
         scope: "all" to lint the whole wiki, or a page slug to lint one page.
         Do NOT pass "report" here — use synthadoc_lint_report for a zero-cost status read.
         """
+        if scope != "all" and orchestrator._store.read_page(scope) is None:
+            return {"error": "page not found", "slug": scope}
         job_id = await orchestrator.lint(scope=scope)
         return {"job_id": job_id, "scope": scope}
 
@@ -161,10 +165,10 @@ def create_mcp_server(orchestrator):
 
     @mcp.tool()
     async def synthadoc_status() -> dict:
-        """Get wiki status: page count and path."""
+        """Get wiki status: page count and wiki name."""
         return {
             "pages": len(orchestrator._store.list_pages()),
-            "wiki": str(orchestrator._root),
+            "wiki": orchestrator._root.name,
         }
 
     @mcp.tool()
@@ -175,6 +179,8 @@ def create_mcp_server(orchestrator):
         "contradicted", "stale", or "archived".
         Use synthadoc_read_page to get full content and sources for a specific page.
         """
+        if status != "all" and status not in _VALID_STATES:
+            return {"error": f"invalid status {status!r}. Valid: all, {', '.join(sorted(_VALID_STATES))}"}
         slugs = orchestrator._store.list_pages()
         pages = []
         for slug in slugs:

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -106,6 +106,10 @@ async def test_mcp_status_tool_returns_page_count(mock_orch):
             "synthadoc_status", {}, convert_result=False
         )
     assert result["pages"] == 2
+    # wiki field must be the directory name, not the full path
+    assert result["wiki"] == mock_orch._root.name
+    assert "\\" not in result["wiki"]
+    assert "/" not in result["wiki"]
 
 
 # ── New tool: synthadoc_read_page ─────────────────────────────────────────────
@@ -507,6 +511,76 @@ async def test_mcp_jobs_invalid_status_returns_error(mock_orch):
     )
     assert "error" in result
     assert "invalid_status" in result["error"]
+
+
+# ── Bug fixes: input validation ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_mcp_ingest_empty_source_returns_error(mock_orch):
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(mock_orch)
+    with patch("synthadoc.core.orchestrator.Orchestrator.ingest",
+               new=AsyncMock(return_value="job-xyz")) as mock_ingest:
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_ingest", {"source": ""}, convert_result=False
+        )
+    assert "error" in result
+    mock_ingest.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mcp_ingest_calls_ingest_without_auto_confirm(mock_orch):
+    """Regression: auto_confirm was incorrectly passed to Orchestrator.ingest()."""
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(mock_orch)
+    with patch("synthadoc.core.orchestrator.Orchestrator.ingest",
+               new=AsyncMock(return_value="job-abc")) as mock_ingest:
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_ingest", {"source": "paper.pdf"}, convert_result=False
+        )
+    mock_ingest.assert_called_once_with("paper.pdf")
+    assert result["job_id"] == "job-abc"
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_pages_invalid_status_returns_error(mock_orch):
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(mock_orch)
+    result = await mcp._tool_manager.call_tool(
+        "synthadoc_list_pages", {"status": "nonexistent_state"}, convert_result=False
+    )
+    assert "error" in result
+    assert "nonexistent_state" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_lint_nonexistent_slug_returns_error(mock_orch):
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(mock_orch)
+    with patch("synthadoc.storage.wiki.WikiStorage.read_page", return_value=None), \
+         patch("synthadoc.core.orchestrator.Orchestrator.lint",
+               new=AsyncMock(return_value="job-lint")) as mock_lint:
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_lint", {"scope": "does-not-exist"}, convert_result=False
+        )
+    assert "error" in result
+    assert result["error"] == "page not found"
+    mock_lint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mcp_lint_all_scope_skips_page_check(mock_orch):
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(mock_orch)
+    with patch("synthadoc.core.orchestrator.Orchestrator.lint",
+               new=AsyncMock(return_value="job-lint")) as mock_lint, \
+         patch("synthadoc.storage.wiki.WikiStorage.read_page") as mock_read:
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_lint", {"scope": "all"}, convert_result=False
+        )
+    mock_read.assert_not_called()  # read_page must not be called for scope="all"
+    mock_lint.assert_called_once_with(scope="all")
+    assert result["job_id"] == "job-lint"
 
 
 # ── Wiki name injection ───────────────────────────────────────────────────────

--- a/tests/live_mcp_test.py
+++ b/tests/live_mcp_test.py
@@ -1,17 +1,26 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
 """
-Live MCP integration test — history-of-computing wiki on port 7070.
-Tests all 12 MCP tools with real use cases in a realistic order.
+Live MCP integration test — exercises all 12 MCP tools against a running server.
 
-Run with:
-    python tests/live_mcp_test.py
+Prerequisites:
+    synthadoc serve -w history-of-computing   # starts HTTP + MCP on port 7070
+
+Run:
+    python -X utf8 tests/live_mcp_test.py
+
+    # Custom port or wiki:
+    MCP_URL=http://127.0.0.1:8080/mcp/sse python -X utf8 tests/live_mcp_test.py
+
+The -X utf8 flag is required on Windows to avoid encoding errors in terminal output.
+MCP_URL defaults to http://127.0.0.1:7070/mcp/sse if the env var is not set.
 """
 import asyncio
 import json
+import os
 import sys
 
-MCP_URL = "http://127.0.0.1:7070/mcp/sse"
+MCP_URL = os.environ.get("MCP_URL", "http://127.0.0.1:7070/mcp/sse")
 
 PASS = "\033[92m[PASS]\033[0m"
 FAIL = "\033[91m[FAIL]\033[0m"

--- a/tests/live_mcp_test.py
+++ b/tests/live_mcp_test.py
@@ -6,11 +6,16 @@ Live MCP integration test — exercises all 12 MCP tools against a running serve
 Prerequisites:
     synthadoc serve -w history-of-computing   # starts HTTP + MCP on port 7070
 
-Run:
+Run (default port 7070):
     python -X utf8 tests/live_mcp_test.py
 
-    # Custom port or wiki:
-    MCP_URL=http://127.0.0.1:8080/mcp/sse python -X utf8 tests/live_mcp_test.py
+Run against a different port (PowerShell):
+    $env:MCP_URL = "http://127.0.0.1:8080/mcp/sse"
+    python -X utf8 tests/live_mcp_test.py
+
+Run against a different port (bash/macOS/Linux):
+    export MCP_URL=http://127.0.0.1:8080/mcp/sse
+    python -X utf8 tests/live_mcp_test.py
 
 The -X utf8 flag is required on Windows to avoid encoding errors in terminal output.
 MCP_URL defaults to http://127.0.0.1:7070/mcp/sse if the env var is not set.

--- a/tests/live_mcp_test.py
+++ b/tests/live_mcp_test.py
@@ -1,0 +1,439 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+"""
+Live MCP integration test — history-of-computing wiki on port 7070.
+Tests all 12 MCP tools with real use cases in a realistic order.
+
+Run with:
+    python tests/live_mcp_test.py
+"""
+import asyncio
+import json
+import sys
+
+MCP_URL = "http://127.0.0.1:7070/mcp/sse"
+
+PASS = "\033[92m[PASS]\033[0m"
+FAIL = "\033[91m[FAIL]\033[0m"
+WARN = "\033[93m[WARN]\033[0m"
+INFO = "\033[94m[INFO]\033[0m"
+
+results = []
+
+
+def ok(tool, note=""):
+    tag = f"  {PASS} {tool}"
+    if note:
+        tag += f" — {note}"
+    print(tag)
+    results.append(("PASS", tool, note))
+
+
+def fail(tool, note):
+    print(f"  {FAIL} {tool} — {note}")
+    results.append(("FAIL", tool, note))
+
+
+def warn(tool, note):
+    print(f"  {WARN} {tool} — {note}")
+    results.append(("WARN", tool, note))
+
+
+def info(msg):
+    print(f"  {INFO} {msg}")
+
+
+async def call(session, tool_name, args=None):
+    from mcp import types as mct
+    result = await session.call_tool(tool_name, args or {})
+    # FastMCP returns content list; first item is text or dict
+    if result.content and hasattr(result.content[0], "text"):
+        try:
+            return json.loads(result.content[0].text)
+        except Exception:
+            return {"_raw": result.content[0].text}
+    return {"_empty": True}
+
+
+async def run_tests():
+    from mcp.client.session import ClientSession
+    from mcp.client.sse import sse_client
+
+    print(f"\n{'='*60}")
+    print(f"  Synthadoc MCP Live Test — {MCP_URL}")
+    print(f"{'='*60}\n")
+
+    async with sse_client(MCP_URL) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            info("Session initialized")
+
+            # ── 1. synthadoc_status ─────────────────────────────────────────
+            print("\n[1] synthadoc_status")
+            r = await call(session, "synthadoc_status")
+            if "pages" in r and "wiki" in r:
+                ok("synthadoc_status", f"wiki={r['wiki']!r}  pages={r['pages']}")
+                wiki_pages = r["pages"]
+            else:
+                fail("synthadoc_status", f"unexpected response: {r}")
+                wiki_pages = 0
+
+            # ── 2. synthadoc_list_pages (all) ───────────────────────────────
+            print("\n[2] synthadoc_list_pages — all")
+            r = await call(session, "synthadoc_list_pages", {"status": "all"})
+            if "pages" in r and isinstance(r["pages"], list):
+                ok("synthadoc_list_pages(all)", f"total={r['total']}")
+                all_pages = r["pages"]
+                first_slug = all_pages[0]["slug"] if all_pages else None
+                # check each page has expected fields
+                missing = [k for k in ("slug","title","status","type","has_sources") if k not in (all_pages[0] if all_pages else {})]
+                if missing:
+                    warn("synthadoc_list_pages(all)", f"missing fields: {missing}")
+            else:
+                fail("synthadoc_list_pages(all)", f"unexpected: {r}")
+                all_pages = []
+                first_slug = None
+
+            # ── 3. synthadoc_list_pages filtered by status ──────────────────
+            print("\n[3] synthadoc_list_pages — filtered by 'active'")
+            r = await call(session, "synthadoc_list_pages", {"status": "active"})
+            if "pages" in r:
+                active_pages = r["pages"]
+                ok("synthadoc_list_pages(active)", f"active pages={len(active_pages)}")
+                if active_pages:
+                    active_slug = active_pages[0]["slug"]
+                else:
+                    active_slug = None
+                    warn("synthadoc_list_pages(active)", "no active pages found — subsequent lifecycle test may be skipped")
+            else:
+                fail("synthadoc_list_pages(active)", str(r))
+                active_pages = []
+                active_slug = None
+
+            # invalid status value
+            print("\n[3b] synthadoc_list_pages — invalid status")
+            r = await call(session, "synthadoc_list_pages", {"status": "nonexistent_state"})
+            # should return pages filtered to nothing OR error
+            # currently the code returns empty list (no match) rather than an error
+            # This is a quality issue — no validation on status filter
+            if "pages" in r and r["pages"] == []:
+                warn("synthadoc_list_pages(invalid_status)",
+                     "invalid status 'nonexistent_state' silently returns empty list — no error returned. "
+                     "Should validate and return an error like synthadoc_jobs does.")
+            elif "error" in r:
+                ok("synthadoc_list_pages(invalid_status)", "correctly returns error for invalid status")
+            else:
+                info(f"response: {r}")
+
+            # ── 4. synthadoc_search ─────────────────────────────────────────
+            print("\n[4] synthadoc_search")
+            for query in ["transistor", "alan turing", "ENIAC vacuum tube"]:
+                r = await call(session, "synthadoc_search", {"terms": query})
+                if "results" in r and isinstance(r["results"], list):
+                    top = r["results"][0] if r["results"] else None
+                    detail = f"hits={len(r['results'])}" + (f"  top={top['slug']!r}" if top else "  (no results)")
+                    ok(f"synthadoc_search({query!r})", detail)
+                    if r["results"]:
+                        search_slug = r["results"][0]["slug"]
+                else:
+                    fail(f"synthadoc_search({query!r})", str(r))
+
+            # empty query
+            r = await call(session, "synthadoc_search", {"terms": ""})
+            if "results" in r:
+                ok("synthadoc_search(empty string)", f"returns {len(r['results'])} results (BM25 handles empty)")
+            else:
+                warn("synthadoc_search(empty string)", f"unexpected: {r}")
+
+            # ── 5. synthadoc_read_page ──────────────────────────────────────
+            print("\n[5] synthadoc_read_page")
+            if first_slug:
+                r = await call(session, "synthadoc_read_page", {"slug": first_slug})
+                expected = {"slug", "title", "content", "status", "type", "tags", "lint_warnings", "sources"}
+                missing = expected - set(r.keys())
+                if not missing:
+                    ok("synthadoc_read_page(valid)", f"slug={first_slug!r}  content_len={len(r.get('content',''))}")
+                else:
+                    fail("synthadoc_read_page(valid)", f"missing fields: {missing}")
+
+            # non-existent slug
+            r = await call(session, "synthadoc_read_page", {"slug": "this-page-does-not-exist"})
+            if r.get("error") == "page not found":
+                ok("synthadoc_read_page(missing)", "returns {error: 'page not found'}")
+            else:
+                fail("synthadoc_read_page(missing)", f"unexpected: {r}")
+
+            # ── 6. synthadoc_context ────────────────────────────────────────
+            print("\n[6] synthadoc_context")
+            r = await call(session, "synthadoc_context",
+                           {"goal": "Who invented the transistor and what was its impact?",
+                            "token_budget": 5000})
+            if "pages" in r or "items" in r or isinstance(r, dict):
+                page_count = len(r.get("pages") or r.get("items") or [])
+                omitted = len(r.get("omitted") or [])
+                tokens = r.get("total_tokens") or r.get("tokens_used") or "?"
+                ok("synthadoc_context", f"pages_included={page_count}  omitted={omitted}  tokens={tokens}")
+                # check structure
+                items = r.get("pages") or r.get("items") or []
+                if items:
+                    first = items[0]
+                    missing_fields = [k for k in ("slug","excerpt","relevance") if k not in first]
+                    if missing_fields:
+                        warn("synthadoc_context", f"page item missing fields: {missing_fields}")
+            else:
+                fail("synthadoc_context", f"unexpected structure: {list(r.keys())}")
+
+            # ── 7. synthadoc_lint_report ─────────────────────────────────────
+            print("\n[7] synthadoc_lint_report")
+            r = await call(session, "synthadoc_lint_report")
+            expected_keys = {"contradicted", "orphans", "adversarial_warnings", "adversarial_pages"}
+            missing = expected_keys - set(r.keys())
+            if not missing:
+                ok("synthadoc_lint_report",
+                   f"contradicted={r['contradicted']}  orphans={len(r['orphans'])}  "
+                   f"adversarial_warnings={r['adversarial_warnings']}")
+                has_contradicted = bool(r["contradicted"])
+                contradicted_slugs = r["contradicted"] if isinstance(r["contradicted"], list) else []
+            else:
+                fail("synthadoc_lint_report", f"missing keys: {missing}")
+                has_contradicted = False
+                contradicted_slugs = []
+
+            # ── 8. synthadoc_lint (enqueue) ──────────────────────────────────
+            print("\n[8] synthadoc_lint")
+            if first_slug:
+                r = await call(session, "synthadoc_lint", {"scope": first_slug})
+                if "job_id" in r and "scope" in r:
+                    ok("synthadoc_lint(single page)", f"job_id={r['job_id']}  scope={r['scope']!r}")
+                    lint_job_id = r["job_id"]
+                else:
+                    fail("synthadoc_lint(single page)", str(r))
+                    lint_job_id = None
+            else:
+                warn("synthadoc_lint", "skipped — no page slug available")
+                lint_job_id = None
+
+            # invalid scope (should it error or just enqueue?)
+            r = await call(session, "synthadoc_lint", {"scope": "nonexistent-slug"})
+            if "job_id" in r:
+                warn("synthadoc_lint(nonexistent scope)",
+                     "enqueues job for non-existent page — job will likely fail silently. "
+                     "Consider validating slug before enqueuing.")
+            elif "error" in r:
+                ok("synthadoc_lint(nonexistent scope)", "correctly returns error")
+
+            # ── 9. synthadoc_jobs ────────────────────────────────────────────
+            print("\n[9] synthadoc_jobs")
+            r = await call(session, "synthadoc_jobs", {"status": "all"})
+            if "jobs" in r and isinstance(r["jobs"], list):
+                ok("synthadoc_jobs(all)", f"total={len(r['jobs'])}")
+                if r["jobs"]:
+                    j = r["jobs"][0]
+                    missing = [k for k in ("id","operation","status","created") if k not in j]
+                    if missing:
+                        warn("synthadoc_jobs", f"job entry missing fields: {missing}")
+            else:
+                fail("synthadoc_jobs(all)", str(r))
+
+            # filter by completed
+            r = await call(session, "synthadoc_jobs", {"status": "completed"})
+            if "jobs" in r:
+                ok("synthadoc_jobs(completed)", f"completed={len(r['jobs'])}")
+            else:
+                fail("synthadoc_jobs(completed)", str(r))
+
+            # invalid status
+            r = await call(session, "synthadoc_jobs", {"status": "bogus"})
+            if "error" in r:
+                ok("synthadoc_jobs(invalid status)", "returns error for invalid status")
+            else:
+                fail("synthadoc_jobs(invalid status)", f"should return error, got: {r}")
+
+            # ── 10. synthadoc_write_page + restore ───────────────────────────
+            print("\n[10] synthadoc_write_page")
+            if first_slug:
+                # read original
+                original = await call(session, "synthadoc_read_page", {"slug": first_slug})
+                original_content = original.get("content", "")
+                original_title = original.get("title", "")
+
+                # write modified content
+                test_content = original_content + "\n\n<!-- MCP live test marker -->"
+                r = await call(session, "synthadoc_write_page",
+                               {"slug": first_slug, "content": test_content})
+                if r.get("slug") == first_slug and "status" in r:
+                    ok("synthadoc_write_page(update content)", f"slug={first_slug!r}  status={r['status']!r}")
+                    # verify the write took effect
+                    verify = await call(session, "synthadoc_read_page", {"slug": first_slug})
+                    if "<!-- MCP live test marker -->" in verify.get("content", ""):
+                        ok("synthadoc_write_page(verify read-back)", "content change confirmed by read_page")
+                    else:
+                        fail("synthadoc_write_page(verify read-back)", "content not updated in storage")
+                    # restore original
+                    await call(session, "synthadoc_write_page",
+                               {"slug": first_slug, "content": original_content, "title": original_title})
+                    info(f"Restored {first_slug!r} to original content")
+                else:
+                    fail("synthadoc_write_page(update content)", str(r))
+
+                # non-existent page
+                r = await call(session, "synthadoc_write_page",
+                               {"slug": "does-not-exist-xyz", "content": "test"})
+                if r.get("error") == "page not found":
+                    ok("synthadoc_write_page(missing slug)", "returns {error: 'page not found'}")
+                else:
+                    fail("synthadoc_write_page(missing slug)", f"unexpected: {r}")
+            else:
+                warn("synthadoc_write_page", "skipped — no page slug available")
+
+            # ── 11. synthadoc_lifecycle ──────────────────────────────────────
+            print("\n[11] synthadoc_lifecycle")
+            if active_slug:
+                # active -> stale (valid transition)
+                r = await call(session, "synthadoc_lifecycle",
+                               {"slug": active_slug, "to_state": "stale",
+                                "reason": "MCP live test — marking stale temporarily"})
+                if "from_state" in r and r.get("to_state") == "stale":
+                    ok("synthadoc_lifecycle(active->stale)", f"slug={active_slug!r}  timestamp={r.get('timestamp','?')!r}")
+                    # restore: stale -> active
+                    restore = await call(session, "synthadoc_lifecycle",
+                                        {"slug": active_slug, "to_state": "active",
+                                         "reason": "MCP live test — restore after stale test"})
+                    if restore.get("to_state") == "active":
+                        ok("synthadoc_lifecycle(stale->active restore)", "page restored to active")
+                    else:
+                        fail("synthadoc_lifecycle(stale->active restore)", str(restore))
+                elif "error" in r:
+                    fail("synthadoc_lifecycle(active->stale)", r["error"])
+                else:
+                    fail("synthadoc_lifecycle(active->stale)", str(r))
+
+                # blocked transition: active -> contradicted -> stale (stale->contradicted is blocked)
+                # First go active -> stale again, then try stale -> contradicted (must be blocked)
+                await call(session, "synthadoc_lifecycle",
+                           {"slug": active_slug, "to_state": "stale", "reason": "setup for blocked test"})
+                r = await call(session, "synthadoc_lifecycle",
+                               {"slug": active_slug, "to_state": "contradicted",
+                                "reason": "should be blocked"})
+                if "error" in r and "not permitted" in r["error"]:
+                    ok("synthadoc_lifecycle(stale->contradicted blocked)", "correctly rejected with 'not permitted'")
+                else:
+                    fail("synthadoc_lifecycle(stale->contradicted blocked)",
+                         f"expected error 'not permitted', got: {r}")
+                # restore
+                await call(session, "synthadoc_lifecycle",
+                           {"slug": active_slug, "to_state": "active", "reason": "restore after blocked test"})
+
+                # same-state transition (should error)
+                r = await call(session, "synthadoc_lifecycle",
+                               {"slug": active_slug, "to_state": "active", "reason": "same state test"})
+                if "error" in r and "already in state" in r["error"]:
+                    ok("synthadoc_lifecycle(same-state)", "correctly returns 'already in state' error")
+                else:
+                    fail("synthadoc_lifecycle(same-state)", f"expected 'already in state' error, got: {r}")
+
+                # non-existent page
+                r = await call(session, "synthadoc_lifecycle",
+                               {"slug": "no-such-page-xyz", "to_state": "active", "reason": "test"})
+                if r.get("error") == "page not found":
+                    ok("synthadoc_lifecycle(missing slug)", "returns {error: 'page not found'}")
+                else:
+                    fail("synthadoc_lifecycle(missing slug)", str(r))
+
+                # invalid to_state
+                r = await call(session, "synthadoc_lifecycle",
+                               {"slug": active_slug, "to_state": "published", "reason": "test"})
+                if "error" in r and "invalid to_state" in r["error"]:
+                    ok("synthadoc_lifecycle(invalid state)", "returns error for invalid to_state")
+                else:
+                    fail("synthadoc_lifecycle(invalid state)", f"expected invalid-state error, got: {r}")
+
+            else:
+                warn("synthadoc_lifecycle", "skipped — no active page available")
+
+            # ── 12. synthadoc_export ─────────────────────────────────────────
+            print("\n[12] synthadoc_export")
+
+            # llms.txt — inline content (no output_path)
+            r = await call(session, "synthadoc_export",
+                           {"format": "llms.txt", "status_filter": "active"})
+            if "content" in r and r.get("format") == "llms.txt":
+                ok("synthadoc_export(llms.txt inline)", f"pages={r.get('pages')}  content_len={len(r['content'])}")
+            elif "error" in r:
+                fail("synthadoc_export(llms.txt inline)", r["error"])
+            else:
+                fail("synthadoc_export(llms.txt inline)", f"unexpected: {list(r.keys())}")
+
+            # json — inline
+            r = await call(session, "synthadoc_export",
+                           {"format": "json", "status_filter": "all"})
+            if "content" in r and r.get("format") == "json":
+                ok("synthadoc_export(json inline)", f"pages={r.get('pages')}  content_len={len(str(r['content']))}")
+            else:
+                fail("synthadoc_export(json inline)", f"unexpected: {r}")
+
+            # okf — writes to disk (default path)
+            r = await call(session, "synthadoc_export",
+                           {"format": "okf", "status_filter": "active"})
+            if r.get("format") == "okf" and "output_path" in r and "files_written" in r:
+                ok("synthadoc_export(okf to disk)", f"files_written={r['files_written']}  path={r['output_path']!r}")
+            elif "error" in r:
+                fail("synthadoc_export(okf to disk)", r["error"])
+            else:
+                fail("synthadoc_export(okf to disk)", f"unexpected: {r}")
+
+            # invalid format
+            r = await call(session, "synthadoc_export", {"format": "pdf"})
+            if "error" in r and "unknown format" in r["error"]:
+                ok("synthadoc_export(invalid format)", "returns error for unknown format")
+            else:
+                fail("synthadoc_export(invalid format)", f"expected 'unknown format' error, got: {r}")
+
+            # ── 13. synthadoc_ingest ─────────────────────────────────────────
+            print("\n[13] synthadoc_ingest")
+            # ingest a plain text snippet — should enqueue and return job_id
+            r = await call(session, "synthadoc_ingest",
+                           {"source": "The Harvard Mark I was an electromechanical computer completed in 1944."})
+            if "job_id" in r and "source" in r:
+                ok("synthadoc_ingest(text snippet)", f"job_id={r['job_id']!r}")
+            elif "error" in r:
+                fail("synthadoc_ingest(text snippet)", r["error"])
+            else:
+                fail("synthadoc_ingest(text snippet)", f"unexpected: {r}")
+
+            # empty source — quality check
+            r = await call(session, "synthadoc_ingest", {"source": ""})
+            if "error" in r:
+                ok("synthadoc_ingest(empty source)", "returns error for empty source")
+            elif "job_id" in r:
+                warn("synthadoc_ingest(empty source)",
+                     "empty source enqueues a job — likely fails silently later. "
+                     "Consider validating before enqueuing.")
+            else:
+                info(f"empty ingest response: {r}")
+
+    # ── Summary ──────────────────────────────────────────────────────────────
+    print(f"\n{'='*60}")
+    print("  RESULTS SUMMARY")
+    print(f"{'='*60}")
+    passes = [r for r in results if r[0] == "PASS"]
+    fails  = [r for r in results if r[0] == "FAIL"]
+    warns  = [r for r in results if r[0] == "WARN"]
+    print(f"  PASS : {len(passes)}")
+    print(f"  WARN : {len(warns)}")
+    print(f"  FAIL : {len(fails)}")
+    if warns:
+        print(f"\n  Quality issues (WARN):")
+        for _, tool, note in warns:
+            print(f"    • {tool}: {note}")
+    if fails:
+        print(f"\n  Failures (FAIL):")
+        for _, tool, note in fails:
+            print(f"    • {tool}: {note}")
+    print()
+    return len(fails)
+
+
+if __name__ == "__main__":
+    n_fails = asyncio.run(run_tests())
+    sys.exit(1 if n_fails else 0)


### PR DESCRIPTION
What

  Add a live MCP integration test covering all 12 tools and fix the four bugs it uncovered.

Why

  The MCP server had no end-to-end test against a real running instance. Manual live testing against the history-of-computing wiki revealed one breaking bug (every ingest call crashed) and three validation gaps that silently misbehaved.

Changes

  i. New test:
  - tests/live_mcp_test.py: standalone script that connects to the MCP SSE endpoint and exercises all 12 tools with realistic inputs, corner cases (missing slugs, invalid status values, blocked lifecycle transitions), and read-back verification

  ii. Bug fixes (synthadoc/integration/mcp_server.py):
  - synthadoc_ingest: removed spurious auto_confirm=True kwarg that caused a TypeError on every call; also added empty-source guard before enqueuing
  - synthadoc_list_pages: now validates the status parameter and returns an error for unknown values (previously returned an empty list silently)
  - synthadoc_lint: now checks the page exists when scope != "all" before enqueuing (previously enqueued a job that failed silently in the background)
  - synthadoc_status: now returns the wiki directory name instead of the full filesystem path

  iii. New unit tests (tests/integration/test_mcp_server.py):
  - 5 regression tests covering each fix, including a call-signature assertion that ingest() is never called with auto_confirm