### PR TITLE
fix(export): fix(export): OKF tags emitted as YAML list + spec conformance tests

### DIFF
--- a/synthadoc/agents/export_agent.py
+++ b/synthadoc/agents/export_agent.py
@@ -332,7 +332,7 @@ class ExportAgent:
                 "type": page.type or "concept",
                 "title": page.title,
                 "description": _first_sentence(page.content or ""),
-                "tags": ", ".join(page.tags) if page.tags else "",
+                "tags": list(page.tags) if page.tags else [],
                 "timestamp": page.updated or (str(page.created) if page.created else ""),
                 "status": page.status,
                 "confidence": page.confidence or "",
@@ -345,11 +345,12 @@ class ExportAgent:
                     resource = url_sources[0]
             if resource:
                 fm["resource"] = resource
-            fm = {k: v for k, v in fm.items() if v != ""}
+            fm = {k: v for k, v in fm.items() if v not in ("", [], None)}
 
             body = _rewrite_wikilinks(page.content or "", slug_to_title)
             if page.contradiction_note:
-                body += f"\n\n> **Contradiction:** {page.contradiction_note}"
+                note = _rewrite_wikilinks(page.contradiction_note, slug_to_title)
+                body += f"\n\n> **Contradiction:** {note}"
             raw = _yaml.dump(fm, default_flow_style=False, allow_unicode=True)
             files[f"wiki/{slug}.md"] = f"---\n{raw}---\n\n{body}\n"
 

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -182,6 +182,85 @@ def _wait_for_terminal(job_id: str, max_wait: int = 120, interval: int = 3) -> s
     return None
 
 
+def _okf_validate(bundle: dict) -> None:
+    """Validate an OKF bundle dict against the OKF v0.1 spec.
+
+    Checks: index.md present, concept files have required `type`, tags are a
+    list (not a string), description has no newlines, wikilinks are rewritten.
+    Reports PASS/WARN per check; never raises so the test suite continues.
+    """
+    try:
+        import yaml as _yaml
+    except ImportError:
+        warn("POST /export (okf) spec-check", "PyYAML not available — skipping content validation")
+        return
+
+    def _fm(text: str) -> dict:
+        if text.startswith("---"):
+            parts = text.split("---", 2)
+            if len(parts) >= 3:
+                return _yaml.safe_load(parts[1]) or {}
+        return {}
+
+    # index.md present with type: index
+    if "index.md" in bundle:
+        fm = _fm(bundle["index.md"])
+        if fm.get("type") == "index":
+            ok("POST /export (okf) spec: index.md type=index")
+        else:
+            warn("POST /export (okf) spec: index.md", f"expected type=index, got {fm.get('type')!r}")
+    else:
+        warn("POST /export (okf) spec: index.md", "missing from bundle")
+
+    # concept files
+    concept_paths = [p for p in bundle if p.startswith("wiki/")]
+    if not concept_paths:
+        warn("POST /export (okf) spec: wiki/ files", "no concept files in bundle")
+        return
+
+    import re as _re
+    _WIKILINK_PAT = _re.compile(r"\[\[[^\]]+\]\]")
+    missing_type, bad_tags, newline_desc, has_wikilinks = [], [], [], []
+    for path in concept_paths:
+        fm = _fm(bundle[path])
+        if "type" not in fm:
+            missing_type.append(path)
+        tags = fm.get("tags")
+        if tags is not None and not isinstance(tags, list):
+            bad_tags.append(path)
+        desc = fm.get("description", "")
+        if desc and "\n" in desc:
+            newline_desc.append(path)
+        body = bundle[path].split("---", 2)[-1] if "---" in bundle[path] else bundle[path]
+        if _WIKILINK_PAT.search(body):
+            has_wikilinks.append(path)
+
+    if missing_type:
+        warn("POST /export (okf) spec: required `type` field",
+             f"missing in {len(missing_type)} file(s): {missing_type[:3]}")
+    else:
+        ok("POST /export (okf) spec: all concept files have `type`",
+           f"{len(concept_paths)} file(s) checked")
+
+    if bad_tags:
+        warn("POST /export (okf) spec: `tags` must be a YAML list",
+             f"string found in {len(bad_tags)} file(s): {bad_tags[:3]}")
+    else:
+        ok("POST /export (okf) spec: `tags` are YAML lists where present")
+
+    if newline_desc:
+        warn("POST /export (okf) spec: `description` must be single sentence",
+             f"newline found in {len(newline_desc)} file(s): {newline_desc[:3]}")
+    else:
+        ok("POST /export (okf) spec: `description` is single-line in all files")
+
+    if has_wikilinks:
+        warn("POST /export (okf) spec: wikilinks not fully rewritten",
+             f"[[...]] found in body of {len(has_wikilinks)} file(s): {has_wikilinks[:3]}")
+    else:
+        ok("POST /export (okf) spec: no raw wikilinks in concept bodies")
+
+
 def sse_probe(path: str, timeout: int = 12) -> tuple[int, str, str]:
     """GET an SSE endpoint; returns (status, content_type, first_chunk)."""
     parsed = urllib.parse.urlparse(SYNTHADOC_URL)
@@ -686,10 +765,11 @@ def main() -> None:
     else:
         fail("POST /export (json)", f"HTTP {code}: {str(body)[:120]}")
 
-    # exportWikiOkf (JSON object)
+    # exportWikiOkf (JSON object) + OKF spec conformance check
     code, body = POST("/export", {"format": "okf", "status_filter": "all"})
     if code == 200 and isinstance(body, dict):
         ok("POST /export (okf)", f"keys={list(body.keys())[:5]}")
+        _okf_validate(body)
     elif code == 200:
         warn("POST /export (okf)", f"HTTP 200 but body type={type(body).__name__} (expected dict)")
     else:

--- a/tests/test_export_agent.py
+++ b/tests/test_export_agent.py
@@ -447,7 +447,8 @@ async def test_okf_resource_present_for_url_source(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_okf_tags_as_comma_string(tmp_path):
+async def test_okf_tags_emitted_as_yaml_list(tmp_path):
+    """OKF spec requires tags to be a YAML list of short strings, not a comma-joined string."""
     store = _make_store(tmp_path)
     _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
                     content="Content.", type_="person",
@@ -455,7 +456,33 @@ async def test_okf_tags_as_comma_string(tmp_path):
     agent = _agent(tmp_path, store)
     result = await agent.export(ExportOptions(format="okf"))
     fm = _parse_frontmatter(result["wiki/alan-turing.md"])
-    assert fm["tags"] == "mathematics, computation"
+    assert fm["tags"] == ["mathematics", "computation"]
+
+
+@pytest.mark.asyncio
+async def test_okf_single_tag_emitted_as_list(tmp_path):
+    """A single tag must still be a YAML list, not a bare scalar string."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
+                    content="Content.", type_="person",
+                    tags=["pioneer"])
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["wiki/alan-turing.md"])
+    assert fm["tags"] == ["pioneer"]
+    assert isinstance(fm["tags"], list)
+
+
+@pytest.mark.asyncio
+async def test_okf_tags_omitted_when_empty(tmp_path):
+    """No tags key must appear in frontmatter when the page has no tags."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
+                    content="Content.", type_="person", tags=[])
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["wiki/alan-turing.md"])
+    assert "tags" not in fm
 
 
 @pytest.mark.asyncio
@@ -576,6 +603,27 @@ async def test_okf_contradiction_note_appended_to_body(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_okf_wikilinks_in_contradiction_note_are_rewritten(tmp_path):
+    """Wikilinks inside contradiction_note must be rewritten — the note is appended
+    after the main body rewrite, so it needs its own rewrite pass."""
+    store = _make_store(tmp_path)
+    page = WikiPage(
+        title="Conflict Page", tags=[], content="Original claim.",
+        status=LifecycleState.CONTRADICTED, confidence="low", sources=[],
+        created="2026-05-26", orphan=False, type="concept",
+        contradiction_note="See [[other-page]] for the corrected claim.",
+    )
+    store.write_page("conflict-page", page)
+    _write_okf_page(store, "other-page", "Other Page", LifecycleState.ACTIVE,
+                    content="Correct claim.")
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    body = result["wiki/conflict-page.md"].split("---", 2)[2]
+    assert "[[other-page]]" not in body, "wikilink in contradiction_note was not rewritten"
+    assert "[Other Page](other-page.md)" in body
+
+
+@pytest.mark.asyncio
 async def test_okf_archived_pages_included_with_status_filter(tmp_path):
     store = _make_store(tmp_path)
     _write_okf_page(store, "old-page", "Old Page", LifecycleState.ARCHIVED,
@@ -643,3 +691,106 @@ def test_okf_log_rendered_when_events_present(tmp_path):
     assert "log.md" in result
     assert "alan-turing" in result["log.md"]
     assert "active" in result["log.md"]
+
+
+# ── OKF spec conformance tests ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_okf_spec_required_type_field_always_present(tmp_path):
+    """Every concept file must have a `type` field — the only required OKF field."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "p1", "Page One", LifecycleState.ACTIVE,
+                    content="Content.", type_="concept")
+    _write_okf_page(store, "p2", "Page Two", LifecycleState.CONTRADICTED,
+                    content="Disputed.", type_=None)  # defaults to "concept"
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    for path, text in result.items():
+        if path.startswith("wiki/"):
+            fm = _parse_frontmatter(text)
+            assert "type" in fm, f"{path} missing required 'type' field"
+
+
+@pytest.mark.asyncio
+async def test_okf_spec_recommended_fields_present(tmp_path):
+    """OKF recommended fields (title, description, timestamp) must appear in concept files."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
+                    content="Father of computer science. Long description follows.",
+                    type_="person", created="2026-01-01", updated="2026-05-15")
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["wiki/alan-turing.md"])
+    assert "title" in fm
+    assert "description" in fm
+    assert "timestamp" in fm
+
+
+@pytest.mark.asyncio
+async def test_okf_spec_description_is_single_line(tmp_path):
+    """OKF spec says description is 'a single sentence'. It must not contain newlines."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
+                    content="First sentence here. Second sentence. Third sentence.",
+                    type_="person")
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["wiki/alan-turing.md"])
+    assert "\n" not in fm["description"]
+    assert fm["description"] == "First sentence here."
+
+
+@pytest.mark.asyncio
+async def test_okf_spec_index_has_type_index(tmp_path):
+    """index.md must have type: index in frontmatter — OKF reserved filename."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
+                    content="Content.", type_="person")
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["index.md"])
+    assert fm.get("type") == "index"
+
+
+@pytest.mark.asyncio
+async def test_okf_spec_log_has_type_log(tmp_path):
+    """log.md must have type: log in frontmatter — OKF reserved filename."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "alan-turing", "Alan Turing", LifecycleState.ACTIVE,
+                    content="Content.", type_="person")
+    agent = _agent(tmp_path, store)
+    events = [{"slug": "alan-turing", "from_state": "draft", "to_state": "active",
+               "reason": "ok", "timestamp": "2026-05-01T10:00:00"}]
+    result = agent._render_okf({"alan-turing": store.read_page("alan-turing")}, events)
+    fm = _parse_frontmatter(result["log.md"])
+    assert fm.get("type") == "log"
+
+
+@pytest.mark.asyncio
+async def test_okf_spec_tags_are_list_not_string(tmp_path):
+    """OKF spec: tags is 'YAML list of short strings'. Parsed value must be a Python list."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "ada", "Ada Lovelace", LifecycleState.ACTIVE,
+                    content="First programmer.", type_="person",
+                    tags=["pioneer", "mathematics", "history"])
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["wiki/ada.md"])
+    assert isinstance(fm["tags"], list), "tags must be a YAML list, not a string"
+    assert fm["tags"] == ["pioneer", "mathematics", "history"]
+
+
+@pytest.mark.asyncio
+async def test_okf_spec_wikilinks_resolved_to_markdown(tmp_path):
+    """OKF spec: concepts link with normal markdown links, not [[wikilinks]]."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "ada", "Ada Lovelace", LifecycleState.ACTIVE,
+                    content="Worked with [[babbage|Charles Babbage]] on the Engine.",
+                    type_="person")
+    _write_okf_page(store, "babbage", "Charles Babbage", LifecycleState.ACTIVE,
+                    content="Designed the Difference Engine.", type_="person")
+    agent = _agent(tmp_path, store)
+    result = await agent.export(ExportOptions(format="okf"))
+    body = result["wiki/ada.md"].split("---", 2)[2]
+    assert "[[" not in body, "wikilinks must be rewritten to markdown links"
+    assert "[Charles Babbage](babbage.md)" in body


### PR DESCRIPTION
What

  Fix OKF export to emit tags as a proper YAML list, and add spec conformance test coverage across unit and live tests.

Why

  The OKF v0.1 spec (published by Google Cloud, June 2026) requires tags to be a "YAML list of short strings." Synthadoc was emitting a comma-joined string ("mathematics, computation" instead of ["mathematics", "computation"]), which violates the spec and would cause consumers to receive a scalar string rather than a list.

Changes

- export_agent.py: emit tags as list(page.tags) instead of ", ".join(page.tags); update frontmatter filter to also exclude empty lists so tags: is omitted when the page has none
- test_export_agent.py: rename and fix test_okf_tags_as_comma_string → test_okf_tags_emitted_as_yaml_list; add test_okf_single_tag_emitted_as_list and test_okf_tags_omitted_when_empty; add 6 OKF spec conformance tests covering required type field on every concept file, recommended fields present, single-line description, index.md type, log.md type, and no raw wikilinks in bodies
- live_plugin_test.py: add _okf_validate() helper that parses the live bundle after each export test and reports PASS/WARN per spec rule (index.md, required type, list tags, single-line description, wikilinks rewritten)