### PR TITLE
[v0.9.3] feat(skills): standalone isolation, complete web_search, per-skill docs, and misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ obsidian-plugin/main.js
 .synthadoc/
 docs/plans/
 docs/blog/
+
+# skills CLI installs (project-local agent skill copies)
+.agents/
 docs/*.docx
 synthadoc/demos/*/log.md
 

--- a/README.md
+++ b/README.md
@@ -1010,7 +1010,7 @@ synthadoc restore backup.zip --name my-wiki-staging --target ~/wikis --port 7071
 
 **Restore flags:** `--name` (override wiki name), `--target/-t` (parent directory, default: same folder as zip), `--port` (skip interactive port prompt).
 
-**Obsidian plugin on restore:** The Obsidian plugin is reinstalled and pre-enabled automatically. Open the restored vault in Obsidian — both plugins are active with no manual toggling needed. Update **Server URL** in Synthadoc plugin settings only if the port changed.
+**Obsidian plugin on restore:** The Obsidian plugin is reinstalled and pre-enabled automatically, with the Server URL updated to match the restored port. Open the restored vault in Obsidian — both plugins are active with no manual steps needed.
 
 **Always excluded from backup:**
 - **Embeddings database** — vector representations of wiki pages, used only when vector search is enabled. Rebuilt automatically in the background on the next server start (pages not yet in the DB are re-embedded).

--- a/README.md
+++ b/README.md
@@ -285,8 +285,6 @@ cd ..
 python scripts/sync_plugin.py   # copy main.js into synthadoc/data/obsidian-plugin/
 ```
 
-On merge to `main`, CI repeats the build, sync, and commit automatically.
-
 ---
 
 ### Set your API keys

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ cd ..
 python scripts/sync_plugin.py   # copy main.js into synthadoc/data/obsidian-plugin/
 ```
 
-Then commit both the TypeScript source changes and `synthadoc/data/obsidian-plugin/`. On merge to `main`, CI repeats the build, sync, and commit automatically.
+On merge to `main`, CI repeats the build, sync, and commit automatically.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -273,15 +273,19 @@ pytest tests/performance/ -v --benchmark-disable
 
 The compiled plugin is bundled with the package and kept up to date by CI — no build step is needed to work on the Python side or run tests.
 
-To modify the TypeScript source:
+If you modify the TypeScript source under `obsidian-plugin/src/`, recompile and sync it into the Python package manually:
 
 ```bash
 cd obsidian-plugin
-npm install
-npm test              # Vitest unit tests
-# edit src/main.ts…
-# push your TypeScript changes — CI builds main.js and syncs it automatically on merge to main
+npm install           # first time only, or after package.json changes
+# edit src/main.ts or other source files
+npm run build         # compile TypeScript → main.js
+npm test              # run Vitest unit tests
+cd ..
+python scripts/sync_plugin.py   # copy main.js into synthadoc/data/obsidian-plugin/
 ```
+
+Then commit both the TypeScript source changes and `synthadoc/data/obsidian-plugin/`. On merge to `main`, CI repeats the build, sync, and commit automatically.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ pip install -e ".[dev]"
 pytest --ignore=tests/performance/ -q
 ```
 
-Expected: all tests pass, 0 failures. Performance benchmarks (optional — Linux/macOS):
+Expected: all tests pass, 0 failures. Performance benchmarks (optional):
 
 ```bash
 pytest tests/performance/ -v --benchmark-disable

--- a/docs/design.md
+++ b/docs/design.md
@@ -2637,7 +2637,7 @@ synthadoc-backup-<wiki>-<YYYYMMDD-HHMMSS>.zip
 ├── AGENTS.md              ← LLM agent instructions (if present)
 ├── ROUTING.md             ← query routing index (if present)
 ├── log.md                 ← human-readable activity log (if present)
-├── sources.txt            ← batch ingest manifest (if present)
+├── *.txt                  ← all batch ingest files at wiki root (if present)
 ├── wiki/
 │   ├── *.md
 │   └── candidates/*.md
@@ -2665,9 +2665,10 @@ Every backup contains a `manifest.json` at the zip root:
   "source_os": "windows",
   "source_hostname": "dev-machine",
   "page_count": 87,
-  "includes_sources": false,
+  "includes_sources": true,
   "includes_exports": true,
   "includes_cache": true,
+  "obsidian_plugin": true,
   "checksum_sha256": "abc123..."
 }
 ```
@@ -2679,7 +2680,8 @@ Every backup contains a `manifest.json` at the zip root:
 | Situation | Behaviour |
 |---|---|
 | Name not in registry | Register normally |
-| Name in registry | Hard stop — use `--name` or uninstall first |
+| Name in registry, path exists | Hard stop — use `--name` to rename or `synthadoc uninstall` first |
+| Name in registry, path gone (stale) | Proceed with a printed note; stale entry is overwritten |
 | Demo wiki renamed via `--name` | Warn + `y/N` prompt (breaks `demo sync`) |
 | Port taken | System suggests the next available port; user confirms or overrides |
 
@@ -2691,7 +2693,7 @@ synthadoc backup -w <wiki> [--output <dir>] [--no-sources] [--no-exports] [--no-
 synthadoc restore <backup.zip> [--name <new-name>] [--target <dir>] [--port <port>]
 ```
 
-`backup` creates a timestamped `ZIP_DEFLATED` archive in the output directory (default: current directory). `restore` extracts the archive, rewrites host-specific config values (port, domain name), updates the global registry, and re-applies any scheduled jobs. Both commands print a summary on completion; `restore` also prints a post-restore checklist.
+`backup` creates a timestamped `ZIP_DEFLATED` archive in `--output` (default: current directory). `restore` extracts the archive to `--target/<wiki-name>/` (default: same directory as the zip), rewrites host-specific config values (port, domain name), updates the global registry, re-applies scheduled jobs, and auto-reinstalls the Obsidian plugin if `obsidian_plugin` is `true` in the manifest. Both commands print a summary on completion.
 
 ---
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -860,6 +860,8 @@ synthadoc
 │   ├── citations [-w wiki] [--page <slug>] [--source <file>] [--broken] [--json]
 │   └── lifecycle
 │       └── purge -w wiki (--before <date> | --keep-latest <n>)
+├── backup [-w wiki] [--output <dir>] [--no-sources] [--no-exports] [--no-cache]
+├── restore <backup.zip> [--name <wiki>] [--target <dir>] [--port <N>]
 ├── cache clear [-w wiki]
 └── schedule
     ├── add --op "<cmd>" --cron "<expr>" [-w wiki]

--- a/docs/design.md
+++ b/docs/design.md
@@ -1585,8 +1585,9 @@ slack_export/
   SKILL.md
   scripts/
     main.py
-  references/
-    format-notes.md   ← optional; load with self.get_resource("format-notes.md")
+  assets/              ← primary resource dir; load with self.get_resource("format-notes.md")
+    format-notes.md
+  references/          ← secondary resource dir (also searched by get_resource)
 ```
 
 **`SKILL.md`:**
@@ -1633,24 +1634,28 @@ class SlackExportSkill(BaseSkill):
 
 **Error handling:** Raise `ValueError` with a clear message if the source cannot be processed. Raise `ImportError` if an optional dependency is missing (the agent will surface a helpful message to the user).
 
+**Skill discovery priority:** `extra_dirs` (passed at runtime) → `<wiki-root>/skills/` → `~/.synthadoc/skills/` → pip entry points (`synthadoc.skills` group) → built-ins. To distribute a skill as a pip package, declare an entry point pointing to the skill folder in your `pyproject.toml`.
+
 ### Writing a provider
 
 Built-in providers: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `deepseek`, `qwen`, `ollama`. For any provider that exposes an OpenAI-compatible API, no custom class is needed — the built-in `openai` provider with a custom `base_url` is sufficient.
 
-For a fully proprietary API, subclass `LLMProvider`:
+For a fully proprietary API, subclass `LLMProvider` and wire it into `synthadoc/providers/__init__.py`:
 
 ```python
 # SPDX-License-Identifier: MIT
 from synthadoc.providers.base import LLMProvider, Message, CompletionResponse
+from typing import Optional
 
 class MyProvider(LLMProvider):
+    supports_vision: bool = False   # set True only if the API accepts image inputs
 
     async def complete(
         self,
         messages: list[Message],
-        model: str,
+        system: Optional[str] = None,
         temperature: float = 0.0,
-        **kwargs,
+        max_tokens: int = 4096,
     ) -> CompletionResponse:
         # Call your API …
         return CompletionResponse(
@@ -1658,18 +1663,35 @@ class MyProvider(LLMProvider):
             input_tokens=N,
             output_tokens=M,
         )
+
+    async def complete_stream(self, messages, system=None, temperature=0.0, max_tokens=4096):
+        """Optional — override for streaming support."""
+        async for token in your_api_stream(...):
+            yield token
 ```
 
-Place in `~/.synthadoc/providers/` or the wiki `providers/` directory. Reference by name in config:
-
-```toml
-[agents]
-default = { provider = "my_provider", model = "my-model-id" }
-```
+Add the provider name to `KNOWN_PROVIDERS` in `synthadoc/config.py` and add an `if name == "my_provider":` branch in `synthadoc/providers/__init__.py` that imports and returns an instance of your class.
 
 ### Writing a hook
 
-Hooks can be in any language. They receive JSON on stdin and must exit 0 on success.
+Hooks fire after key operations. They can be in any language; the process receives JSON on stdin and must exit 0 on success.
+
+**Available events:**
+
+| Event | Fired after | JSON context fields |
+|---|---|---|
+| `on_ingest_complete` | Every completed ingest job | `event`, `wiki`, `source`, `pages_created`, `pages_updated`, `pages_flagged`, `tokens_used`, `cost_usd` |
+| `on_lint_complete` | Every completed lint run | `event`, `wiki`, `contradictions_found`, `orphans` |
+
+**Register hooks in `.synthadoc/config.toml`:**
+
+```toml
+[hooks]
+on_ingest_complete = "hooks/notify.sh"                       # non-blocking (default)
+on_lint_complete   = { cmd = "hooks/alert.sh", blocking = true }  # blocking: error aborts the run
+```
+
+**Example hook script:**
 
 ```bash
 #!/usr/bin/env bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -1277,11 +1277,11 @@ the full list of available scripts.
 
 ## 12. Cache System
 
-Three independent cache layers:
+Four independent cache layers:
 
-### Layer 1 — Embedding cache (`embeddings.db`)
+### Layer 1 — Vector embedding cache (`embeddings.db`) — optional
 
-Stores the BM25 index entry for each wiki page, keyed by page content SHA-256. When a page is updated, only that page's entry is refreshed.
+Stores fastembed vector embeddings for each wiki page, used to re-rank BM25 results by semantic similarity. Only active when `[search] vector = true` in `config.toml` and the `fastembed` optional dependency is installed (`pip install synthadoc[vectors]`). BM25 search is always computed in-memory and is never persisted to disk.
 
 ### Layer 2 — LLM response cache (`cache.db`)
 
@@ -1316,7 +1316,28 @@ The default (`"4"`) is defined in `synthadoc/core/cache.py`. Custom skill author
 | `ingest --force` | `bust_cache=True` → skips `cache.get()`, repopulates |
 | `cache clear` | Deletes all rows from `cache.db` |
 
-### Layer 3 — Provider prompt cache
+### Layer 3 — Query result cache (`cache.db` — `query_cache` table)
+
+Stores full query answers keyed by `question + wiki_epoch + model`. The `wiki_epoch` is a monotonic counter incremented on every ingest or lifecycle state change, so any wiki update automatically invalidates all cached answers.
+
+**Cache key:**
+
+```python
+def make_query_cache_key(question: str, epoch: int, model: str = "") -> str:
+    normalized = " ".join(question.lower().split())   # collapse whitespace, lowercase
+    payload = f"{normalized}|{epoch}|{model}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:32]
+```
+
+**Invalidation triggers:**
+
+| Trigger | Behavior |
+|---------|----------|
+| Any `ingest` or lifecycle change | `wiki_epoch` incremented → all query cache entries for prior epoch bypassed |
+| `--no-cache` flag on query | Cache lookup skipped; fresh LLM call; result repopulated |
+| `cache clear` | Deletes all rows from both `response_cache` and `query_cache` tables |
+
+### Layer 4 — Provider prompt cache
 
 Anthropic, OpenAI, and compatible providers cache stable prompt segments server-side. Long system prompts and `AGENTS.md` content hit this cache on repeated calls, giving 50–90% token savings.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -993,6 +993,7 @@ Every user-facing error carries a stable code in the format `[ERR-<CATEGORY>-<NN
 | `ERR-WIKI-004` | Install target already exists on disk |
 | `ERR-WIKI-005` | Unknown demo template name |
 | `ERR-WIKI-006` | Name not in `~/.synthadoc/wikis.json` |
+| `ERR-WIKI-007` | Backup requires a newer `db_schema_version` than installed |
 | `ERR-CFG-001` | Required API key environment variable not set |
 | `ERR-CFG-002` | Provider name not recognised |
 | `ERR-SKILL-001` | No skill matched the source string |
@@ -1002,7 +1003,11 @@ Every user-facing error carries a stable code in the format `[ERR-<CATEGORY>-<NN
 | `ERR-INGEST-001` | Source file or directory not found |
 | `ERR-INGEST-002` | Source file exists but is empty |
 | `ERR-INGEST-003` | `--batch` target is not a directory |
+| `ERR-QUERY-001` | LLM synthesis timed out; retry the query |
 | `ERR-JOB-001` | Job ID does not exist in `jobs.db` |
+| `ERR-PROV-001` | Daily API quota exhausted for today |
+| `ERR-PROV-002` | Coding tool CLI usage quota exhausted |
+| `ERR-AGENT-001` | LLM agent call failed (empty response, bad JSON, timeout) |
 
 **CLI errors** go through the `cli_error(code, message, hint)` helper, which prints `[ERR-XXX-NNN] message` to stderr with an optional hint line and exits with code 1. **Agent and skill errors** embed the code directly in the exception message string so it surfaces in the job `error` field.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1347,9 +1347,9 @@ Anthropic, OpenAI, and compatible providers cache stable prompt segments server-
 
 ## 13. Cost Guard
 
-**File:** `synthadoc/core/cost_guard.py`
+**Files:** `synthadoc/core/cost_guard.py`, `synthadoc/providers/pricing.py`
 
-Enforces per-operation budget limits. Evaluated before every LLM call.
+Cost tracking is live: `estimate_cost()` is called after each ingest and query operation and the result is written to `audit.db`. The `CostGuard` threshold enforcement (soft warn / hard gate) is implemented and configurable but not yet wired into the LLM call path — it is infrastructure ready to activate.
 
 ### Thresholds
 
@@ -1381,6 +1381,7 @@ Separate input and output rates reflect real-world API pricing (output tokens co
 |---|---|---|---|
 | Anthropic | claude-haiku-4-5-20251001 | $0.000001 | $0.000005 |
 | Anthropic | claude-sonnet-4-6 | $0.000003 | $0.000015 |
+| Anthropic | claude-opus-4-7 | $0.000005 | $0.000025 |
 | OpenAI | gpt-4o-mini | $0.00000015 | $0.0000006 |
 | Gemini | gemini-2.5-flash | $0.0000003 | $0.0000025 |
 | Groq | llama-3.3-70b-versatile | $0.00000059 | $0.00000079 |

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -2986,7 +2986,7 @@ Creates a timestamped compressed zip in the current directory:
 synthadoc-backup-history-of-computing-20260624-103000.zip
 ```
 
-**What's included by default:** wiki pages, candidates, config, audit database, exports, query cache, raw sources, and root-level wiki files (`AGENTS.md`, `ROUTING.md`, `log.md`, `sources.txt`) when present.
+**What's included by default:** wiki pages, candidates, config, audit database, exports, query cache, raw sources, and root-level wiki files (`AGENTS.md`, `ROUTING.md`, `log.md`, and any `*.txt` batch ingest files) when present.
 
 **Flags:**
 ```

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -161,7 +161,7 @@ Both Synthadoc and Dataview are already installed **and enabled** by Step 2 — 
 Go to **Settings → Community Plugins** to confirm both show a blue enabled toggle. While there:
 
 1. Click the gear icon next to **Synthadoc**
-2. Confirm **Server URL** is `http://127.0.0.1:7070` (set automatically — only change this if your server runs on a different port)
+2. Confirm **Server URL** is `http://127.0.0.1:7070` (set automatically from `config.toml` — if the port ever changes, re-run `synthadoc plugin install` to update it)
 3. Close settings
 
 The **Synthadoc ribbon icon** (book icon on the far-left sidebar) confirms the plugin is

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -6,8 +6,8 @@ This guide walks you through the **History of Computing** demo wiki — a fully 
 Synthadoc environment with 13 pre-built pages and six raw source files that cover every
 major engine feature. No setup beyond following the steps below is required.
 
-> **Before you start:** complete [README Installation Steps 1–6](../README.md#installation)
-> (clone, install, set your API key, install the demo wiki, and start the engine).
+> **Before you start:** complete the [README Installation](../README.md#installation) section —
+> install synthadoc (production or development), set your API key, install the demo wiki, and start the engine.
 > Then come back here.
 >
 > **Already installed the demo wiki?** Skip `synthadoc install` and run `synthadoc demo sync history-of-computing` instead. This copies any new source files added to the latest demo template into your existing wiki without overwriting anything you have already ingested or modified.

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -3014,8 +3014,7 @@ Restores to the same directory as the zip file by default. Detects port conflict
 **Post-restore checklist (printed automatically):**
 1. Set your LLM API key in your environment
 2. `synthadoc serve -w <wiki-name>`
-3. Open the vault in Obsidian — the Obsidian plugin is reinstalled and pre-enabled automatically; no manual toggling needed
-4. Update **Server URL** in the Synthadoc plugin settings if the port changed
+3. Open the vault in Obsidian — the Obsidian plugin is reinstalled and pre-enabled automatically; Server URL is updated to match the restored port, no manual steps needed
 
 ### What is NOT backed up
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,59 @@
+{
+  "version": 1,
+  "skills": {
+    "docx": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/docx/SKILL.md",
+      "computedHash": "3536d8df3c0e7f9874e21a67325fd866f75e342cd181c34f3e11092ace39dd03"
+    },
+    "image": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/image/SKILL.md",
+      "computedHash": "440f5c625b83d51633b11765ea3a943fbc5bb293d0373df967cf60e51a68b252"
+    },
+    "markdown": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/markdown/SKILL.md",
+      "computedHash": "21d976863c7ae45dd907f13a6e4f16866ee06bd477699fe2cd2618493da6c078"
+    },
+    "pdf": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/pdf/SKILL.md",
+      "computedHash": "ca51b1507cafc2350b4f595b2e854cc77999d97dee0fcf62596fb385055c5ff4"
+    },
+    "pptx": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/pptx/SKILL.md",
+      "computedHash": "a3de5d01527806ce903f95816095712880fbab75228c35001a8c93a81d35730d"
+    },
+    "url": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/url/SKILL.md",
+      "computedHash": "b84afa511d116572772b598ddcf0078e524a872e1110791c60c743fe21bca117"
+    },
+    "web_search": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/web_search/SKILL.md",
+      "computedHash": "5c1917756e92fffa1e15b9a3626eaeb6d3f62e745009a3b10c73d5fc67d721f5"
+    },
+    "xlsx": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/xlsx/SKILL.md",
+      "computedHash": "3dd724188c3750c17e925038743c39e500bf38e4491df383ad2796b1101785b6"
+    },
+    "youtube": {
+      "source": "axoviq-ai/synthadoc",
+      "sourceType": "github",
+      "skillPath": "synthadoc/skills/youtube/SKILL.md",
+      "computedHash": "6c03606ecd14f9936b08d7fa986dd3aaa15c888e647c24a00c2743094b198c44"
+    }
+  }
+}

--- a/synthadoc/core/backup_engine.py
+++ b/synthadoc/core/backup_engine.py
@@ -25,10 +25,12 @@ def _iter_wiki_files(
         for f in sorted(wiki_dir.rglob("*.md")):
             yield f, str(f.relative_to(wiki_root)).replace("\\", "/")
 
-    for name in ("AGENTS.md", "ROUTING.md", "log.md", "sources.txt"):
+    for name in ("AGENTS.md", "ROUTING.md", "log.md"):
         p = wiki_root / name
         if p.exists():
             yield p, name
+    for p in sorted(wiki_root.glob("*.txt")):
+        yield p, p.name
 
     sd = wiki_root / ".synthadoc"
     for name in ("config.toml", "audit.db"):

--- a/synthadoc/demos/history-of-computing/wiki/purpose.md
+++ b/synthadoc/demos/history-of-computing/wiki/purpose.md
@@ -1,6 +1,16 @@
 # Wiki Purpose
 
-This wiki covers: History of Computing.
+This wiki covers the History of Computing — from mechanical calculators to the modern internet, open-source movement, and emerging computing paradigms.
 
-Include: topics directly related to History of Computing — key figures, machines, programming languages, operating systems, hardware milestones, software movements, and organizations that shaped the computing industry.
-Exclude: unrelated domains (e.g. biology, economics, politics unless directly tied to computing history). When in doubt, ingest and review.
+Include:
+- Key figures and pioneers (Turing, Hopper, von Neumann, Lovelace, Ritchie, Torvalds, Zuse, and others)
+- Machines and hardware milestones (mechanical calculators, vacuum tubes, transistors, microchips, personal computers)
+- Programming languages, compilers, and operating systems
+- Software movements (open source, free software, Unix philosophy)
+- Networking and internet origins (ARPANET, TCP/IP, the World Wide Web)
+- Artificial intelligence history and foundational research
+- Quantum computing as an emerging paradigm rooted in computing history
+- Organizations, institutions, and research labs that shaped the field
+- Social and cultural impact of computing advances
+
+Exclude: unrelated domains (biology, economics, politics) unless directly tied to a computing milestone or figure. When in doubt, ingest and let the lint pass decide relevance.

--- a/synthadoc/errors.py
+++ b/synthadoc/errors.py
@@ -46,21 +46,10 @@ SKILL_URL_BLOCKED = "ERR-SKILL-003"  # URL returned 403 (bot/paywall protection)
 SKILL_WEB_NO_KEY  = "ERR-SKILL-004"  # TAVILY_API_KEY not set for web search
 
 
-class DomainBlockedException(Exception):
-    """Raised by the URL skill when a domain returns a bot-blocking response.
-
-    The orchestrator catches this, auto-adds the domain to
-    ``.synthadoc/blocked_domains.json``, records an audit event, and
-    permanently fails the job (no retry).
-    """
-    def __init__(self, domain: str, url: str, status_code: int) -> None:
-        self.domain = domain
-        self.url = url
-        self.status_code = status_code
-        super().__init__(
-            f"[{SKILL_URL_BLOCKED}] Domain auto-blocked ({status_code}): {domain} — "
-            f"site blocked automated access. Future URLs from this domain will be skipped."
-        )
+# DomainBlockedException is defined in skills/base.py so the url skill stays
+# decoupled from synthadoc core. Re-exported here so all existing callers
+# (orchestrator, tests) continue to work unchanged.
+from synthadoc.skills.base import DomainBlockedException  # noqa: F401
 
 # ── Provider ──────────────────────────────────────────────────────────────────
 PROVIDER_DAILY_QUOTA = "ERR-PROV-001"  # Daily API quota exhausted for today

--- a/synthadoc/providers/base.py
+++ b/synthadoc/providers/base.py
@@ -6,11 +6,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import AsyncGenerator, Optional, Union
 
-
-@dataclass
-class Message:
-    role: str
-    content: Union[str, list]  # list for vision: [{"type": "image", ...}, {"type": "text", ...}]
+# Message is defined in skills/base.py so skills remain standalone-importable
+# without pulling in the providers package. Re-exported here for backward compat.
+from synthadoc.skills.base import Message  # noqa: F401
 
 
 @dataclass

--- a/synthadoc/skills/base.py
+++ b/synthadoc/skills/base.py
@@ -1,12 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026 Paul Chen / axoviq.com
 # Plugin interface — third-party skills may extend these base classes under any licence.
+# This file is intentionally stdlib-only so skills/ can operate without the rest of
+# the synthadoc package (e.g. when installed standalone into Claude Code or another agent).
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
+
+
+@dataclass
+class Message:
+    """Minimal LLM message contract used by vision and summarisation skills.
+
+    Keeping this here (not in synthadoc.providers) means skills that call an
+    LLM (image, youtube) can do so without importing the full providers package.
+    synthadoc.providers.base re-exports this class so all existing code is
+    unaffected.
+    """
+    role: str
+    content: Union[str, list]  # list for vision: [{"type": "image", ...}, ...]
+
+
+class DomainBlockedException(Exception):
+    """Raised by UrlSkill when a site returns a bot-blocking HTTP status.
+
+    Defined here (not in synthadoc.errors) so the url skill stays decoupled
+    from Synthadoc core.  synthadoc.errors re-exports this class so the
+    orchestrator's isinstance() check continues to work unchanged.
+    """
+    def __init__(self, domain: str, url: str, status_code: int) -> None:
+        self.domain = domain
+        self.url = url
+        self.status_code = status_code
+        super().__init__(
+            f"[ERR-SKILL-003] Domain auto-blocked ({status_code}): {domain} — "
+            f"site blocked automated access. Future URLs from this domain will be skipped."
+        )
 
 
 @dataclass

--- a/synthadoc/skills/docx/SKILL.md
+++ b/synthadoc/skills/docx/SKILL.md
@@ -21,6 +21,27 @@ license: AGPL-3.0-or-later
 
 Extracts paragraph text from `.docx` files using `python-docx`.
 
+## Setup
+
+```bash
+pip install python-docx
+```
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.docx.scripts.main import DocxSkill
+
+skill = DocxSkill()
+
+async def main():
+    result = await skill.extract("/path/to/document.docx")
+    print(result.text)      # all paragraphs joined as plain text
+
+asyncio.run(main())
+```
+
 ## When this skill is used
 
 - Source path ends with `.docx`

--- a/synthadoc/skills/docx/requirements.txt
+++ b/synthadoc/skills/docx/requirements.txt
@@ -1,0 +1,1 @@
+python-docx

--- a/synthadoc/skills/image/SKILL.md
+++ b/synthadoc/skills/image/SKILL.md
@@ -18,16 +18,59 @@ triggers:
     - "screenshot"
     - "diagram"
     - "photo"
-requires: []
+requires: []   # no pip packages; a vision LLM provider must be passed at construction time
 author: axoviq.com
 license: AGPL-3.0-or-later
 ---
 
 # Image Skill
 
-Base64-encodes the image and returns it in `metadata` for the IngestAgent to
-process via a vision-capable LLM. The `text` field is left empty at extract
-time and filled in by the agent.
+Base64-encodes the image and passes it to a vision-capable LLM that extracts
+all text and key information. Returns the LLM's response as `result.text`.
+
+## Setup
+
+No pip dependency — the skill uses only the Python standard library plus a
+LLM provider you supply at construction time. The provider can be any object
+that implements the `complete()` interface (see below).
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.image.scripts.main import ImageSkill
+
+# ImageSkill REQUIRES a vision-capable provider — calling extract() without
+# one raises ValueError immediately.
+skill = ImageSkill(provider=my_provider)
+
+async def main():
+    result = await skill.extract("/path/to/screenshot.png")
+    print(result.text)          # extracted text from the image
+    print(result.metadata)      # {"tokens_input": N, "tokens_output": N}
+
+asyncio.run(main())
+```
+
+**Provider interface** — any object with this async method:
+
+```python
+async def complete(
+    messages: list,             # list of Message objects from synthadoc.skills.base
+    system: str | None = None,
+    temperature: float = 0.0,
+    max_tokens: int = 4096,
+) -> object                     # must have .text (str), .input_tokens (int), .output_tokens (int)
+```
+
+Build the provider with any vision-capable model. `Message` is importable
+from `synthadoc.skills.base` — no dependency on `synthadoc.providers`:
+
+```python
+from synthadoc.skills.base import Message
+```
+
+**Supported image formats:** `.png`, `.jpg`/`.jpeg`, `.webp`, `.gif`, `.tiff`
 
 ## When this skill is used
 

--- a/synthadoc/skills/image/scripts/main.py
+++ b/synthadoc/skills/image/scripts/main.py
@@ -45,7 +45,7 @@ class ImageSkill(BaseSkill):
         media_type = _MEDIA_MAP.get(suffix, "image/png")
         b64 = base64.b64encode(data).decode()
 
-        from synthadoc.providers.base import Message
+        from synthadoc.skills.base import Message
         resp = await self._provider.complete(
             messages=[Message(role="user", content=[
                 {"type": "image", "source": {

--- a/synthadoc/skills/markdown/SKILL.md
+++ b/synthadoc/skills/markdown/SKILL.md
@@ -22,6 +22,25 @@ license: AGPL-3.0-or-later
 
 Reads a Markdown or plain text file and returns its content verbatim.
 
+## Setup
+
+No external dependencies — uses only the Python standard library.
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.markdown.scripts.main import MarkdownSkill
+
+skill = MarkdownSkill()
+
+async def main():
+    result = await skill.extract("/path/to/notes.md")
+    print(result.text)      # file contents verbatim
+
+asyncio.run(main())
+```
+
 ## When this skill is used
 
 - Source path ends with `.md` or `.txt`

--- a/synthadoc/skills/pdf/SKILL.md
+++ b/synthadoc/skills/pdf/SKILL.md
@@ -25,6 +25,28 @@ Extracts text from PDF files using `pypdf` as the primary parser, with
 `pdfminer.six` as a fallback for CJK fonts that pypdf cannot decode
 (detected when pypdf yields fewer than 50 characters per page on average).
 
+## Setup
+
+```bash
+pip install pypdf pdfminer.six
+```
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.pdf.scripts.main import PdfSkill
+
+skill = PdfSkill()
+
+async def main():
+    result = await skill.extract("/path/to/paper.pdf")
+    print(result.text)          # extracted text from all pages
+    print(result.metadata)      # {"pages": N, "cjk_fallback": bool, ...}
+
+asyncio.run(main())
+```
+
 ## When this skill is used
 
 - Source path ends with `.pdf`

--- a/synthadoc/skills/pdf/requirements.txt
+++ b/synthadoc/skills/pdf/requirements.txt
@@ -1,0 +1,2 @@
+pypdf
+pdfminer.six

--- a/synthadoc/skills/pptx/SKILL.md
+++ b/synthadoc/skills/pptx/SKILL.md
@@ -20,7 +20,30 @@ license: AGPL-3.0-or-later
 
 # PPTX Skill
 
-Extracts text from `.pptx` files using `python-pptx`. Each slide is rendered as a titled section; speaker notes are appended when present.
+Extracts text from `.pptx` files using `python-pptx`. Each slide is rendered
+as a titled section; speaker notes are appended when present.
+
+## Setup
+
+```bash
+pip install python-pptx
+```
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.pptx.scripts.main import PptxSkill
+
+skill = PptxSkill()
+
+async def main():
+    result = await skill.extract("/path/to/slides.pptx")
+    print(result.text)      # slide titles + body text + speaker notes
+    print(result.metadata)  # {"slides": N}
+
+asyncio.run(main())
+```
 
 ## When this skill is used
 

--- a/synthadoc/skills/pptx/requirements.txt
+++ b/synthadoc/skills/pptx/requirements.txt
@@ -1,0 +1,1 @@
+python-pptx

--- a/synthadoc/skills/url/SKILL.md
+++ b/synthadoc/skills/url/SKILL.md
@@ -23,7 +23,45 @@ license: AGPL-3.0-or-later
 # URL Skill
 
 Fetches a web URL using `httpx`, strips navigation/script/style tags with
-`BeautifulSoup`, and returns clean body text.
+`BeautifulSoup`, and returns clean body text. PDF URLs are extracted with
+`pypdf` (primary) and `pdfminer.six` (fallback).
+
+## Setup
+
+```bash
+pip install httpx beautifulsoup4
+
+# Optional — needed only if you ingest PDF URLs:
+pip install pypdf pdfminer.six
+```
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.url.scripts.main import UrlSkill
+
+skill = UrlSkill()
+
+async def main():
+    result = await skill.extract("https://example.com/article")
+    print(result.text)          # clean body text
+    print(result.metadata)      # {"url": "https://..."}
+
+asyncio.run(main())
+```
+
+`DomainBlockedException` is raised when the site returns HTTP 401, 403, or
+429. Catch it to log and skip the domain:
+
+```python
+from synthadoc.skills.base import DomainBlockedException
+
+try:
+    result = await skill.extract(url)
+except DomainBlockedException as e:
+    print(f"Blocked: {e.domain} (HTTP {e.status_code})")
+```
 
 ## When this skill is used
 

--- a/synthadoc/skills/url/requirements.txt
+++ b/synthadoc/skills/url/requirements.txt
@@ -1,0 +1,5 @@
+httpx
+beautifulsoup4
+# Optional — only needed for PDF URL ingestion:
+pypdf
+pdfminer.six

--- a/synthadoc/skills/url/scripts/main.py
+++ b/synthadoc/skills/url/scripts/main.py
@@ -5,8 +5,7 @@ import tempfile
 import httpx
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse
-from synthadoc.skills.base import BaseSkill, ExtractedContent, SkillMeta
-from synthadoc.errors import DomainBlockedException
+from synthadoc.skills.base import BaseSkill, ExtractedContent, SkillMeta, DomainBlockedException
 
 logger = logging.getLogger(__name__)
 

--- a/synthadoc/skills/web_search/SKILL.md
+++ b/synthadoc/skills/web_search/SKILL.md
@@ -28,50 +28,99 @@ license: AGPL-3.0-or-later
 # Web Search Skill
 
 Accepts a natural language query, calls the Tavily AI search API, and
-returns the top matching URLs as child sources. The IngestAgent fans those
-URLs out as individual ingest jobs; each URL is then fetched and compiled
-into a wiki page by the url or youtube skill.
+returns the top matching URLs. Your agent receives those URLs and decides
+what to do with them — fetch each one, display them, pass them to another
+skill, etc.
 
-## Status
+## Setup
 
-**Implemented.** Requires `TAVILY_API_KEY` (free tier: 1000 searches/month —
-sign up at https://tavily.com).
-
-Set the key before running:
-```
-export TAVILY_API_KEY=<your-key>
+**1. Install the dependency:**
+```bash
+pip install tavily-python
 ```
 
-Control result volume with `SYNTHADOC_WEB_SEARCH_MAX_RESULTS` (default: 20).
+**2. Set your Tavily API key** (free tier: 1,000 searches/month — sign up at
+https://tavily.com, no credit card required):
+```bash
+# macOS / Linux
+export TAVILY_API_KEY="tvly-your-key-here"
 
-## When this skill is used
+# Windows (Command Prompt)
+set TAVILY_API_KEY=tvly-your-key-here
 
-- Source string matches an intent prefix: `search for`, `find on the web`,
-  `look up`, `web search`, `browse`
-- YouTube-specific prefixes (`youtube:`, `search youtube:`, `youtube video:`,
-  etc.) restrict the Tavily search to `youtube.com` and `youtu.be`
-- CJK intent phrases: 查找, 搜索, 网络搜索, 在网上查, 查一下
-- No file extension — purely intent-driven
-
-## End-to-end flow
-
+# Windows (PowerShell)
+$env:TAVILY_API_KEY = "tvly-your-key-here"
 ```
-synthadoc ingest "search for: transformer architecture papers"
-  → WebSearchSkill strips intent prefix → query: "transformer architecture papers"
-  → Tavily API → top N URLs
-  → filter static blocked domains (reddit, medium, paywalls, etc.)
-  → filter dynamic blocked domains (.synthadoc/blocked_domains.json)
-  → return child_sources = [url1, url2, ...]
-  → Orchestrator enqueues each URL as a separate ingest job
-  → UrlSkill / YoutubeSkill scrape each one → wiki pages created
+
+**3. Optional — cap the number of results** (default: 20):
+```bash
+export SYNTHADOC_WEB_SEARCH_MAX_RESULTS=10
 ```
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.web_search.scripts.main import WebSearchSkill
+
+skill = WebSearchSkill()
+
+async def main():
+    result = await skill.extract("search for: transformer architecture papers")
+    urls = result.metadata["child_sources"]   # list[str] — top matching URLs
+    query = result.metadata["query"]          # "transformer architecture papers"
+    print(f"Found {len(urls)} URLs for '{query}':")
+    for url in urls:
+        print(" ", url)
+
+asyncio.run(main())
+```
+
+`result.text` is always empty — the skill is a discovery step that returns
+URLs, not page content. Pass the URLs to the `url` or `youtube` skill (or
+your own HTTP client) to fetch content.
+
+## Intent prefixes
+
+The skill strips a leading intent phrase before sending the query to Tavily:
+
+| Input | Query sent to Tavily |
+|---|---|
+| `search for: RAG evaluation` | `RAG evaluation` |
+| `find on the web: LLM benchmarks` | `LLM benchmarks` |
+| `look up quantum computing` | `quantum computing` |
+| `youtube: Karpathy transformers` | `Karpathy transformers` (YouTube only) |
+| `搜索: 深度学习架构` | `深度学习架构` |
+
+YouTube-specific prefixes (`youtube:`, `search youtube:`, `youtube video:`,
+etc.) restrict the Tavily search to `youtube.com` and `youtu.be`.
+
+CJK intent phrases supported: 查找, 搜索, 网络搜索, 在网上查, 查一下
+
+## Domain filtering
+
+A built-in blocklist skips sites that block automated HTTP clients:
+`reddit.com`, `medium.com`, `quora.com`, `twitter.com`/`x.com`,
+`linkedin.com`, `wikipedia.org`, IEEE Xplore, ACM DL, and common
+subscription-only academic publishers.
+
+If `SYNTHADOC_WIKI_ROOT` is set, the skill also loads
+`$SYNTHADOC_WIKI_ROOT/.synthadoc/blocked_domains.json` (a JSON array of
+domain strings) to extend the blocklist at runtime.
 
 ## Scripts
 
 - `scripts/main.py` — `WebSearchSkill`: intent parsing, domain filtering,
-  child source fan-out
+  returns `child_sources` in metadata
 - `scripts/fetcher.py` — thin async wrapper around `AsyncTavilyClient`
 
 ## Assets
 
 - `assets/search-providers.json` — search provider registry (currently Tavily)
+
+## Using with full Synthadoc
+
+When running inside Synthadoc, the Orchestrator reads `child_sources` from
+the result metadata and automatically enqueues each URL as a separate ingest
+job, which are then processed by the `url` or `youtube` skill. No additional
+setup is required beyond the env vars above.

--- a/synthadoc/skills/web_search/SKILL.md
+++ b/synthadoc/skills/web_search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web_search
-version: "0.1"
+version: "1.0"
 description: Search the web and ingest results as wiki pages
 entry:
   script: scripts/main.py
@@ -20,34 +20,58 @@ triggers:
     - "在网上查"
     - "查一下"
 requires:
-  - httpx
-  - beautifulsoup4
+  - tavily-python
 author: axoviq.com
 license: AGPL-3.0-or-later
 ---
 
 # Web Search Skill
 
-Accepts a natural language query, calls a configured search API, fetches
-the top results, and returns extracted text to the IngestAgent for wiki
-compilation.
+Accepts a natural language query, calls the Tavily AI search API, and
+returns the top matching URLs as child sources. The IngestAgent fans those
+URLs out as individual ingest jobs; each URL is then fetched and compiled
+into a wiki page by the url or youtube skill.
 
 ## Status
 
-**v1 stub — `extract()` raises `NotImplementedError`.** Full implementation
-is scheduled for v2.
+**Implemented.** Requires `TAVILY_API_KEY` (free tier: 1000 searches/month —
+sign up at https://tavily.com).
+
+Set the key before running:
+```
+export TAVILY_API_KEY=<your-key>
+```
+
+Control result volume with `SYNTHADOC_WEB_SEARCH_MAX_RESULTS` (default: 20).
 
 ## When this skill is used
 
-- Source string contains: `search for`, `find on the web`, `look up`,
-  `web search`, `browse`
+- Source string matches an intent prefix: `search for`, `find on the web`,
+  `look up`, `web search`, `browse`
+- YouTube-specific prefixes (`youtube:`, `search youtube:`, `youtube video:`,
+  etc.) restrict the Tavily search to `youtube.com` and `youtu.be`
+- CJK intent phrases: 查找, 搜索, 网络搜索, 在网上查, 查一下
 - No file extension — purely intent-driven
+
+## End-to-end flow
+
+```
+synthadoc ingest "search for: transformer architecture papers"
+  → WebSearchSkill strips intent prefix → query: "transformer architecture papers"
+  → Tavily API → top N URLs
+  → filter static blocked domains (reddit, medium, paywalls, etc.)
+  → filter dynamic blocked domains (.synthadoc/blocked_domains.json)
+  → return child_sources = [url1, url2, ...]
+  → Orchestrator enqueues each URL as a separate ingest job
+  → UrlSkill / YoutubeSkill scrape each one → wiki pages created
+```
 
 ## Scripts
 
-- `scripts/main.py` — `WebSearchSkill` (stub)
-- `scripts/fetcher.py` — HTTP + HTML cleaning helper (v2)
+- `scripts/main.py` — `WebSearchSkill`: intent parsing, domain filtering,
+  child source fan-out
+- `scripts/fetcher.py` — thin async wrapper around `AsyncTavilyClient`
 
 ## Assets
 
-- `assets/search-providers.json` — search API endpoint configuration (v2)
+- `assets/search-providers.json` — search provider registry (currently Tavily)

--- a/synthadoc/skills/web_search/requirements.txt
+++ b/synthadoc/skills/web_search/requirements.txt
@@ -1,0 +1,1 @@
+tavily-python

--- a/synthadoc/skills/web_search/scripts/main.py
+++ b/synthadoc/skills/web_search/scripts/main.py
@@ -8,7 +8,7 @@ import re
 from pathlib import Path
 from urllib.parse import urlparse
 
-from synthadoc.skills.base import BaseSkill, ExtractedContent
+from synthadoc.skills.base import BaseSkill, ExtractedContent, SkillMeta, Triggers
 
 # Matches all generic intents declared in SKILL.md; colon and leading whitespace optional
 _INTENT_RE = re.compile(
@@ -76,6 +76,20 @@ def _load_dynamic_blocked() -> set[str]:
 
 
 class WebSearchSkill(BaseSkill):
+    meta = SkillMeta(
+        name="web_search",
+        description="Search the web and ingest results as wiki pages",
+        triggers=Triggers(
+            extensions=[],
+            intents=[
+                "search for", "find on the web", "look up",
+                "web search", "browse", "youtube",
+                "查找", "搜索", "网络搜索", "在网上查", "查一下",
+            ],
+        ),
+        requires=["tavily-python"],
+    )
+
     async def extract(self, source: str) -> ExtractedContent:
         api_key = os.environ.get("TAVILY_API_KEY", "").strip()
         if not api_key:

--- a/synthadoc/skills/xlsx/SKILL.md
+++ b/synthadoc/skills/xlsx/SKILL.md
@@ -24,6 +24,30 @@ license: AGPL-3.0-or-later
 Reads `.xlsx` files using `openpyxl` and `.csv` files using the stdlib `csv`
 module, returning all rows as comma-separated text.
 
+## Setup
+
+```bash
+pip install openpyxl
+```
+
+`.csv` files use only the Python standard library — no additional install required.
+
+## Standalone usage
+
+```python
+import asyncio
+from synthadoc.skills.xlsx.scripts.main import XlsxSkill
+
+skill = XlsxSkill()
+
+async def main():
+    result = await skill.extract("/path/to/data.xlsx")
+    print(result.text)      # all rows as comma-separated text
+    print(result.metadata)  # {"rows": N, "sheets": N}  (xlsx only)
+
+asyncio.run(main())
+```
+
 ## When this skill is used
 
 - Source path ends with `.xlsx` or `.csv`

--- a/synthadoc/skills/xlsx/requirements.txt
+++ b/synthadoc/skills/xlsx/requirements.txt
@@ -1,0 +1,2 @@
+openpyxl
+# csv is Python stdlib — no install needed

--- a/synthadoc/skills/youtube/SKILL.md
+++ b/synthadoc/skills/youtube/SKILL.md
@@ -20,7 +20,58 @@ license: AGPL-3.0-or-later
 # YouTube Skill
 
 Extracts the transcript (captions) from a YouTube video using the YouTube
-caption system — no API key or audio download required.
+caption system — no API key or audio download required. Optionally uses a
+vision-capable LLM to produce a structured summary (Overview, Topics,
+Key takeaways) before the raw transcript.
+
+## Setup
+
+```bash
+pip install youtube-transcript-api
+```
+
+## Standalone usage
+
+**Transcript only** (no LLM required):
+
+```python
+import asyncio
+from synthadoc.skills.youtube.scripts.main import YoutubeSkill
+
+skill = YoutubeSkill()          # no provider — returns raw timestamped transcript
+
+async def main():
+    result = await skill.extract("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    print(result.text)          # "[0:00] text [0:04] text ..."
+    print(result.metadata)      # {"video_id": "...", "title": "...", "url": "..."}
+
+asyncio.run(main())
+```
+
+**With LLM summarization** (pass any provider that implements `complete()`):
+
+```python
+skill = YoutubeSkill(provider=my_provider)
+result = await skill.extract(url)
+# result.text contains:
+#   ## Executive Summary
+#   <Overview / Topics / Key takeaways>
+#
+#   ## Transcript
+#   [0:00] ...
+```
+
+The provider must implement:
+```python
+async def complete(messages, system=None, temperature=0.0, max_tokens=4096)
+    -> object with .text (str), .input_tokens (int), .output_tokens (int)
+```
+
+`Message` (used to build the `messages` list) is importable from
+`synthadoc.skills.base`:
+```python
+from synthadoc.skills.base import Message
+```
 
 ## When this skill is used
 
@@ -35,8 +86,6 @@ synthadoc ingest "youtube Moore's Law"
 synthadoc ingest "youtube kids: Sesame Street"
 synthadoc ingest "search for youtube: history of computing"
 ```
-
-Each YouTube URL returned by Tavily is then ingested by this skill.
 
 ## Limitations
 

--- a/synthadoc/skills/youtube/requirements.txt
+++ b/synthadoc/skills/youtube/requirements.txt
@@ -1,0 +1,2 @@
+youtube-transcript-api
+# httpx is optional — used only for video title lookup; skill works without it

--- a/synthadoc/skills/youtube/scripts/main.py
+++ b/synthadoc/skills/youtube/scripts/main.py
@@ -97,7 +97,7 @@ class YoutubeSkill(BaseSkill):
             limit=limit,
             transcript=transcript_text[:6000],
         )
-        from synthadoc.providers.base import Message
+        from synthadoc.skills.base import Message
         resp = await self._provider.complete(
             messages=[Message(role="user", content=prompt)],
             temperature=0.3,

--- a/synthadoc/skills/youtube/scripts/main.py
+++ b/synthadoc/skills/youtube/scripts/main.py
@@ -35,8 +35,16 @@ logger = logging.getLogger(__name__)
 
 
 async def _fetch_video_title(video_id: str) -> str | None:
-    """Fetch video title from YouTube oEmbed — free, no API key required."""
-    import httpx
+    """Fetch video title from YouTube oEmbed — free, no API key required.
+
+    httpx is used here but is not a hard requirement of the skill — the
+    transcript extraction works without it.  If httpx is absent the title
+    is simply omitted from the result metadata.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return None
     url = (
         f"https://www.youtube.com/oembed"
         f"?url=https://www.youtube.com/watch?v={video_id}&format=json"

--- a/tests/cli/test_backup_cli.py
+++ b/tests/cli/test_backup_cli.py
@@ -230,6 +230,41 @@ def test_restore_stale_registry_entry_proceeds(tmp_path):
     assert (restore_dir / "my-wiki" / "wiki" / "page1.md").exists()
 
 
+def test_backup_includes_all_txt_files(tmp_path):
+    wiki_root = _make_wiki(tmp_path)
+    (wiki_root / "sources.txt").write_text("# batch 1", encoding="utf-8")
+    (wiki_root / "sources-extra.txt").write_text("# batch 2", encoding="utf-8")
+    (wiki_root / "notes.txt").write_text("# notes", encoding="utf-8")
+    out_dir = tmp_path / "backups"
+    with _patch_resolve_wiki(), _patch_registry(wiki_root):
+        runner.invoke(app, ["backup", "-w", "my-wiki", "--output", str(out_dir)])
+    zip_path = list(out_dir.glob("*.zip"))[0]
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    assert "sources.txt" in names
+    assert "sources-extra.txt" in names
+    assert "notes.txt" in names
+
+
+def test_restore_preserves_all_txt_files(tmp_path):
+    wiki_root = _make_wiki(tmp_path)
+    (wiki_root / "sources.txt").write_text("# batch 1", encoding="utf-8")
+    (wiki_root / "sources-extra.txt").write_text("# batch 2", encoding="utf-8")
+    (wiki_root / "notes.txt").write_text("# notes", encoding="utf-8")
+    zip_path = _make_backup_zip(wiki_root, tmp_path / "zips")
+    restore_dir = tmp_path / "restore"
+    with _patch_registry_for_restore(), _patch_write_registry(), \
+         _patch_reserved_ports(), _patch_schedule_apply():
+        result = runner.invoke(app, [
+            "restore", str(zip_path), "--target", str(restore_dir), "--port", "7071",
+        ])
+    assert result.exit_code == 0, result.output
+    restored = restore_dir / "my-wiki"
+    assert (restored / "sources.txt").read_text(encoding="utf-8") == "# batch 1"
+    assert (restored / "sources-extra.txt").read_text(encoding="utf-8") == "# batch 2"
+    assert (restored / "notes.txt").read_text(encoding="utf-8") == "# notes"
+
+
 def test_restore_stale_registry_reuses_original_port(tmp_path):
     wiki_root = _make_wiki(tmp_path)
     zip_path = _make_backup_zip(wiki_root, tmp_path / "zips")

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -597,6 +597,29 @@ def run_live_tests(wiki_root: pathlib.Path) -> None:
     check("audit events",    ["audit", "events"]     + w)
     check("audit citations", ["audit", "citations"]  + w)
 
+    # ── logging ───────────────────────────────────────────────────────────────
+    print("\n[24] logging")
+    import json as _json
+    log_path = wiki_root / ".synthadoc" / "logs" / "synthadoc.log"
+    if not log_path.exists():
+        fail("log file exists", f"expected {log_path}")
+    else:
+        ok("log file exists", str(log_path))
+        lines = [l for l in log_path.read_text(encoding="utf-8", errors="replace").splitlines() if l.strip()]
+        if not lines:
+            fail("log file non-empty", "synthadoc.log contains no entries")
+        else:
+            ok("log file non-empty", f"{len(lines)} entries")
+            try:
+                record = _json.loads(lines[-1])
+                missing = [k for k in ("ts", "level", "msg") if k not in record]
+                if missing:
+                    fail("log JSON schema", f"missing keys: {missing}")
+                else:
+                    ok("log JSON schema", "ts, level, msg present")
+            except _json.JSONDecodeError as e:
+                fail("log JSON schema", f"last line not valid JSON: {e}")
+
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 

--- a/tests/skills/test_skill_isolation.py
+++ b/tests/skills/test_skill_isolation.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+"""Standalone-isolation tests for synthadoc/skills/.
+
+These tests verify that every built-in skill can be imported and instantiated
+using *only* the synthadoc/skills/ subtree — no synthadoc.core, synthadoc.agents,
+synthadoc.providers, synthadoc.errors, or any other Synthadoc component.
+
+This is the prerequisite for the use case where skills are installed into an
+external agent environment (e.g. Claude Code) without the full Synthadoc package.
+"""
+import importlib
+import sys
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Non-skills synthadoc modules that must be absent to prove isolation.
+_BLOCKED_PREFIXES = (
+    "synthadoc.core",
+    "synthadoc.agents",
+    "synthadoc.providers",
+    "synthadoc.errors",
+    "synthadoc.config",
+    "synthadoc.storage",
+    "synthadoc.cli",
+    "synthadoc.integration",
+    "synthadoc.observability",
+    "synthadoc.demos",
+)
+
+
+@contextmanager
+def _skills_only():
+    """Context manager that blocks all non-skills synthadoc modules.
+
+    Any attempt to import a blocked module raises ImportError, exactly as
+    it would in an environment where only synthadoc/skills/ is present.
+    Existing cached imports are temporarily hidden for the duration.
+    """
+    blocked_keys = [k for k in sys.modules if any(k == p or k.startswith(p + ".") for p in _BLOCKED_PREFIXES)]
+    saved = {k: sys.modules.pop(k) for k in blocked_keys}
+
+    class _BlockingFinder:
+        @staticmethod
+        def find_module(name, path=None):
+            if any(name == p or name.startswith(p + ".") for p in _BLOCKED_PREFIXES):
+                return _BlockingFinder
+            return None
+
+        @staticmethod
+        def load_module(name):
+            raise ImportError(
+                f"Isolation violation: skill imported '{name}' which is outside synthadoc/skills/. "
+                f"Move the dependency into skills/base.py or make it a lazy import."
+            )
+
+    sys.meta_path.insert(0, _BlockingFinder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(_BlockingFinder)
+        sys.modules.update(saved)
+
+
+# ── base.py is self-contained ──────────────────────────────────────────────────
+
+def test_skills_base_imports_without_synthadoc_core():
+    # Verify skills/base.py is already importable and exposes the full contract.
+    # We do NOT force a fresh import here — doing so would create a new class
+    # object for DomainBlockedException that diverges from the one cached in
+    # synthadoc.errors, breaking isinstance() checks in subsequent tests.
+    with _skills_only():
+        mod = importlib.import_module("synthadoc.skills.base")
+        assert hasattr(mod, "BaseSkill")
+        assert hasattr(mod, "ExtractedContent")
+        assert hasattr(mod, "Message")
+        assert hasattr(mod, "DomainBlockedException")
+        assert hasattr(mod, "SkillMeta")
+
+
+# ── One test per skill: import + instantiate ───────────────────────────────────
+
+def test_markdown_skill_isolated():
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.markdown.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.markdown.scripts.main")
+        skill = mod.MarkdownSkill()
+        assert skill is not None
+
+
+def test_pdf_skill_isolated():
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.pdf.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.pdf.scripts.main")
+        skill = mod.PdfSkill()
+        assert skill is not None
+
+
+def test_docx_skill_isolated():
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.docx.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.docx.scripts.main")
+        skill = mod.DocxSkill()
+        assert skill is not None
+
+
+def test_pptx_skill_isolated():
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.pptx.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.pptx.scripts.main")
+        skill = mod.PptxSkill()
+        assert skill is not None
+
+
+def test_xlsx_skill_isolated():
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.xlsx.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.xlsx.scripts.main")
+        skill = mod.XlsxSkill()
+        assert skill is not None
+
+
+def test_url_skill_isolated():
+    """url skill must not import synthadoc.errors.DomainBlockedException."""
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.url.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.url.scripts.main")
+        skill = mod.UrlSkill()
+        assert skill is not None
+        # DomainBlockedException must come from skills/base, not synthadoc.errors
+        from synthadoc.skills.base import DomainBlockedException
+        assert mod.DomainBlockedException is DomainBlockedException
+
+
+def test_web_search_skill_isolated():
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.web_search.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.web_search.scripts.main")
+        skill = mod.WebSearchSkill()
+        assert skill is not None
+
+
+def test_image_skill_isolated():
+    """image skill must not import synthadoc.providers.base.Message at module level."""
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.image.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.image.scripts.main")
+        skill = mod.ImageSkill()
+        assert skill is not None
+
+
+def test_youtube_skill_isolated():
+    """youtube skill must not import synthadoc.providers.base.Message at module level."""
+    with _skills_only():
+        sys.modules.pop("synthadoc.skills.youtube.scripts.main", None)
+        mod = importlib.import_module("synthadoc.skills.youtube.scripts.main")
+        skill = mod.YoutubeSkill()
+        assert skill is not None
+
+
+# ── Message from skills/base is compatible with provider.complete() ────────────
+
+def test_message_from_skills_base_works_with_mock_provider():
+    """Skills calling provider.complete(messages=[Message(...)]) must work when
+    Message comes from skills/base — not providers/base."""
+    from synthadoc.skills.base import Message, ExtractedContent
+    import asyncio
+
+    mock_provider = MagicMock()
+    mock_provider.supports_vision = True
+    mock_response = MagicMock()
+    mock_response.text = "extracted text"
+    mock_response.input_tokens = 100
+    mock_response.output_tokens = 50
+    mock_provider.complete = AsyncMock(return_value=mock_response)
+
+    msg = Message(role="user", content="hello")
+    assert msg.role == "user"
+    assert msg.content == "hello"
+
+    # Provider receives the message — duck typing means class origin doesn't matter
+    async def _run():
+        return await mock_provider.complete(messages=[msg])
+
+    result = asyncio.run(_run())
+    assert result.text == "extracted text"
+
+
+# ── DomainBlockedException identity: same class from both import paths ──────────
+
+def test_domain_blocked_exception_same_class_via_errors_and_skills():
+    """The orchestrator imports DomainBlockedException from synthadoc.errors.
+    Skills import from synthadoc.skills.base. They must be the same class
+    so isinstance() checks in the orchestrator still catch skill exceptions."""
+    from synthadoc.errors import DomainBlockedException as ErrDBE
+    from synthadoc.skills.base import DomainBlockedException as SkillDBE
+    assert ErrDBE is SkillDBE, (
+        "DomainBlockedException from errors and skills/base must be the same "
+        "class object — otherwise the orchestrator's isinstance() check fails."
+    )
+
+
+def test_domain_blocked_exception_attributes():
+    from synthadoc.skills.base import DomainBlockedException
+    exc = DomainBlockedException(domain="example.com", url="https://example.com/page", status_code=403)
+    assert exc.domain == "example.com"
+    assert exc.url == "https://example.com/page"
+    assert exc.status_code == 403
+    assert "ERR-SKILL-003" in str(exc)
+    assert "example.com" in str(exc)

--- a/tests/skills/test_web_search.py
+++ b/tests/skills/test_web_search.py
@@ -406,6 +406,28 @@ def test_load_dynamic_blocked_returns_empty_on_invalid_json(tmp_path, monkeypatc
 
 # ── CJK (Chinese / Japanese / Korean) coverage ───────────────────────────────
 
+# ── WebSearchSkill.meta ───────────────────────────────────────────────────────
+
+def test_web_search_skill_has_meta_attribute():
+    """WebSearchSkill must expose a meta class attribute (used by standalone callers)."""
+    from synthadoc.skills.web_search.scripts.main import WebSearchSkill
+    from synthadoc.skills.base import SkillMeta
+    assert hasattr(WebSearchSkill, "meta"), "WebSearchSkill is missing the meta class attribute"
+    assert isinstance(WebSearchSkill.meta, SkillMeta)
+    assert WebSearchSkill.meta.name == "web_search"
+
+
+def test_web_search_meta_intents_cover_skill_md_triggers():
+    """meta.triggers.intents must include all intent strings declared in SKILL.md."""
+    from synthadoc.skills.web_search.scripts.main import WebSearchSkill
+    intents = WebSearchSkill.meta.triggers.intents
+    required = ["search for", "find on the web", "look up", "web search", "browse", "youtube"]
+    for intent in required:
+        assert intent in intents, f"meta.triggers.intents is missing: {intent!r}"
+
+
+# ── CJK (Chinese / Japanese / Korean) coverage ───────────────────────────────
+
 def test_web_search_pure_cjk_intent_not_matched():
     """A pure CJK intent prefix ('搜索：量子计算') is NOT matched as a web search intent.
 

--- a/tests/skills/test_youtube_skill.py
+++ b/tests/skills/test_youtube_skill.py
@@ -277,6 +277,57 @@ async def test_summary_uses_limit_1000_for_latin():
 
 
 @pytest.mark.asyncio
+async def test_fetch_video_title_returns_none_when_httpx_missing():
+    """_fetch_video_title must return None (not raise) when httpx is not installed.
+
+    This guards the fix for the hidden dependency: the import statement was
+    previously outside try/except, meaning a missing httpx would propagate as
+    ImportError through extract() and break transcript ingestion entirely.
+    """
+    import sys
+    from synthadoc.skills.youtube.scripts.main import _fetch_video_title
+
+    saved = sys.modules.pop("httpx", None)
+    # Block httpx re-import for the duration of this test
+    sys.modules["httpx"] = None  # type: ignore[assignment]
+    try:
+        result = await _fetch_video_title("dQw4w9WgXcQ")
+    finally:
+        if saved is not None:
+            sys.modules["httpx"] = saved
+        else:
+            sys.modules.pop("httpx", None)
+
+    assert result is None, "Expected None when httpx is unavailable, got: %r" % result
+
+
+@pytest.mark.asyncio
+async def test_extract_succeeds_when_httpx_missing():
+    """extract() must succeed (returning transcript) even when httpx is absent.
+
+    Title fetch is best-effort; a missing httpx must not crash the skill.
+    """
+    import sys
+    from synthadoc.skills.youtube.scripts.main import YoutubeSkill
+
+    skill = YoutubeSkill()
+    saved = sys.modules.pop("httpx", None)
+    sys.modules["httpx"] = None  # type: ignore[assignment]
+    try:
+        with patch("synthadoc.skills.youtube.scripts.main.asyncio.to_thread",
+                   new=AsyncMock(return_value=_fake_transcript())):
+            result = await skill.extract("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    finally:
+        if saved is not None:
+            sys.modules["httpx"] = saved
+        else:
+            sys.modules.pop("httpx", None)
+
+    assert result.text != "", "Expected transcript text even without httpx"
+    assert "title" not in result.metadata  # title lookup silently skipped
+
+
+@pytest.mark.asyncio
 async def test_summary_uses_limit_2000_for_cjk():
     """CJK transcript → prompt must contain '2000 words'."""
     from types import SimpleNamespace

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,6 +1,24 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 Paul Chen / axoviq.com
-from synthadoc.observability.telemetry import setup_telemetry, get_tracer, record_cost
+import json
+from unittest.mock import MagicMock, patch
+
+from synthadoc.observability.telemetry import (
+    _JsonlExporter,
+    setup_telemetry,
+    get_tracer,
+    record_cost,
+)
+
+
+def _make_span(name: str, trace_id: int = 0xABCD1234, attrs: dict | None = None):
+    span = MagicMock()
+    span.name = name
+    span.context.trace_id = trace_id
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    span.attributes = attrs or {}
+    return span
 
 
 def test_tracer_created(tmp_path):
@@ -13,8 +31,58 @@ def test_record_cost_does_not_raise():
 
 
 def test_traces_written_to_file(tmp_path):
-    setup_telemetry(trace_path=tmp_path / "traces.jsonl")
-    tracer = get_tracer()
-    with tracer.start_as_current_span("test.span"):
-        pass
-    assert get_tracer() is not None
+    trace_file = tmp_path / "traces.jsonl"
+    exporter = _JsonlExporter(trace_file)
+
+    exporter.export([_make_span("test.span")])
+
+    assert trace_file.exists(), "traces.jsonl should be created after export()"
+    lines = [l for l in trace_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert lines, "traces.jsonl should contain at least one entry"
+    record = json.loads(lines[0])
+    assert record["name"] == "test.span"
+    assert "trace_id" in record
+    assert "start_time" in record
+    assert "end_time" in record
+
+
+def test_traces_skips_span_with_no_context(tmp_path):
+    trace_file = tmp_path / "traces.jsonl"
+    exporter = _JsonlExporter(trace_file)
+
+    span = MagicMock()
+    span.context = None
+    exporter.export([span])
+
+    # File may not exist at all, or be empty — either is correct
+    if trace_file.exists():
+        lines = [l for l in trace_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert not lines, "span with no context should not be written"
+
+
+def test_traces_appends_multiple_spans(tmp_path):
+    trace_file = tmp_path / "traces.jsonl"
+    exporter = _JsonlExporter(trace_file)
+
+    exporter.export([_make_span("span.one")])
+    exporter.export([_make_span("span.two")])
+
+    lines = [l for l in trace_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert len(lines) == 2
+    assert json.loads(lines[0])["name"] == "span.one"
+    assert json.loads(lines[1])["name"] == "span.two"
+
+
+def test_record_cost_span_name_and_attributes():
+    mock_span = MagicMock()
+    mock_tracer = MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__ = lambda s: mock_span
+    mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("synthadoc.observability.telemetry.get_tracer", return_value=mock_tracer):
+        record_cost(tokens=500, cost_usd=0.05, operation="query")
+
+    mock_tracer.start_as_current_span.assert_called_once_with("cost.query")
+    mock_span.set_attribute.assert_any_call("tokens", 500)
+    mock_span.set_attribute.assert_any_call("cost_usd", 0.05)
+    mock_span.set_attribute.assert_any_call("operation", "query")


### PR DESCRIPTION
What

  Makes all 9 built-in skills installable and usable standalone, without the full Synthadoc package, and ships comprehensive setup documentation for each. Verify SKILLS can be loaded and used in Claude code.

Why

  Skills are distributed via npx -y skills add axoviq-ai/synthadoc to Claude Code and other agents. Users who install only synthadoc/skills/ had no setup instructions and hit import errors from leaky internal dependencies.

Changes

 i. Skills: standalone isolation
  - Moved Message dataclass and DomainBlockedException into skills/base.py; re-exported from providers/base.py and errors.py for backward compat
  - All 9 skills now import only from synthadoc.skills.*:  no dependency on core, agents, or providers
  - Added requirements.txt per skill (docx, pdf, pptx, xlsx, youtube, url, web_search) for standard pip/CI tooling
  -  Verified all SKILLs work with the following npx that can be loaded and run in Claude code:
      
      npx -y skills add axoviq-ai/synthadoc --skill docx --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill image --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill markdown --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill pdf --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill pptx --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill url --agent claude-code 
      npx -y skills add axoviq-ai/synthadoc --skill xlsx --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill youtube --agent claude-code
      npx -y skills add axoviq-ai/synthadoc --skill web_search --agent claude-code  

 ii. Skills: bug fixes
  - youtube: wrapped import httpx in try/except ImportError: httpx is optional for title lookup; missing it no longer crashes transcript extraction
  - web_search: added meta = SkillMeta(...) class attribute:  was missing, broke standalone callers
  - web_search: promoted from stub to fully implemented; SKILL.md updated with complete API key setup, intent prefix table, domain filtering docs, and standalone usage example

 iii. Skills: docs
  - Added ## Setup and ## Standalone usage sections to all 9 SKILL.md files
  - Added .agents/ to .gitignore; committed skills-lock.json

  iv. Tests
  - 13 new isolation tests (test_skill_isolation.py): one import+instantiate test per skill, plus class identity checks for DomainBlockedException and Message
  - 2 new youtube tests: httpx-missing path (title fetch returns None, extract still succeeds)
  - 2 new web_search tests: meta attribute presence and intent coverage

  v. Docs
  - design.md: 5 missing error codes, backup/restore CLI tree, corrections to cost guard, cache system, plugin guide, backup file list
  - user-quick-start-guide.md: prereq, plugin dev steps, server URL setup

  vi. Other
  - fix(backup): include all *.txt files at wiki root, not just sources.txt