### PR TITLE
fix(live-tests): wiki/URL mismatch detection, lifecycle round-trip, README cleanupPdev1

### DIFF
--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -12,19 +12,30 @@ Manual integration tests that run against a live server and LLM.  Not run by CI.
 
 ## Prerequisites
 
-1. **Wiki installed**
+1. **Python** — the command name differs by platform:
+
+   | Platform | Command | One-time fix to use `python` everywhere |
+   |---|---|---|
+   | **Windows** | `python` | _(already works)_ |
+   | **macOS** | `python3` | Add `alias python=python3` to `~/.zshrc`, then `source ~/.zshrc` |
+   | **Linux** | `python3` | `sudo apt install python-is-python3` (Debian/Ubuntu) |
+
+   All examples below use `python` — apply the one-time fix above on macOS/Linux
+   and every example will work as written.
+
+2. **Wiki installed**
    ```
    synthadoc install history-of-computing
    ```
 
-2. **Server running**
+3. **Server running**
    ```
    synthadoc serve -w history-of-computing
    ```
 
-3. **LLM API key** — e.g. `ANTHROPIC_API_KEY` in the environment
+4. **LLM API key** — e.g. `ANTHROPIC_API_KEY` in the environment
 
-4. **MCP client library** (MCP test only)
+5. **MCP client library** (MCP test only)
    ```
    pip install mcp
    ```
@@ -34,11 +45,7 @@ Manual integration tests that run against a live server and LLM.  Not run by CI.
 The simplest invocation uses whichever wiki is set as your default
 (`synthadoc use`).  No flags required:
 
-```bash
-# bash / macOS / Linux
-python3 -X utf8 tests/live/run_all.py
-
-# PowerShell
+```
 python -X utf8 tests/live/run_all.py
 ```
 
@@ -47,68 +54,83 @@ If your setup differs, override with `--wiki` and `--url` — but **the wiki
 name must match what the running server is actually serving**.  The runner
 validates this at startup and exits with a clear error if they don't match.
 
-```bash
-# Example: server is on a non-default port for history-of-computing
-python3 -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
+```
+# Server on a non-default port
+python -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
 
-# Example: testing a different wiki (server must be running for that wiki)
-python3 -X utf8 tests/live/run_all.py --wiki my-other-wiki --url http://127.0.0.1:7072
+# Different wiki (server must be running for that wiki)
+python -X utf8 tests/live/run_all.py --wiki my-other-wiki --url http://127.0.0.1:7072
 ```
 
 ### One suite only
 
-```bash
-python3 -X utf8 tests/live/run_all.py --suite cli
-python3 -X utf8 tests/live/run_all.py --suite mcp
-python3 -X utf8 tests/live/run_all.py --suite plugin
+```
+python -X utf8 tests/live/run_all.py --suite cli
+python -X utf8 tests/live/run_all.py --suite mcp
+python -X utf8 tests/live/run_all.py --suite plugin
 ```
 
 ### Two suites, skip one
 
-```bash
-python3 -X utf8 tests/live/run_all.py --suite cli --suite plugin
+```
+python -X utf8 tests/live/run_all.py --suite cli --suite plugin
 ```
 
 ## Run suites individually
 
 ### CLI test
 
-```bash
-# bash / macOS / Linux — uses default wiki and port
-python3 -X utf8 tests/live/live_cli_test.py
+```
+python -X utf8 tests/live/live_cli_test.py
+python -X utf8 tests/live/live_cli_test.py --help
+```
 
-# Or set via environment variable
-SYNTHADOC_URL=http://127.0.0.1:7070/ python3 -X utf8 tests/live/live_cli_test.py
+PowerShell / bash — set via environment variable instead of flags:
 
+```powershell
 # PowerShell
 $env:SYNTHADOC_URL = "http://127.0.0.1:7070/"
 python -X utf8 tests/live/live_cli_test.py
+```
 
-python -X utf8 tests/live/live_cli_test.py --help
+```bash
+# bash
+SYNTHADOC_URL=http://127.0.0.1:7070/ python -X utf8 tests/live/live_cli_test.py
 ```
 
 ### MCP test
 
-```bash
-# bash / macOS / Linux
-MCP_URL=http://127.0.0.1:7070/mcp/sse python3 -X utf8 tests/live/live_mcp_test.py
+```
+python -X utf8 tests/live/live_mcp_test.py
+```
 
+```powershell
 # PowerShell
 $env:MCP_URL = "http://127.0.0.1:7070/mcp/sse"
 python -X utf8 tests/live/live_mcp_test.py
 ```
 
+```bash
+# bash
+MCP_URL=http://127.0.0.1:7070/mcp/sse python -X utf8 tests/live/live_mcp_test.py
+```
+
 ### Plugin REST API test
 
-```bash
-# bash / macOS / Linux
-SYNTHADOC_URL=http://127.0.0.1:7070 python3 -X utf8 tests/live/live_plugin_test.py
+```
+python -X utf8 tests/live/live_plugin_test.py
+python -X utf8 tests/live/live_plugin_test.py --help
+```
 
+```powershell
 # PowerShell
 $env:SYNTHADOC_URL = "http://127.0.0.1:7070"
 python -X utf8 tests/live/live_plugin_test.py
+```
 
-python -X utf8 tests/live/live_plugin_test.py --help
+```bash
+# bash
+SYNTHADOC_URL=http://127.0.0.1:7070 python -X utf8 tests/live/live_plugin_test.py
 ```
 
 ## Environment variables

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -31,74 +31,83 @@ Manual integration tests that run against a live server and LLM.  Not run by CI.
 
 ## Run all suites together
 
-```powershell
-# PowerShell
-python -X utf8 tests/live/run_all.py
+The simplest invocation uses whichever wiki is set as your default
+(`synthadoc use`).  No flags required:
 
+```bash
 # bash / macOS / Linux
+python3 -X utf8 tests/live/run_all.py
+
+# PowerShell
 python -X utf8 tests/live/run_all.py
 ```
 
-### Different wiki or port
+The default wiki is `history-of-computing` and the default port is 7070.
+If your setup differs, override with `--wiki` and `--url` — but **the wiki
+name must match what the running server is actually serving**.  The runner
+validates this at startup and exits with a clear error if they don't match.
 
-```powershell
-python -X utf8 tests/live/run_all.py --wiki ai-research --url http://127.0.0.1:7071
+```bash
+# Example: server is on a non-default port for history-of-computing
+python3 -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
+
+# Example: testing a different wiki (server must be running for that wiki)
+python3 -X utf8 tests/live/run_all.py --wiki my-other-wiki --url http://127.0.0.1:7072
 ```
 
 ### One suite only
 
-```powershell
-python -X utf8 tests/live/run_all.py --suite cli
-python -X utf8 tests/live/run_all.py --suite mcp
-python -X utf8 tests/live/run_all.py --suite plugin
+```bash
+python3 -X utf8 tests/live/run_all.py --suite cli
+python3 -X utf8 tests/live/run_all.py --suite mcp
+python3 -X utf8 tests/live/run_all.py --suite plugin
 ```
 
 ### Two suites, skip one
 
-```powershell
-python -X utf8 tests/live/run_all.py --suite cli --suite plugin
+```bash
+python3 -X utf8 tests/live/run_all.py --suite cli --suite plugin
 ```
 
 ## Run suites individually
 
 ### CLI test
 
-```powershell
+```bash
+# bash / macOS / Linux — uses default wiki and port
+python3 -X utf8 tests/live/live_cli_test.py
+
+# Or set via environment variable
+SYNTHADOC_URL=http://127.0.0.1:7070/ python3 -X utf8 tests/live/live_cli_test.py
+
 # PowerShell
 $env:SYNTHADOC_URL = "http://127.0.0.1:7070/"
 python -X utf8 tests/live/live_cli_test.py
 
-# bash
-SYNTHADOC_URL=http://127.0.0.1:7070/ python -X utf8 tests/live/live_cli_test.py
-
-# With flags
-python -X utf8 tests/live/live_cli_test.py --wiki ai-research --url http://127.0.0.1:7071/
 python -X utf8 tests/live/live_cli_test.py --help
 ```
 
 ### MCP test
 
-```powershell
+```bash
+# bash / macOS / Linux
+MCP_URL=http://127.0.0.1:7070/mcp/sse python3 -X utf8 tests/live/live_mcp_test.py
+
 # PowerShell
 $env:MCP_URL = "http://127.0.0.1:7070/mcp/sse"
 python -X utf8 tests/live/live_mcp_test.py
-
-# bash
-MCP_URL=http://127.0.0.1:7070/mcp/sse python -X utf8 tests/live/live_mcp_test.py
 ```
 
 ### Plugin REST API test
 
-```powershell
+```bash
+# bash / macOS / Linux
+SYNTHADOC_URL=http://127.0.0.1:7070 python3 -X utf8 tests/live/live_plugin_test.py
+
 # PowerShell
 $env:SYNTHADOC_URL = "http://127.0.0.1:7070"
 python -X utf8 tests/live/live_plugin_test.py
 
-# bash
-SYNTHADOC_URL=http://127.0.0.1:7070 python -X utf8 tests/live/live_plugin_test.py
-
-# With flags
-python -X utf8 tests/live/live_plugin_test.py --url http://127.0.0.1:7071 --wiki ai-research
 python -X utf8 tests/live/live_plugin_test.py --help
 ```
 

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -28,14 +28,12 @@ Manual integration tests that run against a live server and LLM.  Not run by CI.
    synthadoc install history-of-computing
    ```
 
-3. **Server running**
+3. **Server running** (the server needs the LLM API key, not the test client)
    ```
    synthadoc serve -w history-of-computing
    ```
 
-4. **LLM API key** — e.g. `ANTHROPIC_API_KEY` in the environment
-
-5. **MCP client library** (MCP test only)
+4. **MCP client library** — required only for the MCP suite (`live_mcp_test.py`)
    ```
    pip install mcp
    ```

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -141,7 +141,7 @@ All tests are designed to leave the wiki in its original state:
 | CLI | `ingest` — uses `--analyse-only` | no wiki page written |
 | CLI | `schedule` — temp entry added | removed after test |
 | Plugin | `candidates/` — 2 temp pages created | deleted in `finally` block |
-| Plugin | lifecycle — 1 archived page round-trips | ends back in `archived` state |
+| Plugin | lifecycle — 1 archived page round-trips (creates one temporarily if none exist) | ends back in original state |
 | Plugin | staging policy — changed to `off` | restored before test ends |
 | MCP | `synthadoc_write_page` — content modified | original content restored |
 | MCP | lifecycle — 1 active page marked stale | restored to `active` |

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -436,6 +436,35 @@ def main() -> None:
         info(f"Server reachable at {SYNTHADOC_URL} — running live (tier 2) tests")
         # Re-discover wiki_root with server up (status endpoint returns the path)
         wiki_root = discover_wiki_root() or wiki_root
+
+        # Validate that the running server is actually serving WIKI_NAME.
+        # The CLI reads the server port from the wiki's config.toml — if the
+        # server at SYNTHADOC_URL is serving a *different* wiki, all tier-2
+        # CLI commands will get ERR-SRV-001 on the wrong port.
+        try:
+            import json as _json
+            with urllib.request.urlopen(
+                SYNTHADOC_URL.rstrip("/") + "/status", timeout=5
+            ) as _r:
+                _status = _json.loads(_r.read())
+            _serving = pathlib.Path(_status.get("wiki", "")).name
+            if _serving and _serving != WIKI_NAME:
+                print()
+                print(f"  FATAL: wiki/URL mismatch detected.")
+                print(f"    Server at {SYNTHADOC_URL} is serving wiki '{_serving}',")
+                print(f"    but --wiki is set to '{WIKI_NAME}'.")
+                print(f"    The CLI reads the server port from '{WIKI_NAME}' config.toml,")
+                print(f"    so all server-dependent commands will fail.")
+                print()
+                print(f"  Fix one of the following:")
+                print(f"    A) Run the server for the right wiki:")
+                print(f"         synthadoc serve -w {WIKI_NAME}")
+                print(f"    B) Run the tests against the wiki that IS running:")
+                print(f"         python3 -X utf8 tests/live/live_cli_test.py --wiki {_serving}")
+                sys.exit(1)
+        except Exception:
+            pass  # if status probe fails for any reason, let the tests surface it
+
         run_live_tests(wiki_root)
     else:
         warn("live tests (tier 2)",

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -460,7 +460,7 @@ def main() -> None:
                 print(f"    A) Run the server for the right wiki:")
                 print(f"         synthadoc serve -w {WIKI_NAME}")
                 print(f"    B) Run the tests against the wiki that IS running:")
-                print(f"         python3 -X utf8 tests/live/live_cli_test.py --wiki {_serving}")
+                print(f"         {PY} -X utf8 tests/live/live_cli_test.py --wiki {_serving}")
                 sys.exit(1)
         except Exception:
             pass  # if status probe fails for any reason, let the tests surface it

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -574,7 +574,7 @@ def main() -> None:
     # round-trip: find an archived page and cycle it archived→draft→active→archived
     archived_slug: str | None = None
     for p in lc_pages:
-        if isinstance(p, dict) and p.get("status") == "archived":
+        if isinstance(p, dict) and p.get("state") == "archived":
             archived_slug = p.get("slug")
             break
 
@@ -583,7 +583,7 @@ def main() -> None:
     created_archived_slug: str | None = None
     if not archived_slug:
         for p in lc_pages:
-            if isinstance(p, dict) and p.get("status") == "active":
+            if isinstance(p, dict) and p.get("state") == "active":
                 candidate = p.get("slug")
                 code, body = POST("/lifecycle/transition",
                                   {"slug": candidate, "to_state": "archived",

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -578,6 +578,24 @@ def main() -> None:
             archived_slug = p.get("slug")
             break
 
+    # If no archived page exists, promote an active page to archived temporarily
+    # so the round-trip can still run, then restore it to active at the end.
+    created_archived_slug: str | None = None
+    if not archived_slug:
+        for p in lc_pages:
+            if isinstance(p, dict) and p.get("status") == "active":
+                candidate = p.get("slug")
+                code, body = POST("/lifecycle/transition",
+                                  {"slug": candidate, "to_state": "archived",
+                                   "reason": "plugin-live-test setup (temp archive)"})
+                if code == 200:
+                    archived_slug = candidate
+                    created_archived_slug = candidate
+                    info(f"no archived page found — archived '{candidate}' temporarily for round-trip")
+                    break
+        if not archived_slug:
+            warn("POST /lifecycle/transition", "no active or archived page available — skipping round-trip")
+
     if archived_slug:
         info(f"lifecycle round-trip on: {archived_slug}")
 
@@ -604,8 +622,16 @@ def main() -> None:
             ok("POST /lifecycle/transition (active→archived)", "round-trip complete")
         else:
             fail("POST /lifecycle/transition (active→archived)", f"HTTP {code}: {str(body)[:120]}")
-    else:
-        warn("POST /lifecycle/transition", "no archived page found — skipping round-trip")
+
+        # Restore pages that were only archived as test setup back to active
+        if created_archived_slug:
+            POST("/lifecycle/transition",
+                 {"slug": created_archived_slug, "to_state": "draft",
+                  "reason": "plugin-live-test rollback"})
+            POST("/lifecycle/transition",
+                 {"slug": created_archived_slug, "to_state": "active",
+                  "reason": "plugin-live-test rollback"})
+            info(f"rolled back '{created_archived_slug}' to active")
 
     # ── [14] synthadoc-export-wiki ────────────────────────────────────────────
     print("\n[14] synthadoc-export-wiki — api.exportWiki(), api.exportWikiOkf()")

--- a/tests/live/run_all.py
+++ b/tests/live/run_all.py
@@ -14,17 +14,20 @@ Options:
                    Choices: cli  mcp  plugin  (default: all three)
 
 Examples:
-    # Run all suites against default wiki + port
-    python -X utf8 tests/live/run_all.py
+    # Run all suites against the default wiki (history-of-computing, port 7070)
+    python3 -X utf8 tests/live/run_all.py
 
-    # Run against a different wiki and port
-    python -X utf8 tests/live/run_all.py --wiki ai-research --url http://127.0.0.1:7071
+    # Server on a non-default port (wiki name must match what the server serves)
+    python3 -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
+
+    # Different wiki — server must be running for that wiki
+    python3 -X utf8 tests/live/run_all.py --wiki my-wiki --url http://127.0.0.1:7072
 
     # Run only the plugin suite
-    python -X utf8 tests/live/run_all.py --suite plugin
+    python3 -X utf8 tests/live/run_all.py --suite plugin
 
     # Run CLI and MCP only, skip plugin
-    python -X utf8 tests/live/run_all.py --suite cli --suite mcp
+    python3 -X utf8 tests/live/run_all.py --suite cli --suite mcp
 """
 import argparse
 import os
@@ -87,6 +90,32 @@ def main() -> None:
     base    = args.url.rstrip("/")
     mcp_url = args.mcp_url or f"{base}/mcp/sse"
     to_run  = args.suite or list(SUITES)
+
+    # Pre-flight: verify the server is serving the expected wiki before
+    # spending time on any suite.  Mismatch causes the CLI suite to fail
+    # every server-dependent command with ERR-SRV-001.
+    import json as _json
+    import urllib.request as _urlreq
+    try:
+        with _urlreq.urlopen(f"{base}/status", timeout=5) as _r:
+            _status = _json.loads(_r.read())
+        _serving = Path(_status.get("wiki", "")).name
+        if _serving and _serving != args.wiki:
+            print(f"\nERROR: wiki/URL mismatch.")
+            print(f"  Server at {base} is serving wiki '{_serving}',")
+            print(f"  but --wiki is '{args.wiki}'.")
+            print(f"  The CLI reads the server port from '{args.wiki}' config.toml,")
+            print(f"  so all server-dependent CLI commands will fail with ERR-SRV-001.")
+            print()
+            print(f"  Fix one of the following:")
+            print(f"    A) Run the server for the right wiki:")
+            print(f"         synthadoc serve -w {args.wiki}")
+            print(f"    B) Pass the wiki that IS running:")
+            print(f"         python3 -X utf8 tests/live/run_all.py --wiki {_serving}")
+            print(f"         python3 -X utf8 tests/live/run_all.py")
+            sys.exit(1)
+    except Exception:
+        pass  # server not yet up — individual suites will handle this gracefully
 
     # Per-suite CLI args (override env vars for explicit invocation)
     suite_args = {

--- a/tests/live/run_all.py
+++ b/tests/live/run_all.py
@@ -111,8 +111,8 @@ def main() -> None:
             print(f"    A) Run the server for the right wiki:")
             print(f"         synthadoc serve -w {args.wiki}")
             print(f"    B) Pass the wiki that IS running:")
-            print(f"         python -X utf8 tests/live/run_all.py --wiki {_serving}")
-            print(f"         python -X utf8 tests/live/run_all.py")
+            print(f"         {sys.executable} -X utf8 tests/live/run_all.py --wiki {_serving}")
+            print(f"         {sys.executable} -X utf8 tests/live/run_all.py")
             sys.exit(1)
     except Exception:
         pass  # server not yet up — individual suites will handle this gracefully

--- a/tests/live/run_all.py
+++ b/tests/live/run_all.py
@@ -15,19 +15,19 @@ Options:
 
 Examples:
     # Run all suites against the default wiki (history-of-computing, port 7070)
-    python3 -X utf8 tests/live/run_all.py
+    python -X utf8 tests/live/run_all.py
 
     # Server on a non-default port (wiki name must match what the server serves)
-    python3 -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
+    python -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
 
     # Different wiki — server must be running for that wiki
-    python3 -X utf8 tests/live/run_all.py --wiki my-wiki --url http://127.0.0.1:7072
+    python -X utf8 tests/live/run_all.py --wiki my-wiki --url http://127.0.0.1:7072
 
     # Run only the plugin suite
-    python3 -X utf8 tests/live/run_all.py --suite plugin
+    python -X utf8 tests/live/run_all.py --suite plugin
 
     # Run CLI and MCP only, skip plugin
-    python3 -X utf8 tests/live/run_all.py --suite cli --suite mcp
+    python -X utf8 tests/live/run_all.py --suite cli --suite mcp
 """
 import argparse
 import os
@@ -111,8 +111,8 @@ def main() -> None:
             print(f"    A) Run the server for the right wiki:")
             print(f"         synthadoc serve -w {args.wiki}")
             print(f"    B) Pass the wiki that IS running:")
-            print(f"         python3 -X utf8 tests/live/run_all.py --wiki {_serving}")
-            print(f"         python3 -X utf8 tests/live/run_all.py")
+            print(f"         python -X utf8 tests/live/run_all.py --wiki {_serving}")
+            print(f"         python -X utf8 tests/live/run_all.py")
             sys.exit(1)
     except Exception:
         pass  # server not yet up — individual suites will handle this gracefully


### PR DESCRIPTION
1. Wiki/URL mismatch detection (run_all.py, live_cli_test.py)
When --wiki and --url point to different wikis, the CLI suite fails every server-dependent command with ERR-SRV-001 because the CLI reads the server port from the wiki's config.toml rather than from SYNTHADOC_URL. Both run_all.py and live_cli_test.py now probe GET /status at startup, compare the serving wiki name against --wiki, and exit immediately with a clear error and fix instructions instead of silently failing 20 tests.

2. Lifecycle round-trip always runs (live_plugin_test.py)
The [13] lifecycle-modal test previously warned and skipped when no archived page was found. It now picks the first active page, archives it as test setup, runs the full archived → draft → active → archived round-trip, then restores the page to its original active state. The wiki is left unchanged.

3. README examples (tests/live/README.md)
Removed hardcoded --wiki ai-research from all examples. The default invocation now uses whatever wiki the server is serving (matching the synthadoc use default). Added a note that the runner validates wiki/URL alignment at startup.