### PR TITLE
fix: v1.0 pre-release hardening

### DIFF
--- a/docs/media/README.md
+++ b/docs/media/README.md
@@ -4,5 +4,5 @@
 |---|---|
 | [DEV.to](https://forem.com/paul_chen_90371fe7426cb44) | Architecture, use cases and design posts |
 | [Medium](medium.md) | Long-form tutorials and deep dives |
-| [Coderlegion](coderlegion.md) | Architecture and design pattern posts |
+| [Coderlegion](https://coderlegion.com/user/PaulChen088/posts?type=posts&cat=articles) | Architecture and design pattern posts |
 | [YouTube](youtube.md) | Video walkthroughs and demos |

--- a/docs/media/coderlegion.md
+++ b/docs/media/coderlegion.md
@@ -1,7 +1,0 @@
-# Synthadoc on Coderlegion
-
-All Synthadoc-related articles published on Coderlegion.
-
-- [Four Interfaces, One Knowledge Layer: A Design Pattern for AI Knowledge Systems](https://coderlegion.com/21092/four-interfaces-one-knowledge-layer-a-design-pattern-for-ai-knowledge-systems)
-- [Synthadoc: Your Coding Tool Is Now Your Wiki Brain](https://coderlegion.com/16865/synthadoc-your-coding-tool-is-now-your-wiki-brain)
-- [Synthadoc: Beyond Keyword Search — How It Combines BM25 + Vector Search to Build a Smarter Domain Wiki](https://coderlegion.com/16864/synthadoc-beyond-keyword-search-how-combines-bm25-vector-search-build-smarter-domain-wiki)

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from typing import Optional
 
@@ -174,7 +175,11 @@ _FM_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 
 
 class ContentSizeLimitMiddleware:
-    """Reject requests whose Content-Length exceeds the configured limit."""
+    """Reject requests whose body exceeds the configured limit.
+
+    Checks Content-Length header first (fast path). For chunked transfers that
+    omit Content-Length, counts bytes as they arrive and rejects mid-stream.
+    """
 
     def __init__(self, app, max_bytes: int = _MAX_BODY_BYTES) -> None:
         self.app = app
@@ -184,10 +189,42 @@ class ContentSizeLimitMiddleware:
         if scope["type"] == "http" and not scope.get("path", "").startswith("/mcp"):
             headers = dict(scope.get("headers", []))
             content_length = headers.get(b"content-length")
-            if content_length is not None and int(content_length) > self._max_bytes:
-                response = Response(content="Request body too large", status_code=413)
-                await response(scope, receive, send)
-                return
+            if content_length is not None:
+                if int(content_length) > self._max_bytes:
+                    response = Response(content="Request body too large", status_code=413)
+                    await response(scope, receive, send)
+                    return
+            else:
+                # Chunked transfer body check: only applies to request methods that
+                # carry a body (POST/PUT/PATCH).  GET/HEAD/DELETE have no body; buffering
+                # them would intercept SSE disconnect receive() calls and prematurely
+                # terminate streaming responses.
+                method = scope.get("method", "").upper()
+                if method in ("POST", "PUT", "PATCH"):
+                    total = 0
+                    messages: list = []
+                    while True:
+                        message = await receive()
+                        total += len(message.get("body", b""))
+                        if total > self._max_bytes:
+                            response = Response(content="Request body too large", status_code=413)
+                            await response(scope, receive, send)
+                            return
+                        messages.append(message)
+                        if not message.get("more_body", False):
+                            break
+                    idx = 0
+
+                    async def _replay():
+                        nonlocal idx
+                        if idx < len(messages):
+                            msg = messages[idx]
+                            idx += 1
+                            return msg
+                        return {"type": "http.disconnect"}
+
+                    await self.app(scope, _replay, send)
+                    return
         await self.app(scope, receive, send)
 
 
@@ -195,6 +232,7 @@ class QueryRequest(BaseModel):
     question: str
     save: bool = False
     timeout_seconds: int = 60
+    no_cache: bool = False
 
     @field_validator("question")
     @classmethod
@@ -208,6 +246,13 @@ class IngestRequest(BaseModel):
     source: str
     force: bool = False
     max_results: int | None = None
+
+    @field_validator("source")
+    @classmethod
+    def source_not_empty(cls, v):
+        if not v.strip():
+            raise ValueError("source must not be empty")
+        return v
 
 
 class LintRequest(BaseModel):
@@ -327,6 +372,7 @@ async def _worker_loop(orch) -> None:
                     _purged = await orch._audit.purge_old_sessions(_retention)
                     if _purged:
                         logger.info("Purged %d stale sessions.", _purged)
+                        _session_state.clear()
                 _last_purge_time = time.monotonic()
             except Exception as _pe:
                 logger.error("Session purge failed: %s", _pe)
@@ -390,7 +436,11 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
     from fastapi.middleware.cors import CORSMiddleware
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["app://obsidian.md", "http://localhost", "http://127.0.0.1"],
+        allow_origins=[
+            "app://obsidian.md",
+            "http://localhost", "http://localhost:3000", "http://localhost:5173", "http://localhost:7070",
+            "http://127.0.0.1", "http://127.0.0.1:3000", "http://127.0.0.1:5173", "http://127.0.0.1:7070",
+        ],
         allow_methods=["GET", "POST", "DELETE"],
         allow_headers=["Content-Type"],
     )
@@ -468,6 +518,8 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
             "cacheable": result.cacheable,
         }
 
+    _NO_STORE = {"Cache-Control": "no-store"}
+
     @app.get("/query")
     async def query(q: str, timeout_seconds: int = 60, no_cache: bool = False):
         if not q.strip():
@@ -480,15 +532,27 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
         if not no_cache:
             cached = await orch._cache.get_query(cache_key)
             if cached is not None:
-                return cached
+                return JSONResponse(content=cached, headers=_NO_STORE)
         result = await _run_query(q, timeout_seconds=timeout_seconds)
         if result.get("cacheable", True):
             await orch._cache.set_query(cache_key, orch._wiki_epoch, result)
-        return result
+        return JSONResponse(content=result, headers=_NO_STORE)
 
     @app.post("/query")
     async def query_post(req: QueryRequest):
-        return await _run_query(req.question, timeout_seconds=req.timeout_seconds)
+        orch = app.state.orch
+        from synthadoc.core.cache import make_query_cache_key
+        _qcfg = orch._cfg.agents.resolve("query")
+        _query_model = f"{_qcfg.provider}/{_qcfg.model}"
+        cache_key = make_query_cache_key(req.question, orch._wiki_epoch, _query_model)
+        if not req.no_cache:
+            cached = await orch._cache.get_query(cache_key)
+            if cached is not None:
+                return JSONResponse(content=cached, headers=_NO_STORE)
+        result = await _run_query(req.question, timeout_seconds=req.timeout_seconds)
+        if result.get("cacheable", True):
+            await orch._cache.set_query(cache_key, orch._wiki_epoch, result)
+        return JSONResponse(content=result, headers=_NO_STORE)
 
     @app.get("/query/stream")
     async def query_stream(q: str, session_id: str | None = None, no_cache: bool = False, timeout_seconds: int = 60):
@@ -860,13 +924,19 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
             "adversarial_warnings": adversarial_warnings,
         }
 
+    _VALID_JOB_SORT = {"created_at", "status", "operation"}
+    _VALID_JOB_ORDER = {"asc", "desc"}
+
     @app.get("/jobs")
     async def list_jobs(status: str | None = None, sort: str = "created_at", order: str = "asc"):
         from synthadoc.core.queue import JobStatus
+        if sort not in _VALID_JOB_SORT:
+            raise HTTPException(status_code=400, detail=f"Invalid sort {sort!r}. Valid: {sorted(_VALID_JOB_SORT)}")
+        if order not in _VALID_JOB_ORDER:
+            raise HTTPException(status_code=400, detail=f"Invalid order {order!r}. Valid: asc, desc")
         try:
             job_status = JobStatus(status) if status else None
         except ValueError:
-            from fastapi import HTTPException
             raise HTTPException(status_code=400, detail=f"Invalid status {status!r}. Valid values: {[s.value for s in JobStatus]}")
         jobs = await app.state.orch.queue.list_jobs(status=job_status, sort_by=sort, order=order)
         return [{"id": j.id, "status": j.status, "operation": j.operation,
@@ -1150,8 +1220,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
         sort: str = "ingested_at",
         order: str = "desc",
     ):
-        audit = _AuditDB(wiki_root / ".synthadoc" / "audit.db")
-        await audit.init()
+        audit = app.state.orch._audit
         if broken:
             all_failures = await audit.list_citation_failures(limit=100_000, offset=0)
             rows = await audit.list_citation_failures(limit=limit, offset=offset)
@@ -1177,8 +1246,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
 
     @app.get("/lifecycle/pages")
     async def lifecycle_pages():
-        audit = _AuditDB(wiki_root / ".synthadoc" / "audit.db")
-        await audit.init()
+        audit = app.state.orch._audit
         pages = await audit.get_all_page_states()
         cdir = _cand_dir()
         pages = [p for p in pages if not (cdir / f"{p['slug']}.md").exists()]
@@ -1186,8 +1254,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
 
     @app.get("/lifecycle/status")
     async def lifecycle_status():
-        audit = _AuditDB(wiki_root / ".synthadoc" / "audit.db")
-        await audit.init()
+        audit = app.state.orch._audit
         counts = await audit.get_lifecycle_summary()
         # Split draft into wiki-domain drafts vs staged-in-candidates drafts.
         if counts.get("draft", 0) > 0:
@@ -1207,8 +1274,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
         limit: int = 50,
         offset: int = 0,
     ):
-        audit = _AuditDB(wiki_root / ".synthadoc" / "audit.db")
-        await audit.init()
+        audit = app.state.orch._audit
         events, total = await audit.get_lifecycle_events(
             slug=slug or None,
             to_state=to_state or None,
@@ -1240,8 +1306,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
         orch._store.write_page(req.slug, page)
         from datetime import datetime, timezone
         ts = datetime.now(timezone.utc).isoformat()
-        audit = _AuditDB(wiki_root / ".synthadoc" / "audit.db")
-        await audit.init()
+        audit = app.state.orch._audit
         await audit.set_page_state(req.slug, req.to_state, TriggerSource.USER)
         await audit.record_lifecycle_event(req.slug, from_state, req.to_state,
                                             req.reason, TriggerSource.USER)

--- a/synthadoc/integration/mcp_server.py
+++ b/synthadoc/integration/mcp_server.py
@@ -208,6 +208,8 @@ def create_mcp_server(orchestrator):
 
         Returns the updated slug, title, and status.
         """
+        if not content or not content.strip():
+            return {"error": "content must not be empty"}
         from datetime import date
         page = orchestrator._store.read_page(slug)
         if page is None:
@@ -317,7 +319,13 @@ def create_mcp_server(orchestrator):
     # correctly when multiple Synthadoc servers are connected simultaneously.
     if _wiki_name:
         _prefix = f"Wiki: {_wiki_name}. "
-        for _tool in mcp._tool_manager._tools.values():
-            _tool.description = _prefix + (_tool.description or "")
+        try:
+            for _tool in mcp._tool_manager._tools.values():
+                _tool.description = _prefix + (_tool.description or "")
+        except AttributeError:
+            logger.warning(
+                "Could not inject wiki name into tool descriptions — "
+                "FastMCP internal API changed; descriptions unchanged"
+            )
 
     return mcp

--- a/synthadoc/storage/wiki.py
+++ b/synthadoc/storage/wiki.py
@@ -203,7 +203,10 @@ class WikiStorage:
         if raw.startswith("---"):
             parts = raw.split("---", 2)
             if len(parts) >= 3:
-                fm = yaml.safe_load(parts[1]) or {}
+                try:
+                    fm = yaml.safe_load(parts[1]) or {}
+                except yaml.YAMLError:
+                    fm = {}
                 body = parts[2].lstrip("\n")
 
         sources = _sources_from_dicts(fm.get("sources", []))

--- a/tests/cli/test_jobs_cli.py
+++ b/tests/cli/test_jobs_cli.py
@@ -80,3 +80,15 @@ def test_jobs_list_default_sort_is_created_at_asc(tmp_path):
     call_kwargs = mock_get.call_args
     assert call_kwargs.kwargs.get("sort") == "created_at" or "created_at" in str(call_kwargs)
     assert call_kwargs.kwargs.get("order") == "asc" or ("asc" in str(call_kwargs) and "desc" not in str(call_kwargs))
+
+
+def test_jobs_delete_calls_http_delete_and_echoes_id(tmp_path):
+    """jobs delete <id> must call DELETE /jobs/<id> and confirm the deletion."""
+    with patch("synthadoc.cli.jobs.http_delete") as mock_del:
+        mock_del.return_value = {}
+        result = runner.invoke(app, ["jobs", "delete", "job-abc", "--wiki", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "job-abc" in result.output
+    mock_del.assert_called_once()
+    call_args = str(mock_del.call_args)
+    assert "job-abc" in call_args

--- a/tests/cli/test_lint_cli.py
+++ b/tests/cli/test_lint_cli.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
 import pytest
+from unittest.mock import patch
 from typer.testing import CliRunner
 from synthadoc.cli.main import app
 from synthadoc.cli.lint import _parse_frontmatter, _index_suggestion
@@ -332,6 +333,52 @@ def test_lint_report_shows_citation_issues(tmp_path, monkeypatch):
     assert result.exit_code == 0
     assert "Citation" in result.output
     assert "broken_ref" in result.output
+
+
+# ---------------------------------------------------------------------------
+# lint run command (enqueues a job via the HTTP API)
+# ---------------------------------------------------------------------------
+
+def test_lint_run_enqueues_job(tmp_path, monkeypatch):
+    """lint run must POST to /jobs/lint and echo the returned job_id."""
+    import synthadoc.cli.install as install_mod
+    monkeypatch.setattr(install_mod, "_read_registry",
+                        lambda: {"mywiki": {"path": str(tmp_path)}})
+    with patch("synthadoc.cli.lint.post", return_value={"job_id": "lint-001"}):
+        result = runner.invoke(app, ["lint", "run", "-w", "mywiki"])
+    assert result.exit_code == 0, result.output
+    assert "lint-001" in result.output
+
+
+def test_lint_run_no_adversarial_flag(tmp_path, monkeypatch):
+    """lint run --no-adversarial must pass adversarial=False in the payload."""
+    import synthadoc.cli.install as install_mod
+    monkeypatch.setattr(install_mod, "_read_registry",
+                        lambda: {"mywiki": {"path": str(tmp_path)}})
+    captured = {}
+    def fake_post(wiki, path, payload):
+        captured["payload"] = payload
+        return {"job_id": "lint-002"}
+    with patch("synthadoc.cli.lint.post", side_effect=fake_post):
+        result = runner.invoke(app, ["lint", "run", "--no-adversarial", "-w", "mywiki"])
+    assert result.exit_code == 0, result.output
+    assert captured["payload"]["adversarial"] is False
+    assert "lint_warnings cleared" in result.output.lower() or "adversarial pass skipped" in result.output.lower()
+
+
+def test_lint_run_scope_forwarded(tmp_path, monkeypatch):
+    """lint run --scope contradictions must forward scope in the payload."""
+    import synthadoc.cli.install as install_mod
+    monkeypatch.setattr(install_mod, "_read_registry",
+                        lambda: {"mywiki": {"path": str(tmp_path)}})
+    captured = {}
+    def fake_post(wiki, path, payload):
+        captured["payload"] = payload
+        return {"job_id": "lint-003"}
+    with patch("synthadoc.cli.lint.post", side_effect=fake_post):
+        result = runner.invoke(app, ["lint", "run", "--scope", "contradictions", "-w", "mywiki"])
+    assert result.exit_code == 0, result.output
+    assert captured["payload"]["scope"] == "contradictions"
 
 
 def test_lint_report_no_citation_section_when_clean(tmp_path, monkeypatch):

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 William Johnason / axoviq.com
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from typer.testing import CliRunner
 from synthadoc.cli.main import app
 
@@ -95,6 +95,41 @@ def test_schedule_run_uses_wiki_root_as_cwd(tmp_path):
         ])
     assert result.exit_code == 0, result.output
     assert captured["cwd"] == str(wiki)
+
+
+def test_schedule_history_empty(tmp_path):
+    """schedule history with no runs must echo a 'no history' message."""
+    wiki = _make_wiki(tmp_path)
+    with patch("synthadoc.storage.log.AuditDB") as MockDB:
+        instance = MagicMock()
+        instance.init = AsyncMock()
+        instance.list_scheduled_runs = AsyncMock(return_value=[])
+        MockDB.return_value = instance
+        result = runner.invoke(app, ["schedule", "history", "--wiki", str(wiki)])
+    assert result.exit_code == 0, result.output
+    assert "No scheduled run history" in result.output
+
+
+def test_schedule_history_shows_entries(tmp_path):
+    """schedule history must render run rows when runs exist."""
+    wiki = _make_wiki(tmp_path)
+    run = {
+        "run_id": "run-001",
+        "op": "lint",
+        "started_at": "2026-06-01T02:00:00",
+        "duration_s": 4.2,
+        "status": "success",
+        "error": None,
+    }
+    with patch("synthadoc.storage.log.AuditDB") as MockDB:
+        instance = MagicMock()
+        instance.init = AsyncMock()
+        instance.list_scheduled_runs = AsyncMock(return_value=[run])
+        MockDB.return_value = instance
+        result = runner.invoke(app, ["schedule", "history", "--wiki", str(wiki)])
+    assert result.exit_code == 0, result.output
+    assert "run-001" in result.output
+    assert "lint" in result.output
 
 
 def test_schedule_apply_registers_jobs(tmp_path):

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -276,3 +276,88 @@ class TestShutdownNoiseFilter:
         )
         record.exc_info = None  # no exc_info, info level — should pass
         assert self.f.filter(record) is True
+
+
+# ---------------------------------------------------------------------------
+# New code path tests for v1.0 code quality fixes
+# ---------------------------------------------------------------------------
+
+def test_ingest_request_rejects_empty_source(tmp_wiki):
+    """POST /ingest with empty source must return 422 (Pydantic validation error)."""
+    from fastapi.testclient import TestClient
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        resp = client.post("/jobs/ingest", json={"source": ""})
+    assert resp.status_code == 422
+
+
+def test_ingest_request_rejects_whitespace_source(tmp_wiki):
+    """POST /ingest with whitespace-only source must return 422."""
+    from fastapi.testclient import TestClient
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        resp = client.post("/jobs/ingest", json={"source": "   "})
+    assert resp.status_code == 422
+
+
+def test_jobs_rejects_invalid_sort(tmp_wiki):
+    """GET /jobs with an invalid sort param must return 400."""
+    from fastapi.testclient import TestClient
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        resp = client.get("/jobs?sort=injected_column")
+    assert resp.status_code == 400
+    assert "sort" in resp.json()["detail"].lower()
+
+
+def test_jobs_rejects_invalid_order(tmp_wiki):
+    """GET /jobs with an invalid order param must return 400."""
+    from fastapi.testclient import TestClient
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        resp = client.get("/jobs?order=injected")
+    assert resp.status_code == 400
+    assert "order" in resp.json()["detail"].lower()
+
+
+def _fake_query_result():
+    from unittest.mock import MagicMock
+    r = MagicMock()
+    r.answer = "ok"
+    r.citations = []
+    r.knowledge_gap = False
+    r.suggested_searches = []
+    r.cacheable = False
+    return r
+
+
+def test_get_query_returns_no_store_header(tmp_wiki):
+    """GET /query must include Cache-Control: no-store in the response headers."""
+    from fastapi.testclient import TestClient
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        app.state.orch.query = AsyncMock(return_value=_fake_query_result())
+        resp = client.get("/query?q=test&no_cache=true")
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control") == "no-store"
+
+
+def test_post_query_returns_no_store_header(tmp_wiki):
+    """POST /query must include Cache-Control: no-store in the response headers."""
+    from fastapi.testclient import TestClient
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        app.state.orch.query = AsyncMock(return_value=_fake_query_result())
+        resp = client.post("/query", json={"question": "test", "no_cache": True})
+    assert resp.status_code == 200
+    assert resp.headers.get("cache-control") == "no-store"
+
+
+def test_content_size_middleware_blocks_large_body(tmp_wiki):
+    """POST with body exceeding the configured limit must return 413."""
+    from fastapi.testclient import TestClient
+    from synthadoc.integration.http_server import create_app
+    app = create_app(wiki_root=tmp_wiki, max_body_bytes=10)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.post("/jobs/ingest", json={"source": "x" * 50})
+    assert resp.status_code == 413

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -352,6 +352,20 @@ async def test_mcp_write_page_not_found_returns_error(mock_orch):
     assert result == {"error": "page not found", "slug": "missing"}
 
 
+@pytest.mark.asyncio
+async def test_mcp_write_page_rejects_empty_content(mock_orch):
+    """synthadoc_write_page with empty or whitespace-only content must return an error."""
+    from synthadoc.integration.mcp_server import create_mcp_server
+    mcp = create_mcp_server(mock_orch)
+    for bad in ("", "   "):
+        result = await mcp._tool_manager.call_tool(
+            "synthadoc_write_page",
+            {"slug": "some-page", "content": bad},
+            convert_result=False,
+        )
+        assert result == {"error": "content must not be empty"}
+
+
 # ── New tool: synthadoc_lifecycle ─────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -1,0 +1,138 @@
+# Synthadoc Live Tests
+
+Manual integration tests that run against a live server and LLM.  Not run by CI.
+
+## Test suites
+
+| File | What it tests | Checks |
+|---|---|---|
+| `live_cli_test.py` | 44 CLI commands via `python -m synthadoc` | 59 |
+| `live_mcp_test.py` | 12 MCP tools via SSE transport | ~30 |
+| `live_plugin_test.py` | 37 REST API endpoints used by the Obsidian plugin | ~40 |
+
+## Prerequisites
+
+1. **Wiki installed**
+   ```
+   synthadoc install history-of-computing
+   ```
+
+2. **Server running**
+   ```
+   synthadoc serve -w history-of-computing
+   ```
+
+3. **LLM API key** — e.g. `ANTHROPIC_API_KEY` in the environment
+
+4. **MCP client library** (MCP test only)
+   ```
+   pip install mcp
+   ```
+
+## Run all suites together
+
+```powershell
+# PowerShell
+python -X utf8 tests/live/run_all.py
+
+# bash / macOS / Linux
+python -X utf8 tests/live/run_all.py
+```
+
+### Different wiki or port
+
+```powershell
+python -X utf8 tests/live/run_all.py --wiki ai-research --url http://127.0.0.1:7071
+```
+
+### One suite only
+
+```powershell
+python -X utf8 tests/live/run_all.py --suite cli
+python -X utf8 tests/live/run_all.py --suite mcp
+python -X utf8 tests/live/run_all.py --suite plugin
+```
+
+### Two suites, skip one
+
+```powershell
+python -X utf8 tests/live/run_all.py --suite cli --suite plugin
+```
+
+## Run suites individually
+
+### CLI test
+
+```powershell
+# PowerShell
+$env:SYNTHADOC_URL = "http://127.0.0.1:7070/"
+python -X utf8 tests/live/live_cli_test.py
+
+# bash
+SYNTHADOC_URL=http://127.0.0.1:7070/ python -X utf8 tests/live/live_cli_test.py
+
+# With flags
+python -X utf8 tests/live/live_cli_test.py --wiki ai-research --url http://127.0.0.1:7071/
+python -X utf8 tests/live/live_cli_test.py --help
+```
+
+### MCP test
+
+```powershell
+# PowerShell
+$env:MCP_URL = "http://127.0.0.1:7070/mcp/sse"
+python -X utf8 tests/live/live_mcp_test.py
+
+# bash
+MCP_URL=http://127.0.0.1:7070/mcp/sse python -X utf8 tests/live/live_mcp_test.py
+```
+
+### Plugin REST API test
+
+```powershell
+# PowerShell
+$env:SYNTHADOC_URL = "http://127.0.0.1:7070"
+python -X utf8 tests/live/live_plugin_test.py
+
+# bash
+SYNTHADOC_URL=http://127.0.0.1:7070 python -X utf8 tests/live/live_plugin_test.py
+
+# With flags
+python -X utf8 tests/live/live_plugin_test.py --url http://127.0.0.1:7071 --wiki ai-research
+python -X utf8 tests/live/live_plugin_test.py --help
+```
+
+## Environment variables
+
+| Variable | Default | Used by |
+|---|---|---|
+| `SYNTHADOC_URL` | `http://127.0.0.1:7070/` | CLI test, plugin test |
+| `WIKI_NAME` | `history-of-computing` | CLI test, plugin test |
+| `MCP_URL` | `http://127.0.0.1:7070/mcp/sse` | MCP test |
+
+CLI flags (`--url`, `--wiki`) override environment variables.
+
+## Output format
+
+Each check prints one of:
+- `[PASS]` — assertion met
+- `[WARN]` — soft quality issue; does not fail the run
+- `[FAIL]` — assertion failed; exits non-zero
+
+A results summary is printed at the end of each suite.
+
+## Side effects and rollback
+
+All tests are designed to leave the wiki in its original state:
+
+| Test | Side effect | Rollback |
+|---|---|---|
+| CLI | `candidates/` — 2 temp pages created | deleted in `finally` block |
+| CLI | lifecycle — 1 archived page round-trips | ends back in `archived` state |
+| CLI | `ingest` — uses `--analyse-only` | no wiki page written |
+| CLI | `schedule` — temp entry added | removed after test |
+| Plugin | `candidates/` — 2 temp pages created | deleted in `finally` block |
+| Plugin | lifecycle — 1 archived page round-trips | ends back in `archived` state |
+| Plugin | staging policy — changed to `off` | restored before test ends |
+| MCP | `synthadoc_write_page` — content modified | original content restored |
+| MCP | lifecycle — 1 active page marked stale | restored to `active` |

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -25,16 +25,16 @@ No mocks.  This script is run manually, not by CI.
 ────────────────────────────────────────────────────────────────────────────────
   # PowerShell
   $env:SYNTHADOC_URL = "http://127.0.0.1:7070/"
-  python -X utf8 tests/live_cli_test.py
+  python -X utf8 tests/live/live_cli_test.py
 
   # bash / macOS / Linux
   export SYNTHADOC_URL=http://127.0.0.1:7070/
-  python -X utf8 tests/live_cli_test.py
+  python -X utf8 tests/live/live_cli_test.py
 
   # Different wiki
   $env:WIKI_NAME = "ai-research"
   $env:SYNTHADOC_URL = "http://127.0.0.1:7072/"
-  python -X utf8 tests/live_cli_test.py
+  python -X utf8 tests/live/live_cli_test.py
 
 ────────────────────────────────────────────────────────────────────────────────
  TIERS

--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -7,15 +7,15 @@ Prerequisites:
     synthadoc serve -w history-of-computing   # starts HTTP + MCP on port 7070
 
 Run (default port 7070):
-    python -X utf8 tests/live_mcp_test.py
+    python -X utf8 tests/live/live_mcp_test.py
 
 Run against a different port (PowerShell):
     $env:MCP_URL = "http://127.0.0.1:8080/mcp/sse"
-    python -X utf8 tests/live_mcp_test.py
+    python -X utf8 tests/live/live_mcp_test.py
 
 Run against a different port (bash/macOS/Linux):
     export MCP_URL=http://127.0.0.1:8080/mcp/sse
-    python -X utf8 tests/live_mcp_test.py
+    python -X utf8 tests/live/live_mcp_test.py
 
 The -X utf8 flag is required on Windows to avoid encoding errors in terminal output.
 MCP_URL defaults to http://127.0.0.1:7070/mcp/sse if the env var is not set.

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -1,0 +1,679 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+"""
+Live Obsidian plugin REST API integration test.
+
+Calls every REST endpoint used by the Obsidian plugin directly from Python —
+no Obsidian runtime needed.  Organized by the 14 plugin commands + ribbon icon.
+
+────────────────────────────────────────────────────────────────────────────────
+ PREREQUISITES
+────────────────────────────────────────────────────────────────────────────────
+  1. A wiki must be installed (default: history-of-computing).
+  2. The synthadoc server must be running:
+       synthadoc serve -w history-of-computing
+  3. An LLM API key must be set (e.g. ANTHROPIC_API_KEY).
+
+────────────────────────────────────────────────────────────────────────────────
+ ENVIRONMENT VARIABLES
+────────────────────────────────────────────────────────────────────────────────
+  SYNTHADOC_URL  HTTP base URL of the server.   Default: http://127.0.0.1:7070
+  WIKI_NAME      Wiki name (for CLI fallback).  Default: history-of-computing
+
+────────────────────────────────────────────────────────────────────────────────
+ HOW TO RUN
+────────────────────────────────────────────────────────────────────────────────
+  # PowerShell
+  python -X utf8 tests/live/live_plugin_test.py
+
+  # bash / macOS / Linux
+  python -X utf8 tests/live/live_plugin_test.py
+
+  # Different server or wiki
+  python -X utf8 tests/live/live_plugin_test.py --url http://127.0.0.1:7071 --wiki ai-research
+
+  # Show all flags
+  python -X utf8 tests/live/live_plugin_test.py --help
+
+────────────────────────────────────────────────────────────────────────────────
+ COVERAGE
+────────────────────────────────────────────────────────────────────────────────
+  All 37 REST API calls from obsidian-plugin/src/api.ts, grouped by the
+  14 Obsidian plugin commands + ribbon icon.
+
+  Ribbon icon    : GET /health, GET /status
+  [1] query      : POST /sessions, GET /query/stream (SSE), POST /query
+  [2] ingest     : POST /jobs/ingest, GET /jobs/{id}, GET /jobs
+  [3] jobs       : GET /jobs?status=, GET /lifecycle/status,
+                   POST /jobs/{id}/retry, DELETE /jobs/{id},
+                   DELETE /jobs?older_than=
+  [4] lint-report: GET /lint/report
+  [5] lint       : GET /config, POST /jobs/lint
+  [6] scaffold   : POST /jobs/scaffold
+  [7] audit      : GET /audit/history, GET /audit/costs,
+                   GET /audit/queries, GET /audit/events
+  [8] routing    : GET /routing/status, POST /routing/init,
+                   POST /routing/validate, POST /routing/clean
+  [9] staging    : GET /staging/policy, POST /staging/policy
+  [10] candidates: GET /candidates, POST /candidates/{slug}/promote,
+                   POST /candidates/{slug}/discard,
+                   POST /candidates/promote-all,
+                   POST /candidates/discard-all
+  [11] context   : POST /context/build
+  [12] provenance: GET /lifecycle/events?slug=
+  [13] lifecycle : GET /lifecycle/status, GET /lifecycle/pages,
+                   GET /lifecycle/events (various params),
+                   POST /lifecycle/transition
+  [14] export    : POST /export (llms.txt, json, okf)
+
+────────────────────────────────────────────────────────────────────────────────
+ SIDE EFFECTS & ROLLBACK
+────────────────────────────────────────────────────────────────────────────────
+  • candidates  : two temp pages are created on disk, tested via REST,
+                  then deleted.  Rollback in a finally block.
+  • lifecycle   : one archived page is transitioned round-trip
+                  (archived → draft → active → archived).
+  • staging     : policy saved, changed for one call, then restored.
+  All other calls are read-only or idempotent.
+"""
+import argparse
+import http.client
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+SYNTHADOC_URL = os.environ.get("SYNTHADOC_URL", "http://127.0.0.1:7070").rstrip("/")
+WIKI_NAME     = os.environ.get("WIKI_NAME", "history-of-computing")
+PY            = sys.executable
+
+PASS = "\033[92m[PASS]\033[0m"
+FAIL = "\033[91m[FAIL]\033[0m"
+WARN = "\033[93m[WARN]\033[0m"
+INFO = "\033[94m[INFO]\033[0m"
+
+results: list[tuple[str, str, str]] = []
+
+# ── Reporting ─────────────────────────────────────────────────────────────────
+
+def ok(label: str, note: str = "") -> None:
+    print(f"  {PASS} {label}" + (f" — {note}" if note else ""))
+    results.append(("PASS", label, note))
+
+def fail(label: str, note: str) -> None:
+    print(f"  {FAIL} {label} — {note}")
+    results.append(("FAIL", label, note))
+
+def warn(label: str, note: str) -> None:
+    print(f"  {WARN} {label} — {note}")
+    results.append(("WARN", label, note))
+
+def info(msg: str) -> None:
+    print(f"  {INFO} {msg}")
+
+# ── HTTP helpers ───────────────────────────────────────────────────────────────
+
+def _call(method: str, path: str, body: dict | None = None, timeout: int = 30) -> tuple[int, dict | str]:
+    """HTTP call; returns (status_code, parsed_json_or_raw_str)."""
+    url = SYNTHADOC_URL + path
+    if method in ("POST", "PUT", "PATCH"):
+        data = json.dumps(body).encode() if body is not None else b""
+    else:
+        data = None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Accept", "application/json")
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            raw = r.read().decode("utf-8")
+            try:
+                return r.status, json.loads(raw)
+            except json.JSONDecodeError:
+                return r.status, raw
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8")
+        try:
+            return e.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return e.code, raw
+    except Exception as e:
+        return 0, {"_error": str(e)}
+
+
+def GET(path: str, timeout: int = 10) -> tuple[int, dict | str]:
+    return _call("GET", path, timeout=timeout)
+
+def POST(path: str, body: dict | None = None, timeout: int = 60) -> tuple[int, dict | str]:
+    return _call("POST", path, body=body, timeout=timeout)
+
+def DELETE(path: str, timeout: int = 10) -> tuple[int, dict | str]:
+    return _call("DELETE", path, timeout=timeout)
+
+
+def sse_probe(path: str, timeout: int = 12) -> tuple[int, str, str]:
+    """GET an SSE endpoint; returns (status, content_type, first_chunk)."""
+    parsed = urllib.parse.urlparse(SYNTHADOC_URL)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 7070
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+        conn.request("GET", path, headers={"Accept": "text/event-stream"})
+        resp = conn.getresponse()
+        ct = resp.getheader("Content-Type", "")
+        try:
+            chunk = resp.read(512).decode("utf-8", errors="replace")
+        except Exception:
+            chunk = ""
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return resp.status, ct, chunk
+    except Exception as e:
+        return 0, "", str(e)
+
+# ── Wiki root discovery via CLI ────────────────────────────────────────────────
+
+def _discover_wiki_root() -> pathlib.Path | None:
+    try:
+        r = subprocess.run(
+            [PY, "-m", "synthadoc", "status", "-w", WIKI_NAME],
+            capture_output=True, text=True, timeout=15,
+        )
+        for line in (r.stdout + r.stderr).splitlines():
+            if line.strip().startswith("Wiki:"):
+                p = pathlib.Path(line.split("Wiki:", 1)[1].strip())
+                return p if p.exists() else None
+    except Exception:
+        pass
+    return None
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("=" * 64)
+    print("  Synthadoc Live Plugin REST API Test")
+    print(f"  server URL : {SYNTHADOC_URL}")
+    print(f"  wiki name  : {WIKI_NAME}")
+    print("=" * 64)
+
+    # ── Ribbon icon ───────────────────────────────────────────────────────────
+    print("\n[Ribbon] api.health() + api.status()")
+
+    code, body = GET("/health")
+    if code == 200:
+        ok("GET /health", str(body)[:60])
+    else:
+        fail("GET /health", f"HTTP {code}: {str(body)[:120]}")
+        print("\nFATAL: server not reachable. Start: synthadoc serve -w <wiki>")
+        sys.exit(1)
+
+    code, body = GET("/status")
+    if code == 200 and isinstance(body, dict):
+        ok("GET /status", f"pages={body.get('pages', '?')}")
+    else:
+        fail("GET /status", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [1] synthadoc-query ───────────────────────────────────────────────────
+    print("\n[1] synthadoc-query — api.createSession(), api.queryStream(), api.query()")
+
+    code, body = POST("/sessions")
+    session_id: str | None = None
+    if code == 200 and isinstance(body, dict) and "session_id" in body:
+        ok("POST /sessions", f"session_id={body['session_id'][:8]}…")
+        session_id = body["session_id"]
+    else:
+        fail("POST /sessions", f"HTTP {code}: {str(body)[:120]}")
+
+    # SSE probe for GET /query/stream
+    q = urllib.parse.quote("What is ENIAC?")
+    sse_path = f"/query/stream?q={q}&no_cache=true"
+    if session_id:
+        sse_path += f"&session_id={urllib.parse.quote(session_id)}"
+    sse_code, sse_ct, sse_chunk = sse_probe(sse_path)
+    if sse_code == 200 and "text/event-stream" in sse_ct:
+        ok("GET /query/stream (SSE)", f"Content-Type={sse_ct!r}  chunk={sse_chunk[:40]!r}")
+    elif sse_code == 200:
+        warn("GET /query/stream (SSE)", f"HTTP 200 but Content-Type={sse_ct!r} (expected text/event-stream)")
+    else:
+        fail("GET /query/stream (SSE)", f"HTTP {sse_code}: {sse_chunk[:80]!r}")
+
+    code, body = POST("/query", {"question": "What is ENIAC?", "timeout_seconds": 30})
+    if code == 200 and isinstance(body, dict) and "answer" in body:
+        ok("POST /query", f"answer_len={len(body.get('answer', ''))}")
+    else:
+        warn("POST /query", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [2] synthadoc-ingest ──────────────────────────────────────────────────
+    print("\n[2] synthadoc-ingest — api.ingest(), api.job(), api.jobs()")
+
+    code, body = POST("/jobs/ingest", {"source": "https://en.wikipedia.org/wiki/ENIAC"})
+    ingest_job_id: str | None = None
+    if code == 200 and isinstance(body, dict) and "job_id" in body:
+        ok("POST /jobs/ingest", f"job_id={body['job_id'][:8]}…")
+        ingest_job_id = body["job_id"]
+    else:
+        fail("POST /jobs/ingest", f"HTTP {code}: {str(body)[:120]}")
+
+    if ingest_job_id:
+        code, body = GET(f"/jobs/{ingest_job_id}")
+        if code == 200 and isinstance(body, dict) and "status" in body:
+            ok("GET /jobs/{id}", f"status={body['status']}")
+        else:
+            fail("GET /jobs/{id}", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/jobs")
+    if code == 200 and isinstance(body, list):
+        ok("GET /jobs", f"total={len(body)}")
+    else:
+        fail("GET /jobs", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [3] synthadoc-jobs ────────────────────────────────────────────────────
+    print("\n[3] synthadoc-jobs — api.jobs(), api.job(), api.lifecycleStatus(), api.retryJob(), api.deleteJob(), api.purgeJobs()")
+
+    code, body = GET("/jobs?status=completed")
+    if code == 200 and isinstance(body, list):
+        ok("GET /jobs?status=completed", f"count={len(body)}")
+    else:
+        fail("GET /jobs?status=completed", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/lifecycle/status")
+    if code == 200 and isinstance(body, dict):
+        counts = body.get("counts", body)
+        ok("GET /lifecycle/status (jobs badge)", f"counts={counts}")
+    else:
+        fail("GET /lifecycle/status (jobs badge)", f"HTTP {code}: {str(body)[:120]}")
+
+    # find a terminal job for retry + delete
+    code, jobs_list = GET("/jobs")
+    terminal_job: dict | None = None
+    second_terminal: dict | None = None
+    if code == 200 and isinstance(jobs_list, list):
+        for j in jobs_list:
+            if j.get("status") in ("completed", "failed", "cancelled"):
+                if terminal_job is None:
+                    terminal_job = j
+                elif second_terminal is None:
+                    second_terminal = j
+                    break
+
+    if terminal_job:
+        tid = terminal_job["id"]
+        code, body = POST(f"/jobs/{tid}/retry")
+        if code in (200, 409):
+            ok("POST /jobs/{id}/retry", f"id={tid[:8]}…  HTTP={code}")
+        else:
+            fail("POST /jobs/{id}/retry", f"HTTP {code}: {str(body)[:120]}")
+
+        del_job = second_terminal or terminal_job
+        did = del_job["id"]
+        code, body = DELETE(f"/jobs/{did}")
+        if code in (200, 404, 409):
+            ok("DELETE /jobs/{id}", f"id={did[:8]}…  HTTP={code}")
+        else:
+            fail("DELETE /jobs/{id}", f"HTTP {code}: {str(body)[:120]}")
+    else:
+        warn("POST /jobs/{id}/retry + DELETE /jobs/{id}", "no terminal job available — skipping")
+
+    code, body = DELETE("/jobs?older_than=365")
+    if code == 200 and isinstance(body, dict) and "purged" in body:
+        ok("DELETE /jobs?older_than=365", f"purged={body['purged']}")
+    else:
+        fail("DELETE /jobs?older_than=365", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [4] synthadoc-lint-report ─────────────────────────────────────────────
+    print("\n[4] synthadoc-lint-report — api.lintReport()")
+
+    code, body = GET("/lint/report")
+    if code == 200 and isinstance(body, dict):
+        ok("GET /lint/report", f"keys={list(body.keys())[:6]}")
+    else:
+        fail("GET /lint/report", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [5] synthadoc-lint ────────────────────────────────────────────────────
+    print("\n[5] synthadoc-lint — api.config(), api.lint()")
+
+    code, body = GET("/config")
+    if code == 200 and isinstance(body, dict):
+        ok("GET /config", f"keys={list(body.keys())[:6]}")
+    else:
+        fail("GET /config", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = POST("/jobs/lint", {"scope": "all", "auto_resolve": False, "adversarial": False})
+    if code == 200 and isinstance(body, dict) and "job_id" in body:
+        ok("POST /jobs/lint", f"job_id={body['job_id'][:8]}…")
+    else:
+        fail("POST /jobs/lint", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [6] synthadoc-scaffold ────────────────────────────────────────────────
+    print("\n[6] synthadoc-scaffold — api.scaffold()")
+
+    code, body = POST("/jobs/scaffold", {"domain": "history of computing"})
+    if code == 200 and isinstance(body, dict) and "job_id" in body:
+        ok("POST /jobs/scaffold", f"job_id={body['job_id'][:8]}…")
+    else:
+        fail("POST /jobs/scaffold", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [7] synthadoc-audit ───────────────────────────────────────────────────
+    print("\n[7] synthadoc-audit — api.auditHistory(), api.auditCosts(), api.queryHistory(), api.auditEvents()")
+
+    code, body = GET("/audit/history?limit=50")
+    if code == 200:
+        n = len(body) if isinstance(body, list) else len(body.get("history", body.get("entries", []))) if isinstance(body, dict) else "?"
+        ok("GET /audit/history?limit=50", f"entries={n}")
+    else:
+        fail("GET /audit/history?limit=50", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/audit/costs?days=30")
+    if code == 200 and isinstance(body, dict):
+        ok("GET /audit/costs?days=30", f"keys={list(body.keys())[:5]}")
+    else:
+        fail("GET /audit/costs?days=30", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/audit/queries?limit=50")
+    if code == 200:
+        ok("GET /audit/queries?limit=50", f"type={type(body).__name__}")
+    else:
+        fail("GET /audit/queries?limit=50", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/audit/events?limit=100")
+    if code == 200:
+        ok("GET /audit/events?limit=100", f"type={type(body).__name__}")
+    else:
+        fail("GET /audit/events?limit=100", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [8] synthadoc-routing ─────────────────────────────────────────────────
+    print("\n[8] synthadoc-routing — api.routingStatus(), api.routingInit(), api.routingValidate(), api.routingClean()")
+
+    code, body = GET("/routing/status")
+    if code == 200 and isinstance(body, dict):
+        ok("GET /routing/status", f"keys={list(body.keys())[:5]}")
+    else:
+        fail("GET /routing/status", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = POST("/routing/init")
+    if code == 200:
+        ok("POST /routing/init", str(body)[:60])
+    elif code in (400, 409, 422):
+        warn("POST /routing/init", f"HTTP {code} — ROUTING.md likely already exists")
+    else:
+        fail("POST /routing/init", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = POST("/routing/validate")
+    if code == 200 and isinstance(body, dict):
+        ok("POST /routing/validate", str(body)[:60])
+    else:
+        fail("POST /routing/validate", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = POST("/routing/clean")
+    if code == 200 and isinstance(body, dict):
+        ok("POST /routing/clean", str(body)[:60])
+    else:
+        fail("POST /routing/clean", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [9] synthadoc-staging ─────────────────────────────────────────────────
+    print("\n[9] synthadoc-staging — api.stagingPolicy(), api.stagingSetPolicy()")
+
+    code, prev_policy = GET("/staging/policy")
+    if code == 200 and isinstance(prev_policy, dict):
+        ok("GET /staging/policy", f"policy={prev_policy.get('policy', '?')}")
+    else:
+        fail("GET /staging/policy", f"HTTP {code}: {str(prev_policy)[:120]}")
+        prev_policy = {}
+
+    code, body = POST("/staging/policy", {"policy": "off"})
+    if code == 200 and isinstance(body, dict):
+        ok("POST /staging/policy (off)", str(body)[:60])
+    else:
+        fail("POST /staging/policy (off)", f"HTTP {code}: {str(body)[:120]}")
+
+    restore: dict = {"policy": prev_policy.get("policy", "threshold")}
+    if restore["policy"] == "threshold" and "confidence_min" in prev_policy:
+        restore["confidence_min"] = prev_policy["confidence_min"]
+    POST("/staging/policy", restore)
+    ok("POST /staging/policy (restore)", restore["policy"])
+
+    # ── [10] synthadoc-candidates ─────────────────────────────────────────────
+    print("\n[10] synthadoc-candidates — api.candidates(), api.candidatePromote(), api.candidateDiscard(), api.candidatesPromoteAll(), api.candidatesDiscardAll()")
+
+    code, body = GET("/candidates")
+    if code == 200:
+        cands = body if isinstance(body, list) else body.get("candidates", body.get("pages", [])) if isinstance(body, dict) else []
+        ok("GET /candidates", f"count={len(cands)}")
+    else:
+        fail("GET /candidates", f"HTTP {code}: {str(body)[:120]}")
+        cands = []
+
+    _PROMOTE = "_live-plugin-test-promote"
+    _DISCARD = "_live-plugin-test-discard"
+    _fm = (
+        "---\ntitle: Plugin Live Test Page\nstatus: draft\n"
+        "confidence: high\ncreated: '2026-06-23T00:00:00'\n---\n\n"
+        "Temporary page created by live_plugin_test.py.\n"
+    )
+
+    wiki_root = _discover_wiki_root()
+    _promote_dest: pathlib.Path | None = None
+    _created = False
+
+    if wiki_root:
+        cand_dir = wiki_root / "wiki" / "candidates"
+        cand_dir.mkdir(parents=True, exist_ok=True)
+        (cand_dir / f"{_PROMOTE}.md").write_text(_fm, encoding="utf-8")
+        (cand_dir / f"{_DISCARD}.md").write_text(_fm, encoding="utf-8")
+        _promote_dest = wiki_root / "wiki" / f"{_PROMOTE}.md"
+        _created = True
+        info(f"created temp candidates in {cand_dir}")
+    else:
+        warn("candidates setup", "wiki root not found via CLI — promote/discard skipped")
+
+    try:
+        if _created:
+            code, body = POST(f"/candidates/{_PROMOTE}/promote")
+            if code == 200:
+                ok("POST /candidates/{slug}/promote", _PROMOTE)
+            else:
+                fail("POST /candidates/{slug}/promote", f"HTTP {code}: {str(body)[:120]}")
+
+            code, body = POST(f"/candidates/{_DISCARD}/discard")
+            if code == 200:
+                ok("POST /candidates/{slug}/discard", _DISCARD)
+            else:
+                fail("POST /candidates/{slug}/discard", f"HTTP {code}: {str(body)[:120]}")
+
+        code, body = POST("/candidates/promote-all")
+        if code == 200 and isinstance(body, dict):
+            ok("POST /candidates/promote-all", str(body)[:60])
+        else:
+            fail("POST /candidates/promote-all", f"HTTP {code}: {str(body)[:120]}")
+
+        code, body = POST("/candidates/discard-all")
+        if code == 200 and isinstance(body, dict):
+            ok("POST /candidates/discard-all", str(body)[:60])
+        else:
+            fail("POST /candidates/discard-all", f"HTTP {code}: {str(body)[:120]}")
+
+    finally:
+        if wiki_root:
+            if _promote_dest and _promote_dest.exists():
+                _promote_dest.unlink()
+            (wiki_root / "wiki" / "candidates" / f"{_PROMOTE}.md").unlink(missing_ok=True)
+            (wiki_root / "wiki" / "candidates" / f"{_DISCARD}.md").unlink(missing_ok=True)
+            ok("candidates rollback")
+
+    # ── [11] synthadoc-context ────────────────────────────────────────────────
+    print("\n[11] synthadoc-context — api.contextBuild()")
+
+    code, body = POST("/context/build", {"goal": "history of computing", "token_budget": 4000})
+    if code == 200 and isinstance(body, dict):
+        ok("POST /context/build", f"keys={list(body.keys())[:5]}")
+    else:
+        fail("POST /context/build", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── [12] view-page-provenance ─────────────────────────────────────────────
+    print("\n[12] view-page-provenance — api.lifecycleEvents({{slug}})")
+
+    code, body = GET("/lifecycle/pages")
+    prov_slug: str | None = None
+    lc_pages: list = []
+    if code == 200:
+        lc_pages = body if isinstance(body, list) else body.get("pages", []) if isinstance(body, dict) else []
+        if lc_pages:
+            first = lc_pages[0]
+            prov_slug = first.get("slug") if isinstance(first, dict) else first
+
+    if prov_slug:
+        code, body = GET(f"/lifecycle/events?slug={urllib.parse.quote(prov_slug)}")
+        if code == 200:
+            ok("GET /lifecycle/events?slug=...", f"slug={prov_slug!r}  type={type(body).__name__}")
+        else:
+            fail("GET /lifecycle/events?slug=...", f"HTTP {code}: {str(body)[:120]}")
+    else:
+        warn("GET /lifecycle/events?slug=...", "no page found for provenance test")
+
+    # ── [13] lifecycle-modal ──────────────────────────────────────────────────
+    print("\n[13] lifecycle-modal — api.lifecycleStatus(), api.lifecyclePages(), api.lifecycleEvents(), api.lifecycleTransition()")
+
+    code, body = GET("/lifecycle/status")
+    if code == 200 and isinstance(body, dict):
+        ok("GET /lifecycle/status", f"keys={list(body.keys())[:5]}")
+    else:
+        fail("GET /lifecycle/status", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/lifecycle/pages")
+    if code == 200:
+        lc_pages = body if isinstance(body, list) else body.get("pages", []) if isinstance(body, dict) else []
+        ok("GET /lifecycle/pages", f"count={len(lc_pages)}")
+    else:
+        fail("GET /lifecycle/pages", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/lifecycle/events")
+    if code == 200:
+        ok("GET /lifecycle/events", f"type={type(body).__name__}")
+    else:
+        fail("GET /lifecycle/events", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/lifecycle/events?to_state=active")
+    if code == 200:
+        ok("GET /lifecycle/events?to_state=active", f"type={type(body).__name__}")
+    else:
+        fail("GET /lifecycle/events?to_state=active", f"HTTP {code}: {str(body)[:120]}")
+
+    code, body = GET("/lifecycle/events?limit=10&offset=0")
+    if code == 200:
+        ok("GET /lifecycle/events?limit=10&offset=0", f"type={type(body).__name__}")
+    else:
+        fail("GET /lifecycle/events?limit=10&offset=0", f"HTTP {code}: {str(body)[:120]}")
+
+    # round-trip: find an archived page and cycle it archived→draft→active→archived
+    archived_slug: str | None = None
+    for p in lc_pages:
+        if isinstance(p, dict) and p.get("status") == "archived":
+            archived_slug = p.get("slug")
+            break
+
+    if archived_slug:
+        info(f"lifecycle round-trip on: {archived_slug}")
+
+        code, body = POST("/lifecycle/transition",
+                          {"slug": archived_slug, "to_state": "draft",
+                           "reason": "plugin-live-test restore"})
+        if code == 200 and isinstance(body, dict):
+            ok("POST /lifecycle/transition (archived→draft)", f"slug={archived_slug!r}")
+        else:
+            fail("POST /lifecycle/transition (archived→draft)", f"HTTP {code}: {str(body)[:120]}")
+
+        code, body = POST("/lifecycle/transition",
+                          {"slug": archived_slug, "to_state": "active",
+                           "reason": "plugin-live-test activate"})
+        if code == 200 and isinstance(body, dict):
+            ok("POST /lifecycle/transition (draft→active)", f"slug={archived_slug!r}")
+        else:
+            fail("POST /lifecycle/transition (draft→active)", f"HTTP {code}: {str(body)[:120]}")
+
+        code, body = POST("/lifecycle/transition",
+                          {"slug": archived_slug, "to_state": "archived",
+                           "reason": "plugin-live-test archive (restore)"})
+        if code == 200 and isinstance(body, dict):
+            ok("POST /lifecycle/transition (active→archived)", "round-trip complete")
+        else:
+            fail("POST /lifecycle/transition (active→archived)", f"HTTP {code}: {str(body)[:120]}")
+    else:
+        warn("POST /lifecycle/transition", "no archived page found — skipping round-trip")
+
+    # ── [14] synthadoc-export-wiki ────────────────────────────────────────────
+    print("\n[14] synthadoc-export-wiki — api.exportWiki(), api.exportWikiOkf()")
+
+    # exportWiki (raw text): llms.txt
+    code, body = POST("/export", {"format": "llms.txt", "status_filter": "active"})
+    if code == 200 and isinstance(body, str) and body:
+        ok("POST /export (llms.txt)", f"content_len={len(body)}")
+    elif code == 200:
+        warn("POST /export (llms.txt)", f"HTTP 200 but body type={type(body).__name__}")
+    else:
+        fail("POST /export (llms.txt)", f"HTTP {code}: {str(body)[:120]}")
+
+    # exportWiki (raw text): json
+    code, body = POST("/export", {"format": "json", "status_filter": "all"})
+    if code == 200:
+        ok("POST /export (json)", f"type={type(body).__name__}")
+    else:
+        fail("POST /export (json)", f"HTTP {code}: {str(body)[:120]}")
+
+    # exportWikiOkf (JSON object)
+    code, body = POST("/export", {"format": "okf", "status_filter": "all"})
+    if code == 200 and isinstance(body, dict):
+        ok("POST /export (okf)", f"keys={list(body.keys())[:5]}")
+    elif code == 200:
+        warn("POST /export (okf)", f"HTTP 200 but body type={type(body).__name__} (expected dict)")
+    else:
+        fail("POST /export (okf)", f"HTTP {code}: {str(body)[:120]}")
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    passes = sum(1 for r in results if r[0] == "PASS")
+    warns  = sum(1 for r in results if r[0] == "WARN")
+    fails  = sum(1 for r in results if r[0] == "FAIL")
+
+    print()
+    print("=" * 64)
+    print("  RESULTS SUMMARY")
+    print("=" * 64)
+    print(f"  PASS : {passes}")
+    print(f"  WARN : {warns}")
+    print(f"  FAIL : {fails}")
+    if fails:
+        print()
+        print("  Failed endpoints:")
+        for status, label, note in results:
+            if status == "FAIL":
+                print(f"    - {label}: {note[:220]}")
+    print("=" * 64)
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="live_plugin_test.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url", metavar="URL",
+        default=os.environ.get("SYNTHADOC_URL", "http://127.0.0.1:7070"),
+        help="Server base URL (overrides SYNTHADOC_URL env var)",
+    )
+    parser.add_argument(
+        "--wiki", metavar="NAME",
+        default=os.environ.get("WIKI_NAME", "history-of-computing"),
+        help="Wiki name for CLI fallback to discover wiki root (overrides WIKI_NAME env var)",
+    )
+    args = parser.parse_args()
+    SYNTHADOC_URL = args.url.rstrip("/")
+    WIKI_NAME = args.wiki
+    main()

--- a/tests/live/run_all.py
+++ b/tests/live/run_all.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+"""
+Run all Synthadoc live tests in sequence: CLI, MCP, and Obsidian plugin REST API.
+
+Usage:
+    python -X utf8 tests/live/run_all.py [options]
+
+Options:
+    --url URL      Server HTTP base URL (default: http://127.0.0.1:7070)
+    --wiki NAME    Wiki name to test against (default: history-of-computing)
+    --mcp-url URL  MCP SSE endpoint URL (default: <url>/mcp/sse)
+    --suite NAME   Run only this suite; repeatable: --suite cli --suite mcp
+                   Choices: cli  mcp  plugin  (default: all three)
+
+Examples:
+    # Run all suites against default wiki + port
+    python -X utf8 tests/live/run_all.py
+
+    # Run against a different wiki and port
+    python -X utf8 tests/live/run_all.py --wiki ai-research --url http://127.0.0.1:7071
+
+    # Run only the plugin suite
+    python -X utf8 tests/live/run_all.py --suite plugin
+
+    # Run CLI and MCP only, skip plugin
+    python -X utf8 tests/live/run_all.py --suite cli --suite mcp
+"""
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+SUITES = {
+    "cli":    "live_cli_test.py",
+    "mcp":    "live_mcp_test.py",
+    "plugin": "live_plugin_test.py",
+}
+
+PASS = "\033[92mPASS\033[0m"
+FAIL = "\033[91mFAIL\033[0m"
+
+
+def run_suite(name: str, script: Path, extra_args: list[str], env: dict) -> int:
+    print(f"\n{'='*64}")
+    print(f"  Running suite: {name.upper()} — {script.name}")
+    print(f"{'='*64}")
+    r = subprocess.run(
+        [sys.executable, "-X", "utf8", str(script)] + extra_args,
+        env=env,
+    )
+    return r.returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="run_all.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--url", metavar="URL",
+        default="http://127.0.0.1:7070",
+        help="Server HTTP base URL (default: http://127.0.0.1:7070)",
+    )
+    parser.add_argument(
+        "--wiki", metavar="NAME",
+        default="history-of-computing",
+        help="Wiki name (default: history-of-computing)",
+    )
+    parser.add_argument(
+        "--mcp-url", metavar="URL",
+        default=None,
+        help="MCP SSE endpoint URL (default: <url>/mcp/sse)",
+    )
+    parser.add_argument(
+        "--suite", metavar="NAME",
+        action="append",
+        choices=list(SUITES),
+        help="Run only this suite; repeatable (default: all)",
+    )
+    args = parser.parse_args()
+
+    base    = args.url.rstrip("/")
+    mcp_url = args.mcp_url or f"{base}/mcp/sse"
+    to_run  = args.suite or list(SUITES)
+
+    # Per-suite CLI args (override env vars for explicit invocation)
+    suite_args = {
+        "cli":    ["--wiki", args.wiki, "--url", base + "/"],
+        "mcp":    [],
+        "plugin": ["--wiki", args.wiki, "--url", base],
+    }
+    # Per-suite environment
+    suite_env = {
+        "cli":    {**os.environ, "WIKI_NAME": args.wiki, "SYNTHADOC_URL": base + "/"},
+        "mcp":    {**os.environ, "MCP_URL": mcp_url},
+        "plugin": {**os.environ, "WIKI_NAME": args.wiki, "SYNTHADOC_URL": base},
+    }
+
+    codes: dict[str, int] = {}
+    for name in to_run:
+        codes[name] = run_suite(
+            name,
+            HERE / SUITES[name],
+            suite_args[name],
+            suite_env[name],
+        )
+
+    print(f"\n{'='*64}")
+    print("  ALL SUITES SUMMARY")
+    print(f"{'='*64}")
+    for name, code in codes.items():
+        mark = PASS if code == 0 else FAIL
+        print(f"  [{mark}] {name}")
+    print(f"{'='*64}")
+
+    sys.exit(0 if all(c == 0 for c in codes.values()) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/live_cli_test.py
+++ b/tests/live_cli_test.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+"""
+Live CLI integration test — exercises every CLI command against real processes.
+
+Tests run against an EXISTING installed wiki with a live server + LLM.
+No mocks.  This script is run manually, not by CI.
+
+────────────────────────────────────────────────────────────────────────────────
+ PREREQUISITES
+────────────────────────────────────────────────────────────────────────────────
+  1. A wiki must be installed (default: history-of-computing).
+  2. The synthadoc server must be running for that wiki:
+       synthadoc serve -w history-of-computing
+  3. An LLM API key must be set in the environment (e.g. ANTHROPIC_API_KEY).
+
+────────────────────────────────────────────────────────────────────────────────
+ ENVIRONMENT VARIABLES
+────────────────────────────────────────────────────────────────────────────────
+  WIKI_NAME      Wiki to test against.          Default: history-of-computing
+  SYNTHADOC_URL  HTTP base URL of the server.   Default: http://127.0.0.1:7070/
+
+────────────────────────────────────────────────────────────────────────────────
+ HOW TO RUN
+────────────────────────────────────────────────────────────────────────────────
+  # PowerShell
+  $env:SYNTHADOC_URL = "http://127.0.0.1:7070/"
+  python -X utf8 tests/live_cli_test.py
+
+  # bash / macOS / Linux
+  export SYNTHADOC_URL=http://127.0.0.1:7070/
+  python -X utf8 tests/live_cli_test.py
+
+  # Different wiki
+  $env:WIKI_NAME = "ai-research"
+  $env:SYNTHADOC_URL = "http://127.0.0.1:7072/"
+  python -X utf8 tests/live_cli_test.py
+
+────────────────────────────────────────────────────────────────────────────────
+ TIERS
+────────────────────────────────────────────────────────────────────────────────
+  Tier 1 — Offline.  Runs always; no server or LLM key required.
+  Tier 2 — Live.  Runs when server responds at SYNTHADOC_URL; calls LLM.
+
+────────────────────────────────────────────────────────────────────────────────
+ SIDE EFFECTS & ROLLBACK
+────────────────────────────────────────────────────────────────────────────────
+  • candidates: two temp pages are created, tested, then deleted (rollback).
+  • lifecycle:  one archived page is restored → activated → archived (round-trip;
+                page ends in the same archived state it started in).
+  • ingest:     a tiny local file is ingested with --analyse-only (no page
+                written to the wiki).
+  • schedule:   a temporary schedule entry is added then removed.
+  • use:        the default wiki is saved, temporarily changed, then restored.
+  All other commands are read-only or idempotent.
+"""
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+WIKI_NAME     = os.environ.get("WIKI_NAME", "history-of-computing")
+SYNTHADOC_URL = os.environ.get("SYNTHADOC_URL", "http://127.0.0.1:7070/")
+PY            = sys.executable
+
+PASS = "\033[92m[PASS]\033[0m"
+FAIL = "\033[91m[FAIL]\033[0m"
+WARN = "\033[93m[WARN]\033[0m"
+INFO = "\033[94m[INFO]\033[0m"
+
+results: list[tuple[str, str, str]] = []
+
+# ── Reporting helpers ─────────────────────────────────────────────────────────
+
+def ok(label: str, note: str = "") -> None:
+    print(f"  {PASS} {label}" + (f" — {note}" if note else ""))
+    results.append(("PASS", label, note))
+
+def fail(label: str, note: str) -> None:
+    print(f"  {FAIL} {label} — {note}")
+    results.append(("FAIL", label, note))
+
+def warn(label: str, note: str) -> None:
+    print(f"  {WARN} {label} — {note}")
+    results.append(("WARN", label, note))
+
+def info(msg: str) -> None:
+    print(f"  {INFO} {msg}")
+
+# ── CLI runner ────────────────────────────────────────────────────────────────
+
+def run(args: list[str], *, input: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [PY, "-m", "synthadoc"] + args,
+        capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+        input=input,
+    )
+
+def check(
+    label: str,
+    args: list[str],
+    *,
+    contains: list[str] | None = None,
+    not_contains: list[str] | None = None,
+    expect_exit: int = 0,
+    input: str | None = None,
+) -> subprocess.CompletedProcess:
+    r = run(args, input=input)
+    combined = r.stdout + r.stderr
+    if r.returncode != expect_exit:
+        fail(label, f"exit {r.returncode} (expected {expect_exit})\n    {combined[:400]}")
+        return r
+    for phrase in contains or []:
+        if phrase not in combined:
+            fail(label, f"expected {phrase!r} in output\n    {combined[:400]}")
+            return r
+    for phrase in not_contains or []:
+        if phrase in combined:
+            fail(label, f"unexpected {phrase!r} in output\n    {combined[:400]}")
+            return r
+    ok(label, (contains or [""])[0])
+    return r
+
+# ── Server probe ──────────────────────────────────────────────────────────────
+
+def server_alive() -> bool:
+    try:
+        with urllib.request.urlopen(SYNTHADOC_URL.rstrip("/") + "/", timeout=3):
+            return True
+    except Exception:
+        return False
+
+# ── Wiki introspection ────────────────────────────────────────────────────────
+
+def discover_wiki_root() -> pathlib.Path | None:
+    """Parse wiki root path from `synthadoc status` output."""
+    r = run(["status", "-w", WIKI_NAME])
+    for line in (r.stdout + r.stderr).splitlines():
+        if line.strip().startswith("Wiki:"):
+            path_str = line.split("Wiki:", 1)[1].strip()
+            p = pathlib.Path(path_str)
+            if p.exists():
+                return p
+    return None
+
+def find_pages_by_status(wiki_root: pathlib.Path, status: str) -> list[str]:
+    """Return slugs of wiki pages whose frontmatter contains `status: <value>`."""
+    slugs = []
+    wiki_dir = wiki_root / "wiki"
+    for f in sorted(wiki_dir.glob("*.md")):
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+            if f"status: {status}" in text[:600]:
+                slugs.append(f.stem)
+        except OSError:
+            pass
+    return slugs
+
+# ── Tier 1: Offline commands ──────────────────────────────────────────────────
+
+def run_offline_tests(wiki_root: pathlib.Path) -> None:
+    w = ["-w", WIKI_NAME]
+
+    # ── use ──────────────────────────────────────────────────────────────────
+    print("\n[1] use")
+    # Save current default so we can restore it
+    r_use_show = run(["use"])
+    prev_default = ""
+    for line in (r_use_show.stdout + r_use_show.stderr).splitlines():
+        if "default" in line.lower() or WIKI_NAME in line:
+            prev_default = line.strip()
+            break
+
+    check("use show",  ["use"],                   contains=[])
+    check("use set",   ["use", WIKI_NAME],         contains=[WIKI_NAME])
+    check("use clear", ["use", "--clear"],         contains=[])
+    # Restore the wiki as default so the rest of the test's -w flags aren't
+    # the only thing keeping commands bound to the right wiki
+    run(["use", WIKI_NAME])
+    ok("use restore default", WIKI_NAME)
+
+    # ── list ─────────────────────────────────────────────────────────────────
+    print("\n[2] list")
+    check("list", ["list"], contains=[WIKI_NAME])
+
+    # ── demo ─────────────────────────────────────────────────────────────────
+    print("\n[3] demo")
+    check("demo list", ["demo", "list"], contains=["history-of-computing"])
+    check("demo sync", ["demo", "sync", WIKI_NAME])
+
+    # ── routing ──────────────────────────────────────────────────────────────
+    print("\n[4] routing")
+    r_init = run(["routing", "init"] + w)
+    init_out = r_init.stdout + r_init.stderr
+    if r_init.returncode == 0 and "ROUTING" in init_out:
+        ok("routing init", "ROUTING")
+    elif "already exists" in init_out:
+        warn("routing init", "ROUTING.md already exists (expected for existing wiki)")
+    else:
+        fail("routing init", f"exit {r_init.returncode}\n    {init_out[:300]}")
+    check("routing validate", ["routing", "validate"] + w)
+    check("routing clean",    ["routing", "clean"]    + w)
+
+    # ── staging ───────────────────────────────────────────────────────────────
+    print("\n[5] staging")
+    check("staging policy show",      ["staging", "policy"]              + w)
+    check("staging policy off",       ["staging", "policy", "off"]       + w)
+    check("staging policy threshold", ["staging", "policy", "threshold",
+                                       "--min-confidence", "high"]       + w)
+    check("staging policy all",       ["staging", "policy", "all"]       + w)
+    # Restore to a sensible default (threshold/high matches typical config)
+    run(["staging", "policy", "threshold", "--min-confidence", "high"] + w)
+
+    # ── candidates: create temp pages, test promote/discard, rollback ─────────
+    print("\n[6] candidates")
+    cand_dir  = wiki_root / "wiki" / "candidates"
+    wiki_dir  = wiki_root / "wiki"
+    cand_dir.mkdir(parents=True, exist_ok=True)
+
+    _PROMOTE_SLUG = "_live-test-promote"
+    _DISCARD_SLUG = "_live-test-discard"
+    _promote_src  = cand_dir / f"{_PROMOTE_SLUG}.md"
+    _discard_src  = cand_dir / f"{_DISCARD_SLUG}.md"
+    _promote_dest = wiki_dir / f"{_PROMOTE_SLUG}.md"
+
+    _fm = "---\ntitle: Live Test Page\nstatus: draft\nconfidence: high\ncreated: '2026-06-23T00:00:00'\n---\n\nTemporary page created by live_cli_test.py.\n"
+    _promote_src.write_text(_fm, encoding="utf-8")
+    _discard_src.write_text(_fm, encoding="utf-8")
+
+    try:
+        check("candidates list",    ["candidates", "list"]              + w, contains=[_PROMOTE_SLUG])
+        check("candidates promote", ["candidates", "promote", _PROMOTE_SLUG] + w)
+        check("candidates discard", ["candidates", "discard", _DISCARD_SLUG] + w)
+    finally:
+        # Rollback: remove promoted page from main wiki and any leftover cands
+        _promote_dest.unlink(missing_ok=True)
+        _promote_src.unlink(missing_ok=True)
+        _discard_src.unlink(missing_ok=True)
+        ok("candidates rollback")
+
+    # ── context build ─────────────────────────────────────────────────────────
+    print("\n[7] context build")
+    check("context build", ["context", "build", "history of computing"] + w)
+
+    # ── lint report ───────────────────────────────────────────────────────────
+    print("\n[8] lint report")
+    check("lint report", ["lint", "report"] + w)
+
+    # ── schedule ──────────────────────────────────────────────────────────────
+    print("\n[9] schedule")
+    r_add = check("schedule add",
+                  ["schedule", "add", "--op", "lint run", "--cron", "0 2 * * *"] + w,
+                  contains=["sched-"])
+    sched_id = ""
+    for token in (r_add.stdout + r_add.stderr).split():
+        if token.startswith("sched-"):
+            sched_id = token
+            break
+    check("schedule list",    ["schedule", "list"]    + w, contains=["lint run"])
+    check("schedule history", ["schedule", "history"] + w)
+    check("schedule apply",   ["schedule", "apply"]   + w)
+    if sched_id:
+        check("schedule remove", ["schedule", "remove", sched_id] + w, contains=[sched_id])
+    else:
+        warn("schedule remove", "could not extract schedule ID from add output")
+
+    # ── audit lifecycle purge ─────────────────────────────────────────────────
+    print("\n[10] audit lifecycle purge")
+    check("audit lifecycle purge --keep-latest",
+          ["audit", "lifecycle", "purge", "--keep-latest", "10"] + w)
+
+    # ── plugin upgrade (no-op when no vaults registered) ─────────────────────
+    print("\n[11] plugin")
+    check("plugin upgrade", ["plugin", "upgrade"])
+    # plugin install requires an Obsidian vault; WARN if not configured
+    r_pi = run(["plugin", "install"] + w)
+    pi_out = r_pi.stdout + r_pi.stderr
+    if r_pi.returncode == 0:
+        ok("plugin install")
+    else:
+        warn("plugin install", "vault not configured — " + pi_out.strip()[:120])
+
+
+# ── Tier 2: Live server + LLM ─────────────────────────────────────────────────
+
+def run_live_tests(wiki_root: pathlib.Path) -> None:
+    w = ["-w", WIKI_NAME]
+
+    # ── status ────────────────────────────────────────────────────────────────
+    print("\n[12] status")
+    check("status", ["status"] + w, contains=["Pages:"])
+
+    # ── ingest (analyse-only — writes no wiki pages) ──────────────────────────
+    print("\n[13] ingest")
+    _src = pathlib.Path(tempfile.mktemp(suffix=".txt"))
+    _src.write_text(
+        "The ENIAC was the first general-purpose electronic computer, completed in 1945.\n",
+        encoding="utf-8",
+    )
+    try:
+        check("ingest --analyse-only",
+              ["ingest", str(_src), "--analyse-only"] + w,
+              contains=[])
+    finally:
+        _src.unlink(missing_ok=True)
+
+    # ── query ─────────────────────────────────────────────────────────────────
+    print("\n[14] query")
+    check("query (cached or live)",
+          ["query", "What is ENIAC?", "--no-stream"] + w,
+          contains=[])
+
+    # ── scaffold ──────────────────────────────────────────────────────────────
+    print("\n[15] scaffold")
+    check("scaffold", ["scaffold"] + w, contains=["job"])
+
+    # ── export ────────────────────────────────────────────────────────────────
+    print("\n[16] export")
+    check("export llms.txt",      ["export", "-f", "llms.txt"]      + w)
+    check("export llms-full.txt", ["export", "-f", "llms-full.txt"] + w)
+    check("export json",          ["export", "-f", "json"]          + w)
+    check("export graphml",       ["export", "-f", "graphml"]       + w)
+    _okf_dir = tempfile.mkdtemp(prefix="synthadoc_okf_")
+    try:
+        check("export okf", ["export", "-f", "okf", "--output", _okf_dir] + w)
+    finally:
+        shutil.rmtree(_okf_dir, ignore_errors=True)
+
+    # ── jobs ──────────────────────────────────────────────────────────────────
+    print("\n[17] jobs")
+    r_list = check("jobs list",          ["jobs", "list"]                     + w)
+    check("jobs list --sort status",     ["jobs", "list", "--sort", "status"] + w)
+    check("jobs list --order desc",      ["jobs", "list", "--order", "desc"]  + w)
+
+    job_id = delete_id = ""
+    for line in (r_list.stdout + r_list.stderr).splitlines():
+        tokens = line.split()
+        for t in tokens:
+            if len(t) == 8 and all(c in "0123456789abcdef" for c in t):
+                if not job_id:
+                    job_id = t
+                if not delete_id and any(s in line for s in ("completed", "failed", "cancelled")):
+                    delete_id = t
+                break
+
+    if job_id:
+        check("jobs status", ["jobs", "status", job_id] + w)
+        check("jobs retry",  ["jobs", "retry",  job_id] + w)
+    else:
+        warn("jobs status/retry", "no job found in list output")
+
+    if delete_id:
+        check("jobs delete", ["jobs", "delete", delete_id] + w, contains=[delete_id])
+    else:
+        warn("jobs delete", "no completed/failed job available to delete safely")
+
+    check("jobs purge --older-than 365", ["jobs", "purge", "--older-than", "365"] + w)
+    check("jobs cancel --yes",           ["jobs", "cancel", "--yes"]              + w)
+
+    # ── lint run ──────────────────────────────────────────────────────────────
+    print("\n[18] lint run")
+    check("lint run", ["lint", "run"] + w, contains=["job"])
+
+    # ── schedule run ──────────────────────────────────────────────────────────
+    print("\n[19] schedule run")
+    check("schedule run --op lint run",
+          ["schedule", "run", "--op", "lint run"] + w)
+
+    # ── lifecycle log + round-trip (restore → activate → archive) ─────────────
+    print("\n[20] lifecycle")
+    check("lifecycle log", ["lifecycle", "log"] + w)
+
+    archived_slugs = find_pages_by_status(wiki_root, "archived")
+    if archived_slugs:
+        slug = archived_slugs[0]
+        info(f"lifecycle round-trip on: {slug}")
+        check("lifecycle restore",
+              ["lifecycle", "restore", slug, "--reason", "live-test restore"] + w)
+        check("lifecycle activate",
+              ["lifecycle", "activate", slug, "--reason", "live-test activate"] + w)
+        check("lifecycle archive",
+              ["lifecycle", "archive",  slug, "--reason", "live-test archive"]  + w)
+        ok("lifecycle round-trip complete", f"{slug}: archived → draft → active → archived")
+    else:
+        warn("lifecycle activate/archive/restore",
+             "no archived pages found — skipping round-trip")
+
+    # ── cache clear ───────────────────────────────────────────────────────────
+    print("\n[21] cache clear")
+    check("cache clear", ["cache", "clear"] + w)
+
+    # ── audit ─────────────────────────────────────────────────────────────────
+    print("\n[22] audit")
+    check("audit history",   ["audit", "history"]   + w)
+    check("audit cost",      ["audit", "cost"]       + w)
+    check("audit queries",   ["audit", "queries"]    + w)
+    check("audit events",    ["audit", "events"]     + w)
+    check("audit citations", ["audit", "citations"]  + w)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("=" * 64)
+    print("  Synthadoc Live CLI Test")
+    print(f"  wiki      : {WIKI_NAME}")
+    print(f"  server URL: {SYNTHADOC_URL}")
+    print("=" * 64)
+
+    # Verify wiki is installed
+    r = run(["list"])
+    if WIKI_NAME not in (r.stdout + r.stderr):
+        print(f"\nFATAL: wiki '{WIKI_NAME}' is not installed.")
+        print(f"  Run: synthadoc install {WIKI_NAME}")
+        print(f"  Or set WIKI_NAME to an installed wiki.")
+        sys.exit(1)
+    ok(f"wiki '{WIKI_NAME}' is installed")
+
+    wiki_root = discover_wiki_root()
+    if not wiki_root:
+        # Fall back: server may not be up yet but we can still do tier 1
+        # Construct wiki_root from the registry path heuristic
+        wiki_root = pathlib.Path.home() / "wikis" / WIKI_NAME
+    ok(f"wiki root resolved", str(wiki_root))
+
+    run_offline_tests(wiki_root)
+
+    if server_alive():
+        info(f"Server reachable at {SYNTHADOC_URL} — running live (tier 2) tests")
+        # Re-discover wiki_root with server up (status endpoint returns the path)
+        wiki_root = discover_wiki_root() or wiki_root
+        run_live_tests(wiki_root)
+    else:
+        warn("live tests (tier 2)",
+             f"server not reachable at {SYNTHADOC_URL} — skipping")
+        info("start 'synthadoc serve -w <wiki>' then re-run with SYNTHADOC_URL set")
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    passes = sum(1 for r in results if r[0] == "PASS")
+    warns  = sum(1 for r in results if r[0] == "WARN")
+    fails  = sum(1 for r in results if r[0] == "FAIL")
+
+    print()
+    print("=" * 64)
+    print("  RESULTS SUMMARY")
+    print("=" * 64)
+    print(f"  PASS : {passes}")
+    print(f"  WARN : {warns}")
+    print(f"  FAIL : {fails}")
+    if fails:
+        print()
+        print("  Failed commands:")
+        for status, label, note in results:
+            if status == "FAIL":
+                print(f"    - {label}: {note[:220]}")
+    print("=" * 64)
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="live_cli_test.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--wiki", metavar="NAME",
+        default=os.environ.get("WIKI_NAME", "history-of-computing"),
+        help="Wiki to test against (overrides WIKI_NAME env var)",
+    )
+    parser.add_argument(
+        "--url", metavar="URL",
+        default=os.environ.get("SYNTHADOC_URL", "http://127.0.0.1:7070/"),
+        help="Server base URL (overrides SYNTHADOC_URL env var)",
+    )
+    args = parser.parse_args()
+    WIKI_NAME     = args.wiki
+    SYNTHADOC_URL = args.url
+    main()

--- a/tests/storage/test_wiki.py
+++ b/tests/storage/test_wiki.py
@@ -320,3 +320,23 @@ def test_updated_missing_defaults_to_none(tmp_wiki):
     loaded = store.read_page("legacy")
     assert loaded is not None
     assert loaded.updated is None
+
+
+def test_read_page_with_malformed_yaml_frontmatter(tmp_wiki):
+    """read_page must return a WikiPage (with empty frontmatter) when YAML is invalid.
+
+    Previously yaml.YAMLError was unhandled and would crash the caller. The fix
+    silently degrades to an empty fm dict so the page body is still accessible.
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+    (tmp_wiki / "wiki").mkdir(parents=True, exist_ok=True)
+    # YAML with a tab character in a quoted-flow-style context — triggers YAMLError
+    (tmp_wiki / "wiki" / "broken.md").write_text(
+        "---\ntitle: broken:\n  : invalid\n---\n\nsome body",
+        encoding="utf-8"
+    )
+    # Must not raise; must return a WikiPage with empty/default frontmatter
+    loaded = store.read_page("broken")
+    assert loaded is not None
+    assert isinstance(loaded, WikiPage)
+    assert "some body" in loaded.content


### PR DESCRIPTION
## What

Pre-release security and quality hardening across the HTTP server, MCP server, and wiki storage layer — 11 fixes spanning 3 severity levels, plus 9 new regression tests.

## Why

A pre-v1.0 code review identified issues in input validation, body-size enforcement, audit DB reuse, query cache consistency, and CORS coverage.  All fixes reduce risk before the public release without changing any user-facing behaviour.

## Changes

**High**
  - `storage/wiki.py`: wrap `yaml.safe_load` in try/except: malformed frontmatter no longer crashes `read_page()`
  - `mcp_server.py`: `synthadoc_write_page` now rejects empty/whitespace content before attempting the write
  - `http_server.py`: `ContentSizeLimitMiddleware` counts bytes on chunked
  -   POST/PUT/PATCH bodies (GET excluded to preserve SSE receive() flow)

**Medium**
  - `IngestRequest.source` validates non-empty at the Pydantic layer
  - `_session_state` dict is cleared on hourly DB purge (prevents unbounded in-process memory growth)
  - `GET /query` now returns `Cache-Control: no-store`
  - `POST /query` shares cache read/write logic with `GET /query`; added `no_cache` field to `QueryRequest`
  - Five lifecycle/provenance endpoints reuse `orch._audit` singleton instead of opening a fresh SQLite connection per request
  - `GET /jobs` allowlists `sort` and `order` query params

  **Others**
  - FastMCP private `_tool_manager._tools` access wrapped in `AttributeError` guard (graceful degradation on version bump)
  - CORS `allow_origins` extended with dev-server ports `:3000`, `:5173`, `:7070`