### PR TITLE
fix: gap detection, lint report orphan display, and search suggestion hardening

### DIFF
--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -344,6 +344,8 @@ class ActionAgent:
             for slug in state.orphans:
                 lines.append(f"- `{slug}`")
             parts.append("\n".join(lines))
+        else:
+            parts.append("**Orphan pages (0)** — all pages have at least one inbound link.")
 
         if state.adv_pages:
             total = sum(len(p["warnings"]) for p in state.adv_pages)
@@ -361,7 +363,8 @@ class ActionAgent:
                         lines.append(f"  - {concern}")
             parts.append("\n".join(lines))
 
-        if not parts:
+        _any_issues = bool(state.contradicted or state.orphans or state.adv_pages)
+        if not _any_issues:
             message = _MSG_LINT_ALL_CLEAR
         else:
             message = "\n\n".join(parts)

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -196,6 +196,7 @@ _SYNTHADOC_CLI_SUBCOMMANDS: frozenset[str] = frozenset({
 
 _WIKI_INTROSPECTIVE_TRIGGERS: frozenset[str] = frozenset({
     "what topics",
+    "key topics",
     "what subject",
     "what does this wiki",
     "what's in this wiki",
@@ -210,10 +211,20 @@ _WIKI_INTROSPECTIVE_TRIGGERS: frozenset[str] = frozenset({
     "wiki know about",
     "topics covered",
     "subjects covered",
+    "topics in this wiki",
+    "topics in my wiki",
     "this wiki cover",
     "this wiki know",
     "this wiki includ",
     "this wiki contain",
+    # Wiki-purpose / scope meta-queries: "Summarize Wiki Purpose — General",
+    # "What is the purpose of this wiki?". These always resolve from purpose.md
+    # (pinned as _purpose_ctx) so gap detection would fire falsely on 0 candidates.
+    "wiki purpose",
+    "purpose of this wiki",
+    "purpose of my wiki",
+    "purpose of your wiki",
+    "summarize wiki",
 })
 
 # ── Hints used in _fetch_live_wiki_data for lifecycle state display ────────────

--- a/synthadoc/agents/search_decompose_agent.py
+++ b/synthadoc/agents/search_decompose_agent.py
@@ -79,7 +79,7 @@ class SearchDecomposeAgent:
                 type(exc).__name__, exc,
             )
             return [query]
-        filtered = parse_json_string_array(resp.text, _MAX_SUB_QUERIES)
+        filtered = parse_json_string_array(resp.text, _MAX_SUB_QUERIES) or []
         filtered = [
             s for s in filtered
             if not _LOCAL_SITE_RE.match(s.strip()) and not _WIKIPEDIA_RE.search(s)

--- a/synthadoc/agents/search_decompose_agent.py
+++ b/synthadoc/agents/search_decompose_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from synthadoc.agents._utils import parse_json_string_array
 from synthadoc.providers.base import LLMProvider, Message
@@ -11,6 +12,23 @@ logger = logging.getLogger(__name__)
 
 _MAX_SUB_QUERIES = 4
 _MAX_QUERY_CHARS = 2000
+
+# Reject suggestions that use the site: search operator with a local filename
+# extension rather than a real web domain (e.g. "site:purpose.md ...").
+# This happens when the LLM sees a filename in the domain_context and
+# hallucinates it as a web domain.
+_LOCAL_SITE_RE = re.compile(
+    r"^site:[^\s/]*\.(md|txt|pdf|json|yaml|toml|csv|py|js|ts)\b",
+    re.IGNORECASE,
+)
+
+# Reject Wikipedia URLs — they block automated ingest (403/bot detection),
+# and the prompt already instructs the LLM not to suggest them, but it sometimes
+# ignores the instruction.
+_WIKIPEDIA_RE = re.compile(
+    r"(?:https?://)?(?:\w+\.)?wikipedia\.org/",
+    re.IGNORECASE,
+)
 
 
 class SearchDecomposeAgent:
@@ -62,6 +80,10 @@ class SearchDecomposeAgent:
             )
             return [query]
         filtered = parse_json_string_array(resp.text, _MAX_SUB_QUERIES)
+        filtered = [
+            s for s in filtered
+            if not _LOCAL_SITE_RE.match(s.strip()) and not _WIKIPEDIA_RE.search(s)
+        ]
         if filtered:
             if len(filtered) == 1:
                 logger.info("web search is simple — no decomposition (1 query)")

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -202,6 +202,27 @@ async def test_lint_report_action_with_issues(tmp_path):
     assert "page-c" in result.message
 
 
+@pytest.mark.asyncio
+async def test_lint_report_orphan_zero_shown_when_other_issues_exist(tmp_path):
+    """When there are no orphans but other issues exist, the report must explicitly
+    state 'Orphan pages (0)' so orphan-specific queries don't silently omit the answer."""
+    extraction = '{"action": "lint_report", "params": {}}'
+    agent, _ = _make_agent(tmp_path, extraction)
+    with patch("synthadoc.agents.lint_agent.read_current_lint_state") as mock_rcs:
+        mock_rcs.return_value = LintStateSummary(
+            contradicted=["page-a"],
+            orphans=[],
+            adv_pages=[{"slug": "page-b", "warnings": [{"claim": "x", "concern": "y"}]}],
+        )
+        result = await agent.run("What pages are orphan pages?")
+    assert result is not None
+    assert result.success is True
+    assert "page-a" in result.message
+    assert "Orphan pages (0)" in result.message
+    assert "all pages have at least one inbound link" in result.message
+    assert "page-b" in result.message
+
+
 # ── none action ───────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -2093,6 +2093,111 @@ async def test_no_gap_for_wiki_introspective_queries(tmp_wiki):
     assert provider.complete.call_count == 2
 
 
+@pytest.mark.asyncio
+async def test_no_gap_for_key_topics_phrasing(tmp_wiki):
+    """'What are the key topics in this wiki?' must not trigger a gap.
+
+    Previously the trigger 'what topics' missed this because 'what' and 'topics'
+    are not adjacent — 'are the key' sits between them. The new 'key topics'
+    trigger must catch it.
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("transformer", WikiPage(
+        title="Transformer Architecture", tags=["ai"],
+        content="The transformer uses self-attention to process sequences in parallel.",
+        status="active", confidence="high", sources=[],
+    ))
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["What are the key topics in this wiki?"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text="This wiki covers transformers and attention mechanisms.",
+                           input_tokens=50, output_tokens=10),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search)
+    result = await agent.query("What are the key topics in this wiki?")
+
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []
+    assert provider.complete.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_gap_for_topics_in_this_wiki_phrasing(tmp_wiki):
+    """'What topics are covered in this wiki?' must not trigger a gap."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("llm", WikiPage(
+        title="Large Language Models", tags=["ai"],
+        content="Large language models are trained on vast text corpora using transformers.",
+        status="active", confidence="high", sources=[],
+    ))
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["topics in this wiki"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text="This wiki covers LLMs.",
+                           input_tokens=50, output_tokens=10),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search)
+    result = await agent.query("What topics are covered in this wiki?")
+
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []
+    assert provider.complete.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_gap_for_wiki_purpose_phrasing(tmp_wiki):
+    """'Summarize Wiki Purpose — General' must not trigger a gap (wiki-purpose introspective)."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("llm", WikiPage(
+        title="Large Language Models", tags=["ai"],
+        content="Large language models are trained on vast text corpora using transformers.",
+        status="active", confidence="high", sources=[],
+    ))
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["wiki purpose general"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text="This wiki serves as a knowledge base for AI research.",
+                           input_tokens=50, output_tokens=10),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search)
+    result = await agent.query("Summarize Wiki Purpose — General")
+
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []
+    assert provider.complete.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_no_gap_for_purpose_of_this_wiki(tmp_wiki):
+    """'What is the purpose of this wiki?' must not trigger a gap."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    store.write_page("llm", WikiPage(
+        title="Large Language Models", tags=["ai"],
+        content="Large language models are trained on vast text corpora using transformers.",
+        status="active", confidence="high", sources=[],
+    ))
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["ai wiki purpose"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(text="This wiki covers AI and machine learning topics.",
+                           input_tokens=50, output_tokens=10),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search)
+    result = await agent.query("What is the purpose of this wiki?")
+
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []
+    assert provider.complete.call_count == 2
+
+
 # ── _parse_lookback_days ──────────────────────────────────────────────────────
 
 def test_parse_lookback_days_week():

--- a/tests/agents/test_search_decompose_agent.py
+++ b/tests/agents/test_search_decompose_agent.py
@@ -135,6 +135,76 @@ async def test_decompose_prompt_requests_search_strings_not_questions():
     assert any(kw in prompt_text.lower() for kw in ["search string", "search query", "search queries", "keyword"])
 
 
+# ── site: local-file filter ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_decompose_filters_site_local_filename():
+    """Suggestions using site: with a local filename (e.g. site:purpose.md) must be removed."""
+    agent = _make_agent('["site:purpose.md artificial intelligence wiki topics", "large language models survey 2024"]')
+    result = await agent.decompose("What are the key topics in this wiki?")
+    assert result == ["large language models survey 2024"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_filters_site_various_extensions():
+    """site: with .txt, .pdf, .json, .yaml, .toml, .py extensions must all be filtered."""
+    for ext in ("txt", "pdf", "json", "yaml", "toml", "py"):
+        agent = _make_agent(f'["site:config.{ext} topic query", "valid search query"]')
+        result = await agent.decompose("some topic")
+        assert f"site:config.{ext}" not in " ".join(result), f"site:config.{ext} should be filtered"
+        assert "valid search query" in result
+
+
+@pytest.mark.asyncio
+async def test_decompose_preserves_valid_site_searches():
+    """site: with a real web domain (e.g. site:arxiv.org) must NOT be filtered."""
+    agent = _make_agent('["site:arxiv.org transformer attention 2024", "attention mechanism survey"]')
+    result = await agent.decompose("transformer attention mechanisms")
+    assert result == ["site:arxiv.org transformer attention 2024", "attention mechanism survey"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_all_local_site_falls_back():
+    """If all suggestions are site:local and none remain after filter, fall back to [query]."""
+    agent = _make_agent('["site:purpose.md topic", "site:config.toml settings"]')
+    result = await agent.decompose("What topics does this wiki cover?")
+    assert result == ["What topics does this wiki cover?"]
+
+
+# ── wikipedia URL filter ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_decompose_filters_wikipedia_url():
+    """Suggestions containing a Wikipedia URL must be removed."""
+    agent = _make_agent('["https://en.wikipedia.org/wiki/Knowledge_base", "knowledge base structure"]')
+    result = await agent.decompose("wiki knowledge base")
+    assert result == ["knowledge base structure"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_filters_wikipedia_url_no_scheme():
+    """Wikipedia URL without https:// prefix must also be filtered."""
+    agent = _make_agent('["en.wikipedia.org/wiki/Machine_learning", "machine learning overview"]')
+    result = await agent.decompose("machine learning")
+    assert result == ["machine learning overview"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_filters_other_language_wikipedia():
+    """Non-English Wikipedia domains (fr.wikipedia.org etc.) must also be filtered."""
+    agent = _make_agent('["fr.wikipedia.org/wiki/Apprentissage_automatique", "machine learning survey"]')
+    result = await agent.decompose("machine learning")
+    assert result == ["machine learning survey"]
+
+
+@pytest.mark.asyncio
+async def test_decompose_preserves_non_wikipedia_wiki_urls():
+    """URLs containing 'wiki' that are NOT Wikipedia must NOT be filtered."""
+    agent = _make_agent('["https://wiki.archlinux.org/title/Systemd", "systemd linux service"]')
+    result = await agent.decompose("systemd service management")
+    assert result == ["https://wiki.archlinux.org/title/Systemd", "systemd linux service"]
+
+
 # ── performance ───────────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
What

  Fixes three independent query-accuracy bugs discovered during live testing of the ai-research wiki: false-positive gap detection for wiki-purpose queries, silent omission of the orphan section in lint reports, and a TypeError crash when the LLM returns invalid JSON for search suggestions.

Why

  Live testing with 7 ground-truth queries surfaced each issue. The purpose page (purpose.md) is excluded from BM25 search by design, causing gap detection to always fire on wiki-scope queries even though the answer is available via _purpose_ctx. The lint report silently skipped the orphan section when the count was zero, giving no answer to "What pages are orphan pages?". The search suggestion filter introduced a list comprehension that iterated over None - the documented return value from parse_json_string_array on failure - crashing ingest suggestion on any invalid LLM response.

Changes

 i. Gap detection (query_agent.py)
  - Added "key topics", "topics in this wiki", "topics in my wiki", "wiki purpose", "purpose of this wiki", "purpose of my wiki", "purpose of your wiki", and "summarize wiki" to _WIKI_INTROSPECTIVE_TRIGGERS
  - These phrases suppress gap detection so synthesis runs in normal mode using the pinned _purpose_ctx, not the generic gap-knowledge branch

 ii. Lint report (action_agent.py)
  - Always emit the orphan section: when count is zero, show "Orphan pages (0) - all pages have at least one inbound link." instead of silently omitting it
  - Changed "All clear" guard from if not parts: to _any_issues = bool(state.contradicted or state.orphans or state.adv_pages) so the zero-orphan line doesn't suppress the all-clear message when truly no issues exist

  iii. Search suggestion filter (search_decompose_agent.py)
   - Added _LOCAL_SITE_RE to strip site:<filename>.ext hallucinations (e.g. site:purpose.md)
   - Added _WIKIPEDIA_RE to strip Wikipedia URLs that bypass the prompt instruction
   - Fixed TypeError: 'NoneType' object is not iterable by guarding parse_json_string_array result with or [] before the filter comprehension

   iv. Tests
    - 4 new test_query_agent.py tests covering each new introspective trigger phrase
   - 4 new test_search_decompose_agent.py tests for site:local filter; 4 more for Wikipedia URL filter
   - 1 new test_action_agent.py test asserting "Orphan pages (0)" appears when orphans are empty but other issues exist