### PR TITLE
fix(backup): include hooks/ and .synthadoc/extracted/ in backups

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -2641,15 +2641,19 @@ synthadoc-backup-<wiki>-<YYYYMMDD-HHMMSS>.zip
 ├── wiki/
 │   ├── *.md
 │   └── candidates/*.md
+├── hooks/                 ← user hook scripts (always included)
 ├── .synthadoc/
 │   ├── config.toml
 │   ├── audit.db
+│   ├── extracted/         ← text sidecars + PDF pagemaps (always included)
 │   └── cache.db           ← included by default; skip with --no-cache
 ├── exports/               ← included by default; skip with --no-exports
 └── raw_sources/           ← included by default; skip with --no-sources
 ```
 
-Always excluded: `jobs.db`, `embeddings.db`, `server.pid`, `skill_registry.json`, `logs/`.
+Always excluded: `jobs.db`, `embeddings.db`, `server.pid`, `logs/`.
+
+> **v0.9.3 fix:** `hooks/` and `.synthadoc/extracted/` were previously missing from backups. Omitting `extracted/` caused the Source Viewer and Provenance citation modal to show "Could not read source file" after restore.
 
 ### Manifest
 
@@ -2816,6 +2820,25 @@ synthadoc restore <backup.zip> [--name <new-name>] [--target <dir>] [--port <por
 - **Job status and list actions** — the Action Agent now handles `job_status` and `job_list` intent queries. `job_status` with a job ID returns a detailed job card; without an ID it returns a table of all jobs and emits a `clarify` event so the user can pick one via chip. `job_list` accepts an optional multi-status filter (e.g. "show failed and skipped jobs") and includes an Error column when any listed job has a non-null error. Built-in `hints.json` extended with job-status and job-list hints for POWER_USER mode.
 - **Multi-chip clarify continuation** — clarify chip replies (bare UUIDs) are now reliably routed back to the Action Agent across multiple chip clicks. The server tags every clarify message with a `[clarify] ` prefix in the audit log; `detect()` scans back `clarify_lookback` assistant turns to find an open clarify context.
 - **Qwen provider routing** — `qwen-<letter>` model names (e.g. `qwen-plus`, `qwen-max`) route to DashScope cloud API regardless of other config; all other Qwen models (e.g. `qwen3:8b`, `qwen3.5`) route to local Ollama. This decouples cloud/local routing from `QWEN_API_KEY` presence.
+
+### v0.9.3
+
+- **Backup now includes `hooks/` and `.synthadoc/extracted/`** — both directories were silently omitted from backups. `hooks/` contains user-customised hook scripts; `.synthadoc/extracted/` contains per-source text sidecars and PDF pagemaps written by the ingest agent. Without these, the Source Viewer and Provenance citation modal showed "Could not read source file" after restore.
+- **PyPI publish workflow** — `publish.yml` triggers on GitHub Release, builds the wheel with hatchling, and uploads to PyPI via OIDC trusted publishing (no API token stored). `pip install synthadoc` now works.
+- **Web UI bundled in pip package** — `synthadoc/data/web-ui/dist/` is now included in the wheel. `synthadoc web` previously returned 503 on pip-installed instances because the React dist was not packaged.
+- **CI sync checks** — PRs now fail if `synthadoc/data/obsidian-plugin/`, `synthadoc/data/web-ui/`, or `README-pypi.md` are out of sync with their source. All sync-check steps use `shell: bash` for Windows runner compatibility.
+- **`bump_version.py` extended** — now also updates `synthadoc/data/obsidian-plugin/manifest.json` alongside the source manifest, preventing version drift between the bundled copy and the plugin source.
+
+### v0.9.2
+
+- **`synthadoc/data/web-ui/dist/` packaged** — web UI dist files committed to the repo and bundled in the wheel via hatchling artifacts.
+- **`scripts/sync_web_ui.py`** — helper script to sync `web-ui/dist/` into `synthadoc/data/web-ui/dist/` after `npm run build`.
+
+### v0.9.1
+
+- **PyPI metadata** — added `readme`, `keywords`, `classifiers`, and `[project.urls]` to `pyproject.toml` for correct PyPI rendering.
+- **`README-pypi.md`** — generated from `README.md` by `scripts/prepare_pypi_readme.py`; strips `pypi-strip` blocks and rewrites relative links to absolute GitHub URLs.
+- **Branch protection compatibility** — removed post-merge `build-plugin` CI job that pushed compiled plugin directly to `main`. Plugin sync is now enforced in PRs: CI fails if `synthadoc/data/obsidian-plugin/` is out of sync.
 
 ### v0.9.0 (Community Edition)
 

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -3016,12 +3016,21 @@ Restores to the same directory as the zip file by default. Detects port conflict
 2. `synthadoc serve -w <wiki-name>`
 3. Open the vault in Obsidian — the Obsidian plugin is reinstalled and pre-enabled automatically; Server URL is updated to match the restored port, no manual steps needed
 
-### What is NOT backed up
+### What is and isn't backed up
 
-| Item | Why excluded |
-|---|---|
-| LLM API keys | Never stored in config; set via environment variable |
-| `jobs.db` | Stale job queue — meaningless on another machine |
-| `embeddings.db` | Large; rebuilt automatically on first search after restore |
-| `server.pid` | Stale process ID |
-| `raw_sources/` | Included by default; skip with `--no-sources` to reduce zip size |
+| Item | Included? | Notes |
+|---|---|---|
+| `wiki/*.md` | ✓ Always | All compiled wiki pages |
+| `AGENTS.md`, `ROUTING.md`, `log.md` | ✓ Always | Wiki root files |
+| `hooks/` | ✓ Always | User hook scripts |
+| `.synthadoc/config.toml` | ✓ Always | Server config |
+| `.synthadoc/audit.db` | ✓ Always | Full audit trail, lifecycle state, chat history |
+| `.synthadoc/extracted/` | ✓ Always | Text sidecars + PDF pagemaps — required by Source Viewer and Provenance modal |
+| `.synthadoc/cache.db` | ✓ Default | Skip with `--no-cache` |
+| `exports/` | ✓ Default | Skip with `--no-exports` |
+| `raw_sources/` | ✓ Default | Skip with `--no-sources` to reduce zip size |
+| LLM API keys | ✗ Never | Never stored in config; set via environment variable |
+| `jobs.db` | ✗ Never | Stale job queue; job *history* is in `audit.db` |
+| `embeddings.db` | ✗ Never | Rebuilt automatically on next server start |
+| `server.pid` | ✗ Never | Machine-specific process ID |
+| `logs/` | ✗ Never | Server application logs |

--- a/synthadoc/core/backup_engine.py
+++ b/synthadoc/core/backup_engine.py
@@ -32,11 +32,27 @@ def _iter_wiki_files(
     for p in sorted(wiki_root.glob("*.txt")):
         yield p, p.name
 
+    # hooks/ — user-customisable scripts; lost silently if not backed up
+    hooks_dir = wiki_root / "hooks"
+    if hooks_dir.is_dir():
+        for f in sorted(hooks_dir.rglob("*")):
+            if f.is_file():
+                yield f, str(f.relative_to(wiki_root)).replace("\\", "/")
+
     sd = wiki_root / ".synthadoc"
     for name in ("config.toml", "audit.db"):
         p = sd / name
         if p.exists():
             yield p, f".synthadoc/{name}"
+
+    # extracted/ — text sidecars + PDF pagemaps written by ingest agent.
+    # Required by the Source Viewer and Provenance citation modal — without
+    # these files the plugin shows "Could not read source file for <name>".
+    extracted_dir = sd / "extracted"
+    if extracted_dir.is_dir():
+        for f in sorted(extracted_dir.rglob("*")):
+            if f.is_file():
+                yield f, str(f.relative_to(wiki_root)).replace("\\", "/")
 
     if include_cache:
         p = sd / "cache.db"

--- a/tests/core/test_backup_engine.py
+++ b/tests/core/test_backup_engine.py
@@ -160,6 +160,53 @@ def test_create_backup_includes_raw_sources_when_requested(wiki_root, tmp_path):
         assert any("raw_sources" in n for n in zf.namelist())
 
 
+def test_create_backup_includes_hooks_directory(wiki_root, tmp_path):
+    hooks = wiki_root / "hooks"
+    hooks.mkdir()
+    (hooks / "notify.py").write_text("# hook", encoding="utf-8")
+    (hooks / "auto_commit.sh").write_text("#!/bin/sh", encoding="utf-8")
+    zip_path = _make_backup(wiki_root, tmp_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    assert "hooks/notify.py" in names
+    assert "hooks/auto_commit.sh" in names
+
+
+def test_create_backup_skips_hooks_gracefully_when_absent(wiki_root, tmp_path):
+    assert not (wiki_root / "hooks").exists()
+    zip_path = _make_backup(wiki_root, tmp_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        assert not any("hooks" in n for n in zf.namelist())
+
+
+def test_create_backup_includes_extracted_txt_sidecars(wiki_root, tmp_path):
+    extracted = wiki_root / ".synthadoc" / "extracted"
+    extracted.mkdir()
+    (extracted / "doc.txt").write_text("extracted text", encoding="utf-8")
+    (extracted / "video.txt").write_text("transcript", encoding="utf-8")
+    zip_path = _make_backup(wiki_root, tmp_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+    assert ".synthadoc/extracted/doc.txt" in names
+    assert ".synthadoc/extracted/video.txt" in names
+
+
+def test_create_backup_includes_extracted_pdf_pagemaps(wiki_root, tmp_path):
+    extracted = wiki_root / ".synthadoc" / "extracted"
+    extracted.mkdir()
+    (extracted / "report.pdf.pagemap").write_text('{"1": 1}', encoding="utf-8")
+    zip_path = _make_backup(wiki_root, tmp_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        assert ".synthadoc/extracted/report.pdf.pagemap" in zf.namelist()
+
+
+def test_create_backup_skips_extracted_gracefully_when_absent(wiki_root, tmp_path):
+    assert not (wiki_root / ".synthadoc" / "extracted").exists()
+    zip_path = _make_backup(wiki_root, tmp_path)
+    with zipfile.ZipFile(zip_path) as zf:
+        assert not any("extracted" in n for n in zf.namelist())
+
+
 # ── manifest ──────────────────────────────────────────────────────────────────
 
 def test_manifest_contains_required_fields(wiki_root, tmp_path):
@@ -263,6 +310,27 @@ def test_extract_backup_supports_name_override(wiki_root, tmp_path):
     extracted = extract_backup(zip_path, tmp_path / "restore", "renamed-wiki")
     assert extracted.name == "renamed-wiki"
     assert (extracted / "wiki" / "page1.md").exists()
+
+
+def test_extract_backup_restores_hooks(wiki_root, tmp_path):
+    hooks = wiki_root / "hooks"
+    hooks.mkdir()
+    (hooks / "notify.py").write_text("# hook", encoding="utf-8")
+    zip_path = _make_backup(wiki_root, tmp_path)
+    restored = extract_backup(zip_path, tmp_path / "restore", "my-wiki")
+    assert (restored / "hooks" / "notify.py").exists()
+    assert (restored / "hooks" / "notify.py").read_text(encoding="utf-8") == "# hook"
+
+
+def test_extract_backup_restores_extracted_sidecars(wiki_root, tmp_path):
+    extracted_dir = wiki_root / ".synthadoc" / "extracted"
+    extracted_dir.mkdir()
+    (extracted_dir / "doc.txt").write_text("line 1\nline 2", encoding="utf-8")
+    (extracted_dir / "report.pdf.pagemap").write_text('{"1": 1}', encoding="utf-8")
+    zip_path = _make_backup(wiki_root, tmp_path)
+    restored = extract_backup(zip_path, tmp_path / "restore", "my-wiki")
+    assert (restored / ".synthadoc" / "extracted" / "doc.txt").read_text(encoding="utf-8") == "line 1\nline 2"
+    assert (restored / ".synthadoc" / "extracted" / "report.pdf.pagemap").exists()
 
 
 # ── rewrite_config ────────────────────────────────────────────────────────────

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -358,24 +358,26 @@ async def test_run_scaffold_completes_job(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
+    try:
+        job_id = await orch._queue.enqueue("scaffold", {"domain": "Test Domain"})
 
-    job_id = await orch._queue.enqueue("scaffold", {"domain": "Test Domain"})
+        result = ScaffoldResult(
+            index_md="# Index\n",
+            agents_md="# Agents\n",
+            purpose_md="# Purpose\n",
+            dashboard_intro="intro",
+        )
 
-    result = ScaffoldResult(
-        index_md="# Index\n",
-        agents_md="# Agents\n",
-        purpose_md="# Purpose\n",
-        dashboard_intro="intro",
-    )
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+             patch("synthadoc.agents.scaffold_agent.ScaffoldAgent") as MockAgent:
+            MockAgent.return_value.scaffold = AsyncMock(return_value=result)
+            await orch._run_scaffold(job_id, "Test Domain")
 
-    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.scaffold_agent.ScaffoldAgent") as MockAgent:
-        MockAgent.return_value.scaffold = AsyncMock(return_value=result)
-        await orch._run_scaffold(job_id, "Test Domain")
-
-    from synthadoc.core.queue import JobStatus
-    completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
-    assert any(j.id == job_id for j in completed)
+        from synthadoc.core.queue import JobStatus
+        completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
+        assert any(j.id == job_id for j in completed)
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -386,17 +388,20 @@ async def test_run_scaffold_fails_job_on_exception(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
-    job_id = await orch._queue.enqueue("scaffold", {"domain": "Test Domain"})
+    try:
+        job_id = await orch._queue.enqueue("scaffold", {"domain": "Test Domain"})
 
-    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.scaffold_agent.ScaffoldAgent") as MockAgent:
-        MockAgent.return_value.scaffold = AsyncMock(side_effect=RuntimeError("LLM error"))
-        with pytest.raises(RuntimeError):
-            await orch._run_scaffold(job_id, "Test Domain")
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+             patch("synthadoc.agents.scaffold_agent.ScaffoldAgent") as MockAgent:
+            MockAgent.return_value.scaffold = AsyncMock(side_effect=RuntimeError("LLM error"))
+            with pytest.raises(RuntimeError):
+                await orch._run_scaffold(job_id, "Test Domain")
 
-    from synthadoc.core.queue import JobStatus
-    completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
-    assert not any(j.id == job_id for j in completed), "Job must not be completed after exception"
+        from synthadoc.core.queue import JobStatus
+        completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
+        assert not any(j.id == job_id for j in completed), "Job must not be completed after exception"
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -408,17 +413,20 @@ async def test_run_lint_daily_quota_fails_permanent(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
-    job_id = await orch._queue.enqueue("lint", {"scope": "all"})
+    try:
+        job_id = await orch._queue.enqueue("lint", {"scope": "all"})
 
-    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.lint_agent.LintAgent") as MockLint:
-        MockLint.return_value.lint = AsyncMock(
-            side_effect=DailyQuotaExhaustedException(provider="gemini"))
-        await orch._run_lint(job_id)
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+             patch("synthadoc.agents.lint_agent.LintAgent") as MockLint:
+            MockLint.return_value.lint = AsyncMock(
+                side_effect=DailyQuotaExhaustedException(provider="gemini"))
+            await orch._run_lint(job_id)
 
-    from synthadoc.core.queue import JobStatus
-    failed = await orch._queue.list_jobs(status=JobStatus.FAILED)
-    assert any(j.id == job_id for j in failed)
+        from synthadoc.core.queue import JobStatus
+        failed = await orch._queue.list_jobs(status=JobStatus.FAILED)
+        assert any(j.id == job_id for j in failed)
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -429,17 +437,20 @@ async def test_run_lint_generic_exception_reraises(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
-    job_id = await orch._queue.enqueue("lint", {"scope": "all"})
+    try:
+        job_id = await orch._queue.enqueue("lint", {"scope": "all"})
 
-    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.lint_agent.LintAgent") as MockLint:
-        MockLint.return_value.lint = AsyncMock(side_effect=ValueError("unexpected"))
-        with pytest.raises(ValueError):
-            await orch._run_lint(job_id)
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+             patch("synthadoc.agents.lint_agent.LintAgent") as MockLint:
+            MockLint.return_value.lint = AsyncMock(side_effect=ValueError("unexpected"))
+            with pytest.raises(ValueError):
+                await orch._run_lint(job_id)
 
-    from synthadoc.core.queue import JobStatus
-    completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
-    assert not any(j.id == job_id for j in completed), "Job must not be completed after exception"
+        from synthadoc.core.queue import JobStatus
+        completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
+        assert not any(j.id == job_id for j in completed), "Job must not be completed after exception"
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -451,18 +462,21 @@ async def test_run_ingest_rate_limit_requeues_and_raises(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
-    job_id = await orch._queue.enqueue("ingest", {"source": "https://example.com", "force": False})
+    try:
+        job_id = await orch._queue.enqueue("ingest", {"source": "https://example.com", "force": False})
 
-    # Build an exception with status_code=429
-    rate_exc = Exception("rate limited")
-    rate_exc.status_code = 429  # type: ignore
+        # Build an exception with status_code=429
+        rate_exc = Exception("rate limited")
+        rate_exc.status_code = 429  # type: ignore
 
-    mock_agent = MagicMock()
-    mock_agent.ingest = AsyncMock(side_effect=rate_exc)
-    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
-        with pytest.raises(Exception):
-            await orch._run_ingest(job_id, "https://example.com", auto_confirm=True)
+        mock_agent = MagicMock()
+        mock_agent.ingest = AsyncMock(side_effect=rate_exc)
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+             patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+            with pytest.raises(Exception):
+                await orch._run_ingest(job_id, "https://example.com", auto_confirm=True)
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -474,15 +488,17 @@ async def test_auto_block_domain_writes_file(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
+    try:
+        exc = DomainBlockedException(domain="blocked.com", url="https://blocked.com/page", status_code=403)
+        await orch._auto_block_domain(exc)
 
-    exc = DomainBlockedException(domain="blocked.com", url="https://blocked.com/page", status_code=403)
-    await orch._auto_block_domain(exc)
-
-    import json
-    blocked_file = tmp_wiki / ".synthadoc" / "blocked_domains.json"
-    assert blocked_file.exists()
-    domains = json.loads(blocked_file.read_text())
-    assert "blocked.com" in domains
+        import json
+        blocked_file = tmp_wiki / ".synthadoc" / "blocked_domains.json"
+        assert blocked_file.exists()
+        domains = json.loads(blocked_file.read_text())
+        assert "blocked.com" in domains
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -495,15 +511,17 @@ async def test_auto_block_domain_does_not_duplicate(tmp_wiki):
 
     orch = Orchestrator(wiki_root=tmp_wiki, config=load_config())
     await orch.init()
+    try:
+        blocked_file = tmp_wiki / ".synthadoc" / "blocked_domains.json"
+        blocked_file.write_text('["blocked.com"]', encoding="utf-8")
 
-    blocked_file = tmp_wiki / ".synthadoc" / "blocked_domains.json"
-    blocked_file.write_text('["blocked.com"]', encoding="utf-8")
+        exc = DomainBlockedException(domain="blocked.com", url="https://blocked.com/p", status_code=403)
+        await orch._auto_block_domain(exc)
 
-    exc = DomainBlockedException(domain="blocked.com", url="https://blocked.com/p", status_code=403)
-    await orch._auto_block_domain(exc)
-
-    domains = json.loads(blocked_file.read_text())
-    assert domains.count("blocked.com") == 1
+        domains = json.loads(blocked_file.read_text())
+        assert domains.count("blocked.com") == 1
+    finally:
+        await orch.close()
 
 
 @pytest.mark.asyncio
@@ -522,40 +540,42 @@ async def test_run_ingest_vector_embed_on_complete(tmp_wiki):
     await orch._queue.init()
     await orch._audit.init()
     await orch._cache.init()
+    try:
+        # Write the page to the wiki store so read_page returns it
+        page = WikiPage(
+            title="New Page", tags=[], status="active", confidence="high",
+            content="Content.", sources=[],
+        )
+        orch._store.write_page("new-page", page)
 
-    # Write the page to the wiki store so read_page returns it
-    page = WikiPage(
-        title="New Page", tags=[], status="active", confidence="high",
-        content="Content.", sources=[],
-    )
-    orch._store.write_page("new-page", page)
+        job_id = await orch._queue.enqueue("ingest", {"source": "https://ex.com", "force": False})
 
-    job_id = await orch._queue.enqueue("ingest", {"source": "https://ex.com", "force": False})
+        result = IngestResult(source="https://ex.com")
+        result.pages_created = ["new-page"]
+        result.pages_updated = []
+        result.pages_flagged = []
+        result.child_sources = []
+        result.tokens_used = 10
+        result.input_tokens = 5
+        result.output_tokens = 5
+        result.skipped = False
 
-    result = IngestResult(source="https://ex.com")
-    result.pages_created = ["new-page"]
-    result.pages_updated = []
-    result.pages_flagged = []
-    result.child_sources = []
-    result.tokens_used = 10
-    result.input_tokens = 5
-    result.output_tokens = 5
-    result.skipped = False
+        embed_calls = []
 
-    embed_calls = []
+        async def fake_embed(slug, text):
+            embed_calls.append(slug)
 
-    async def fake_embed(slug, text):
-        embed_calls.append(slug)
+        mock_agent = MagicMock()
+        mock_agent.ingest = AsyncMock(return_value=result)
 
-    mock_agent = MagicMock()
-    mock_agent.ingest = AsyncMock(return_value=result)
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+             patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent), \
+             patch.object(orch._search, "embed_page", side_effect=fake_embed):
+            await orch._run_ingest(job_id, "https://ex.com", auto_confirm=True)
 
-    with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
-         patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent), \
-         patch.object(orch._search, "embed_page", side_effect=fake_embed):
-        await orch._run_ingest(job_id, "https://ex.com", auto_confirm=True)
-
-    assert "new-page" in embed_calls
+        assert "new-page" in embed_calls
+    finally:
+        await orch.close()
 
 
 # ── cli/_http.py — server_url and happy paths ─────────────────────────────────


### PR DESCRIPTION
hooks/ contains user-customised hook scripts; .synthadoc/extracted/ contains text sidecars and PDF pagemaps written by ingest. Without extracted/, the Source Viewer and Provenance modal show "Could not read source file" after restore.

Updated design.md zip structure, exclusion list, and release notes (v0.9.1–v0.9.3). Updated user-quick-start-guide.md backup table to show all included/excluded items clearly.