### PR TITLE
fix(plugin): patch workspace.json reading view on install/upgrade

### DIFF
--- a/synthadoc/cli/plugin.py
+++ b/synthadoc/cli/plugin.py
@@ -142,6 +142,52 @@ def _set_reading_view_default(wiki_path: Path) -> bool:
     return True
 
 
+def _patch_workspace_reading_view(wiki_path: Path) -> bool:
+    """Set mode=preview on every markdown leaf in .obsidian/workspace.json.
+
+    Obsidian restores each file in its last-saved mode, so defaultViewMode
+    in app.json has no effect on files already in the workspace.  Patching
+    workspace.json here ensures they re-open in Reading View after an upgrade.
+
+    Returns True if workspace.json was rewritten; False if unchanged or absent.
+    Must be called while Obsidian is closed — Obsidian overwrites workspace.json
+    on exit with its current in-memory state.
+    """
+    ws_json = wiki_path / ".obsidian" / "workspace.json"
+    if not ws_json.exists():
+        return False
+    try:
+        workspace = json.loads(ws_json.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+
+    changed = False
+
+    def _patch(node: object) -> None:
+        nonlocal changed
+        if isinstance(node, dict):
+            state = node.get("state", {})
+            if (
+                node.get("type") == "leaf"
+                and isinstance(state, dict)
+                and state.get("type") == "markdown"
+            ):
+                inner = state.get("state", {})
+                if isinstance(inner, dict) and inner.get("mode") != _OBSIDIAN_READING_VIEW:
+                    inner["mode"] = _OBSIDIAN_READING_VIEW
+                    changed = True
+            for v in node.values():
+                _patch(v)
+        elif isinstance(node, list):
+            for item in node:
+                _patch(item)
+
+    _patch(workspace)
+    if changed:
+        ws_json.write_text(json.dumps(workspace, indent=2), encoding="utf-8")
+    return changed
+
+
 def _install_plugin_into(wiki_path: Path) -> list[str]:
     """Copy plugin files into wiki_path and write data.json.  Returns copied filenames."""
     dest_dir = wiki_path / ".obsidian" / "plugins" / _PLUGIN_ID
@@ -202,6 +248,7 @@ def plugin_install_cmd(
     dataview_status = _install_dataview(wiki_path)
     _update_community_plugins(wiki_path, _DATAVIEW_ID, _PLUGIN_ID)
     _set_reading_view_default(wiki_path)
+    _patch_workspace_reading_view(wiki_path)
 
     dest_dir = wiki_path / ".obsidian" / "plugins" / _PLUGIN_ID
     typer.echo(f"Plugin installed into: {dest_dir}")
@@ -260,6 +307,7 @@ def plugin_upgrade_cmd():
             copied = _install_plugin_into(wiki_path)
             if copied:
                 _set_reading_view_default(wiki_path)
+                _patch_workspace_reading_view(wiki_path)
                 upgraded.append(name)
             else:
                 skipped.append(f"  {name}: no plugin files found — run: python scripts/sync_plugin.py")
@@ -270,6 +318,8 @@ def plugin_upgrade_cmd():
         typer.echo(f"Upgraded {len(upgraded)} wiki(s):")
         for name in upgraded:
             typer.echo(f"  {name}")
+        typer.echo()
+        typer.echo("Restart Obsidian (or reopen each vault) for the changes to take effect.")
     if skipped:
         typer.echo("Skipped:")
         for msg in skipped:

--- a/tests/cli/test_plugin.py
+++ b/tests/cli/test_plugin.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from synthadoc.cli.main import app  # noqa: F401 - prevents circular import
-from synthadoc.cli.plugin import _set_reading_view_default
+from synthadoc.cli.plugin import _set_reading_view_default, _patch_workspace_reading_view
 
 
 def test_set_reading_view_default_creates_app_json(tmp_path):
@@ -82,3 +82,81 @@ def test_set_reading_view_default_creates_obsidian_dir(tmp_path):
     result = _set_reading_view_default(wiki)
     assert result is True
     assert (wiki / ".obsidian" / "app.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _patch_workspace_reading_view
+# ---------------------------------------------------------------------------
+
+def _make_workspace(leaves: list[dict]) -> dict:
+    """Build a minimal workspace.json structure with the given leaf state dicts."""
+    children = [
+        {
+            "id": f"leaf{i}",
+            "type": "leaf",
+            "state": {
+                "type": leaf.get("type", "markdown"),
+                "state": {k: v for k, v in leaf.items() if k != "type"},
+            },
+        }
+        for i, leaf in enumerate(leaves)
+    ]
+    return {"main": {"id": "root", "type": "split", "children": children}}
+
+
+def test_patch_workspace_no_file(tmp_path):
+    """Returns False when workspace.json does not exist."""
+    wiki = tmp_path / "wiki"
+    (wiki / ".obsidian").mkdir(parents=True)
+    assert _patch_workspace_reading_view(wiki) is False
+
+
+def test_patch_workspace_patches_source_leaves(tmp_path):
+    """Markdown leaves with mode=source are switched to mode=preview."""
+    wiki = tmp_path / "wiki"
+    (wiki / ".obsidian").mkdir(parents=True)
+    ws_json = wiki / ".obsidian" / "workspace.json"
+    workspace = _make_workspace([{"mode": "source", "file": "wiki/note.md"}])
+    ws_json.write_text(json.dumps(workspace), encoding="utf-8")
+
+    result = _patch_workspace_reading_view(wiki)
+    assert result is True
+    data = json.loads(ws_json.read_text(encoding="utf-8"))
+    leaf_state = data["main"]["children"][0]["state"]["state"]
+    assert leaf_state["mode"] == "preview"
+
+
+def test_patch_workspace_idempotent(tmp_path):
+    """Already-preview leaves are left unchanged; returns False."""
+    wiki = tmp_path / "wiki"
+    (wiki / ".obsidian").mkdir(parents=True)
+    ws_json = wiki / ".obsidian" / "workspace.json"
+    workspace = _make_workspace([{"mode": "preview", "file": "wiki/note.md"}])
+    ws_json.write_text(json.dumps(workspace), encoding="utf-8")
+
+    result = _patch_workspace_reading_view(wiki)
+    assert result is False
+
+
+def test_patch_workspace_skips_non_markdown_leaves(tmp_path):
+    """Non-markdown leaves (e.g. file-explorer) are not touched."""
+    wiki = tmp_path / "wiki"
+    (wiki / ".obsidian").mkdir(parents=True)
+    ws_json = wiki / ".obsidian" / "workspace.json"
+    workspace = _make_workspace([{"type": "file-explorer"}])
+    ws_json.write_text(json.dumps(workspace), encoding="utf-8")
+
+    result = _patch_workspace_reading_view(wiki)
+    assert result is False
+
+
+def test_patch_workspace_malformed_json(tmp_path):
+    """Malformed workspace.json is left untouched; returns False."""
+    wiki = tmp_path / "wiki"
+    (wiki / ".obsidian").mkdir(parents=True)
+    ws_json = wiki / ".obsidian" / "workspace.json"
+    ws_json.write_text("{ not valid }", encoding="utf-8")
+
+    result = _patch_workspace_reading_view(wiki)
+    assert result is False
+    assert ws_json.read_text(encoding="utf-8") == "{ not valid }"


### PR DESCRIPTION
Obsidian restores each file in its last-saved view mode from workspace.json, so defaultViewMode in app.json has no effect on files the user has already opened in editing mode.

Add _patch_workspace_reading_view() which walks the workspace.json leaf tree and sets mode=preview on every markdown leaf.  Call it from both plugin install and plugin upgrade so Reading View is enforced on the next Obsidian restart regardless of prior state.

Also add restart reminder to the upgrade command output, which previously printed nothing about needing a restart after applying app.json and workspace.json changes.