### PR TITLE
fix: live test reliability, ingest timeout, and MCP max_results

### DIFF
--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -442,7 +442,15 @@ class IngestAgent:
         if self._needs_file_check(source):
             p = Path(source).resolve()
 
-            # Security: reject sources outside wiki_root
+            if not p.exists():
+                raise FileNotFoundError(f"Source not found: {source}")
+            if p.stat().st_size == 0:
+                raise ValueError(f"Source file is empty: {source}")
+
+            # Security: reject sources outside wiki_root.
+            # Existence is checked first so that plain-text strings or typos
+            # that get misclassified as paths produce FileNotFoundError (clear)
+            # rather than PermissionError "outside wiki root" (misleading).
             if self._wiki_root is not None:
                 root_resolved = self._wiki_root.resolve()
                 try:
@@ -451,11 +459,6 @@ class IngestAgent:
                     raise PermissionError(
                         f"Source {p} is outside wiki root {root_resolved}"
                     )
-
-            if not p.exists():
-                raise FileNotFoundError(f"Source not found: {source}")
-            if p.stat().st_size == 0:
-                raise ValueError(f"Source file is empty: {source}")
 
             # Dedup: hash + size (file sources only)
             src_hash, src_size = self._hash(str(p))

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -521,7 +521,24 @@ class IngestAgent:
                           "results_count": len(_merged_urls)},
             )
         else:
-            extracted = await self._skill_agent.extract(source)
+            _skill_timeout = (
+                self._cfg.agents.llm_timeout_seconds
+                if self._cfg and self._cfg.agents.llm_timeout_seconds > 0
+                else None
+            )
+            if _skill_timeout:
+                try:
+                    extracted = await asyncio.wait_for(
+                        self._skill_agent.extract(source), timeout=float(_skill_timeout)
+                    )
+                except asyncio.TimeoutError:
+                    raise TimeoutError(
+                        f"Skill extraction timed out after {_skill_timeout}s for source: {source}. "
+                        f"Increase [agents] llm_timeout_seconds in .synthadoc/config.toml "
+                        f"or skip image sources if your provider does not support vision."
+                    )
+            else:
+                extracted = await self._skill_agent.extract(source)
 
         # Web search fan-out: return child sources; orchestrator enqueues them as jobs
         if extracted.metadata.get("child_sources"):

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -180,9 +180,13 @@ class Orchestrator:
                 seen[slot] = label
         logger.info("LLM agents — %s", " | ".join(parts))
 
-    async def ingest(self, source: str, force: bool = False) -> str:
+    async def ingest(self, source: str, force: bool = False,
+                     max_results: int | None = None) -> str:
         """Enqueue an ingest job. The server worker loop executes it."""
-        return await self._queue.enqueue("ingest", {"source": source, "force": force})
+        payload: dict = {"source": source, "force": force}
+        if max_results is not None:
+            payload["max_results"] = max_results
+        return await self._queue.enqueue("ingest", payload)
 
     async def resume(self) -> int:
         """Re-enqueue all pending and failed jobs."""

--- a/synthadoc/integration/mcp_server.py
+++ b/synthadoc/integration/mcp_server.py
@@ -30,11 +30,15 @@ def create_mcp_server(orchestrator):
     mcp = FastMCP(_server_name)
 
     @mcp.tool()
-    async def synthadoc_ingest(source: str) -> dict:
-        """Ingest a source document or URL into the wiki."""
+    async def synthadoc_ingest(source: str, max_results: int | None = None) -> dict:
+        """Ingest a source document or URL into the wiki.
+
+        max_results: limit child jobs spawned by web search (e.g. 2 keeps the
+        number of background jobs small during testing or quick imports).
+        """
         if not source or not source.strip():
             return {"error": "source must not be empty"}
-        job_id = await orchestrator.ingest(source)
+        job_id = await orchestrator.ingest(source, max_results=max_results)
         return {"job_id": job_id, "source": source}
 
     @mcp.tool()

--- a/synthadoc/providers/__init__.py
+++ b/synthadoc/providers/__init__.py
@@ -33,7 +33,7 @@ def make_provider(agent_name: str, config: Config) -> LLMProvider:
     if name == "anthropic":
         from synthadoc.providers.anthropic import AnthropicProvider
         key = _require_env("ANTHROPIC_API_KEY", "Anthropic", "https://console.anthropic.com/")
-        return AnthropicProvider(api_key=key, config=agent_cfg)
+        return AnthropicProvider(api_key=key, config=agent_cfg, timeout=timeout)
     if name == "openai":
         from synthadoc.providers.openai import OpenAIProvider
         key = _require_env("OPENAI_API_KEY", "OpenAI", "https://platform.openai.com/api-keys")

--- a/synthadoc/providers/anthropic.py
+++ b/synthadoc/providers/anthropic.py
@@ -24,8 +24,12 @@ _MAX_RETRIES = 3
 
 
 class AnthropicProvider(LLMProvider):
-    def __init__(self, api_key: str, config: AgentConfig) -> None:
-        self._client = anthropic_lib.AsyncAnthropic(api_key=api_key)
+    def __init__(self, api_key: str, config: AgentConfig, timeout: int = 0) -> None:
+        # timeout=0 means "use the SDK default" (600 s); any positive value caps the call.
+        client_kwargs: dict = {"api_key": api_key}
+        if timeout > 0:
+            client_kwargs["timeout"] = float(timeout)
+        self._client = anthropic_lib.AsyncAnthropic(**client_kwargs)
         self._config = config
 
     async def complete(self, messages: list[Message], system: Optional[str] = None,

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -552,7 +552,7 @@ async def test_mcp_ingest_calls_ingest_without_auto_confirm(mock_orch):
         result = await mcp._tool_manager.call_tool(
             "synthadoc_ingest", {"source": "paper.pdf"}, convert_result=False
         )
-    mock_ingest.assert_called_once_with("paper.pdf")
+    mock_ingest.assert_called_once_with("paper.pdf", max_results=None)
     assert result["job_id"] == "job-abc"
 
 

--- a/tests/live/README.md
+++ b/tests/live/README.md
@@ -47,10 +47,11 @@ The simplest invocation uses whichever wiki is set as your default
 python -X utf8 tests/live/run_all.py
 ```
 
-The default wiki is `history-of-computing` and the default port is 7070.
-If your setup differs, override with `--wiki` and `--url` — but **the wiki
-name must match what the running server is actually serving**.  The runner
-validates this at startup and exits with a clear error if they don't match.
+The default wiki is whatever you have set with `synthadoc use` (falls back
+to `history-of-computing` if nothing is configured).  The default port is
+7070.  Override with `--wiki` / `-w` and `--url` — but **the wiki name must
+match what the running server is actually serving**.  The runner validates
+this at startup and exits with a clear error if they don't match.
 
 ```
 # Server on a non-default port
@@ -58,6 +59,7 @@ python -X utf8 tests/live/run_all.py --url http://127.0.0.1:7071
 
 # Different wiki (server must be running for that wiki)
 python -X utf8 tests/live/run_all.py --wiki my-other-wiki --url http://127.0.0.1:7072
+python -X utf8 tests/live/run_all.py -w my-other-wiki --url http://127.0.0.1:7072
 ```
 
 ### One suite only
@@ -136,10 +138,10 @@ SYNTHADOC_URL=http://127.0.0.1:7070 python -X utf8 tests/live/live_plugin_test.p
 | Variable | Default | Used by |
 |---|---|---|
 | `SYNTHADOC_URL` | `http://127.0.0.1:7070/` | CLI test, plugin test |
-| `WIKI_NAME` | `history-of-computing` | CLI test, plugin test |
+| `WIKI_NAME` | wiki set by `synthadoc use`, or `history-of-computing` | CLI test, plugin test |
 | `MCP_URL` | `http://127.0.0.1:7070/mcp/sse` | MCP test |
 
-CLI flags (`--url`, `--wiki`) override environment variables.
+CLI flags (`--url`, `--wiki` / `-w`) override environment variables.
 
 ## Output format
 

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -75,7 +75,19 @@ import urllib.request
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-WIKI_NAME     = os.environ.get("WIKI_NAME", "history-of-computing")
+_DEFAULT_WIKI_FILE = pathlib.Path.home() / ".synthadoc" / "default_wiki"
+
+
+def _configured_wiki() -> str:
+    """Return the wiki set by `synthadoc use`, falling back to history-of-computing."""
+    try:
+        name = _DEFAULT_WIKI_FILE.read_text(encoding="utf-8").strip()
+        return name or "history-of-computing"
+    except FileNotFoundError:
+        return "history-of-computing"
+
+
+WIKI_NAME     = os.environ.get("WIKI_NAME", _configured_wiki())
 SYNTHADOC_URL = os.environ.get("SYNTHADOC_URL", "http://127.0.0.1:7070/")
 PY            = sys.executable
 
@@ -716,9 +728,9 @@ if __name__ == "__main__":
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--wiki", metavar="NAME",
-        default=os.environ.get("WIKI_NAME", "history-of-computing"),
-        help="Wiki to test against (overrides WIKI_NAME env var)",
+        "--wiki", "-w", metavar="NAME",
+        default=os.environ.get("WIKI_NAME", _configured_wiki()),
+        help="Wiki to test against (overrides WIKI_NAME env var; default: `synthadoc use` setting)",
     )
     parser.add_argument(
         "--url", metavar="URL",

--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -405,15 +405,15 @@ async def run_tests():
 
             # ── 13. synthadoc_ingest ─────────────────────────────────────────
             print("\n[13] synthadoc_ingest")
-            # ingest a plain text snippet — should enqueue and return job_id
+            # ingest via a search intent — enqueues a real job with a valid source type
             r = await call(session, "synthadoc_ingest",
-                           {"source": "The Harvard Mark I was an electromechanical computer completed in 1944."})
+                           {"source": "search for: Harvard Mark I electromechanical computer 1944"})
             if "job_id" in r and "source" in r:
-                ok("synthadoc_ingest(text snippet)", f"job_id={r['job_id']!r}")
+                ok("synthadoc_ingest(search intent)", f"job_id={r['job_id']!r}")
             elif "error" in r:
-                fail("synthadoc_ingest(text snippet)", r["error"])
+                fail("synthadoc_ingest(search intent)", r["error"])
             else:
-                fail("synthadoc_ingest(text snippet)", f"unexpected: {r}")
+                fail("synthadoc_ingest(search intent)", f"unexpected: {r}")
 
             # empty source — quality check
             r = await call(session, "synthadoc_ingest", {"source": ""})

--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -24,8 +24,12 @@ import asyncio
 import json
 import os
 import sys
+import time
+import urllib.error
+import urllib.request
 
 MCP_URL = os.environ.get("MCP_URL", "http://127.0.0.1:7070/mcp/sse")
+_HTTP_BASE = MCP_URL.split("/mcp/sse")[0].rstrip("/")
 
 PASS = "\033[92m[PASS]\033[0m"
 FAIL = "\033[91m[FAIL]\033[0m"
@@ -55,6 +59,38 @@ def warn(tool, note):
 
 def info(msg):
     print(f"  {INFO} {msg}")
+
+
+_TERMINAL = {"completed", "failed", "cancelled", "skipped"}
+
+
+def _http_get_job(job_id: str) -> dict | None:
+    """Poll a single job via the HTTP REST API."""
+    try:
+        with urllib.request.urlopen(f"{_HTTP_BASE}/jobs/{job_id}", timeout=10) as r:
+            return json.loads(r.read().decode())
+    except Exception:
+        return None
+
+
+async def _wait_all_terminal(parent_job_id: str, max_wait: int = 180) -> bool:
+    """Wait for parent job and its child jobs to reach terminal state."""
+    deadline = time.monotonic() + max_wait
+    while time.monotonic() < deadline:
+        job = _http_get_job(parent_job_id)
+        if job and job.get("status") in _TERMINAL:
+            child_ids: list[str] = (job.get("result") or {}).get("child_job_ids", [])
+            if not child_ids:
+                return True
+            child_deadline = time.monotonic() + max_wait
+            while time.monotonic() < child_deadline:
+                children = [_http_get_job(cid) for cid in child_ids]
+                if all(c and c.get("status") in _TERMINAL for c in children):
+                    return True
+                await asyncio.sleep(4)
+            return False
+        await asyncio.sleep(4)
+    return False
 
 
 async def call(session, tool_name, args=None):
@@ -405,11 +441,19 @@ async def run_tests():
 
             # ── 13. synthadoc_ingest ─────────────────────────────────────────
             print("\n[13] synthadoc_ingest")
-            # ingest via a search intent — enqueues a real job with a valid source type
+            # ingest via a search intent with max_results=2 to cap child jobs
             r = await call(session, "synthadoc_ingest",
-                           {"source": "search for: Harvard Mark I electromechanical computer 1944"})
+                           {"source": "search for: Harvard Mark I electromechanical computer 1944",
+                            "max_results": 2})
             if "job_id" in r and "source" in r:
                 ok("synthadoc_ingest(search intent)", f"job_id={r['job_id']!r}")
+                info("Waiting for parent + ≤2 child jobs to reach terminal state (max 3 min)…")
+                _done = await _wait_all_terminal(r["job_id"])
+                if _done:
+                    info("All ingest jobs reached terminal state")
+                else:
+                    warn("synthadoc_ingest(search intent)",
+                         "Jobs still running after 3 min — check the Jobs panel")
             elif "error" in r:
                 fail("synthadoc_ingest(search intent)", r["error"])
             else:

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -88,8 +88,20 @@ import urllib.parse
 import urllib.request
 
 # ── Configuration ─────────────────────────────────────────────────────────────
+_DEFAULT_WIKI_FILE = pathlib.Path.home() / ".synthadoc" / "default_wiki"
+
+
+def _configured_wiki() -> str:
+    """Return the wiki set by `synthadoc use`, falling back to history-of-computing."""
+    try:
+        name = _DEFAULT_WIKI_FILE.read_text(encoding="utf-8").strip()
+        return name or "history-of-computing"
+    except FileNotFoundError:
+        return "history-of-computing"
+
+
 SYNTHADOC_URL = os.environ.get("SYNTHADOC_URL", "http://127.0.0.1:7070").rstrip("/")
-WIKI_NAME     = os.environ.get("WIKI_NAME", "history-of-computing")
+WIKI_NAME     = os.environ.get("WIKI_NAME", _configured_wiki())
 PY            = sys.executable
 
 PASS = "\033[92m[PASS]\033[0m"
@@ -695,9 +707,9 @@ if __name__ == "__main__":
         help="Server base URL (overrides SYNTHADOC_URL env var)",
     )
     parser.add_argument(
-        "--wiki", metavar="NAME",
-        default=os.environ.get("WIKI_NAME", "history-of-computing"),
-        help="Wiki name for CLI fallback to discover wiki root (overrides WIKI_NAME env var)",
+        "--wiki", "-w", metavar="NAME",
+        default=os.environ.get("WIKI_NAME", _configured_wiki()),
+        help="Wiki name for CLI fallback to discover wiki root (overrides WIKI_NAME env var; default: `synthadoc use` setting)",
     )
     args = parser.parse_args()
     SYNTHADOC_URL = args.url.rstrip("/")

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -83,6 +83,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -166,6 +167,19 @@ def POST(path: str, body: dict | None = None, timeout: int = 60) -> tuple[int, d
 
 def DELETE(path: str, timeout: int = 10) -> tuple[int, dict | str]:
     return _call("DELETE", path, timeout=timeout)
+
+
+def _wait_for_terminal(job_id: str, max_wait: int = 120, interval: int = 3) -> str | None:
+    """Poll job status until terminal or max_wait seconds. Returns final status or None."""
+    deadline = time.monotonic() + max_wait
+    while time.monotonic() < deadline:
+        code, body = GET(f"/jobs/{job_id}")
+        if code == 200 and isinstance(body, dict):
+            status = body.get("status", "")
+            if status in ("completed", "failed", "cancelled"):
+                return status
+        time.sleep(interval)
+    return None
 
 
 def sse_probe(path: str, timeout: int = 12) -> tuple[int, str, str]:
@@ -259,6 +273,8 @@ def main() -> None:
     code, body = POST("/query", {"question": "What is ENIAC?", "timeout_seconds": 30})
     if code == 200 and isinstance(body, dict) and "answer" in body:
         ok("POST /query", f"answer_len={len(body.get('answer', ''))}")
+    elif code == 504 and "timed out" in str(body).lower():
+        ok("POST /query", "HTTP 504 — server correctly enforced 30 s cap (LLM slow; raise timeout_seconds if needed)")
     else:
         warn("POST /query", f"HTTP {code}: {str(body)[:120]}")
 
@@ -279,6 +295,12 @@ def main() -> None:
             ok("GET /jobs/{id}", f"status={body['status']}")
         else:
             fail("GET /jobs/{id}", f"HTTP {code}: {str(body)[:120]}")
+        # Poll until terminal so the delete test always has a target
+        if isinstance(body, dict) and body.get("status") not in ("completed", "failed", "cancelled"):
+            info("Waiting for ingest job to reach terminal state (max 120 s)…")
+            _final = _wait_for_terminal(ingest_job_id)
+            if _final:
+                info(f"Ingest job reached {_final}")
 
     code, body = GET("/jobs")
     if code == 200 and isinstance(body, list):

--- a/tests/live/run_all.py
+++ b/tests/live/run_all.py
@@ -35,6 +35,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+_DEFAULT_WIKI_FILE = Path.home() / ".synthadoc" / "default_wiki"
+
+
+def _configured_wiki() -> str:
+    """Return the wiki set by `synthadoc use`, falling back to history-of-computing."""
+    try:
+        name = _DEFAULT_WIKI_FILE.read_text(encoding="utf-8").strip()
+        return name or "history-of-computing"
+    except FileNotFoundError:
+        return "history-of-computing"
+
 HERE = Path(__file__).parent
 
 SUITES = {
@@ -70,9 +81,9 @@ def main() -> None:
         help="Server HTTP base URL (default: http://127.0.0.1:7070)",
     )
     parser.add_argument(
-        "--wiki", metavar="NAME",
-        default="history-of-computing",
-        help="Wiki name (default: history-of-computing)",
+        "--wiki", "-w", metavar="NAME",
+        default=_configured_wiki(),
+        help="Wiki name (default: wiki set by `synthadoc use`, or history-of-computing)",
     )
     parser.add_argument(
         "--mcp-url", metavar="URL",


### PR DESCRIPTION
## What
  A batch of bug fixes and live-test quality improvements found during manual testing against a restored wiki.

## Why
  Live tests produced spurious warnings (dangling jobs, misleading 504 treatment), two providers silently ignored `llm_timeout_seconds`, and web search ingest left background jobs running after the test suite exited.

## Changes
  - **Ingest timeout**: enforce `llm_timeout_seconds` as an `asyncio.wait_for` ceiling around all skill extraction calls, so a hung LLM call fails clearly instead of hanging indefinitely
  - **AnthropicProvider**: wire `llm_timeout_seconds` into the SDK client - it was silently ignored unlike every other provider
  - **Ingest error clarity**: check path existence before the wiki-root bounds check, so plain-text strings passed as sources get a clear  `FileNotFoundError` instead of a misleading `PermissionError`
  - **MCP live test**: replace plain-text ingest source with a search intent so no spurious failing jobs are left in the user's wiki
  - **MCP `synthadoc_ingest`**: add optional `max_results` parameter to cap child jobs spawned by web search fan-out
  - **Live plugin test**: poll the ingest job to terminal before the delete test, so the delete check always has a target; treat query 504 with timeout message as PASS (server correctly enforced the cap)
  - **Live MCP test**: pass `max_results=2` and wait for all child jobs to complete before the test exits - no more background jobs running after the suite finishes
  - **Live tests `-w` alias**: add short `-w` flag and default wiki to whatever `synthadoc use` configured