### PR TITLE
fix: stale detection, ghost-draft sweep, and skill routing correctness

### DIFF
--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -862,6 +862,10 @@ class IngestAgent:
             )
             result.skipped = True
             result.skip_reason = "out of scope (purpose.md)"
+            # Record the current hash so lint doesn't mark the page stale on the
+            # next run just because the audit DB never saw this file version.
+            await self._audit.record_ingest(src_hash, src_size, source,
+                                            p.stem, result.tokens_used, result.cost_usd)
             return result
         target = decisions.get("target", "")
         new_slug = decisions.get("new_slug") or ""

--- a/synthadoc/agents/lint_agent.py
+++ b/synthadoc/agents/lint_agent.py
@@ -588,21 +588,26 @@ class LintAgent:
 
         # Ghost-draft sweep: DB entries in 'draft' with no corresponding wiki file.
         # This happens when the server is restarted mid-ingest before the file is written.
+        # Candidate pages (wiki/candidates/<slug>.md) are legitimately draft — skip them.
         if self._audit and promote_drafts:
             fs_slugs = set(slugs)
+            candidates_dir = self._wiki_root / "wiki" / "candidates"
             all_states = await self._audit.get_all_page_states()
             for entry in all_states:
-                if entry["state"] == LifecycleState.DRAFT and entry["slug"] not in fs_slugs:
+                slug = entry["slug"]
+                if entry["state"] == LifecycleState.DRAFT and slug not in fs_slugs:
+                    if (candidates_dir / f"{slug}.md").exists():
+                        continue  # staged candidate — not a ghost
                     _log.warning(
                         "lifecycle ghost-draft: slug=%s has no wiki file — archiving "
                         "(ingest was interrupted before file was written)",
-                        entry["slug"],
+                        slug,
                     )
                     await self._audit.set_page_state(
-                        entry["slug"], LifecycleState.ARCHIVED, TriggerSource.LINT
+                        slug, LifecycleState.ARCHIVED, TriggerSource.LINT
                     )
                     await self._audit.record_lifecycle_event(
-                        entry["slug"], LifecycleState.DRAFT, LifecycleState.ARCHIVED,
+                        slug, LifecycleState.DRAFT, LifecycleState.ARCHIVED,
                         "wiki file missing — ingest interrupted before file was written",
                         TriggerSource.LINT,
                     )

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -150,11 +150,18 @@ class SkillAgent:
                         return meta
         if best_url:
             return best_url[1]
-        # Pass 2: intent match
+        # Pass 2: intent match — longest match wins so that more-specific intents
+        # (e.g. "search for" at 9 chars) beat shorter ones (e.g. "pdf" at 3 chars)
+        # that happen to appear as substrings in the query.  Consistent with the
+        # longest-prefix rule already used for URL routing in Pass 1.
+        best_intent: tuple[int, SkillMeta] | None = None
         for meta in self._registry.values():
             for intent in meta.triggers.intents:
                 if intent in s:
-                    return meta
+                    if best_intent is None or len(intent) > best_intent[0]:
+                        best_intent = (len(intent), meta)
+        if best_intent:
+            return best_intent[1]
         raise SkillNotFoundError(source, list(self._registry.keys()))
 
     def get_skill(self, name: str) -> BaseSkill:

--- a/synthadoc/agents/skill_agent.py
+++ b/synthadoc/agents/skill_agent.py
@@ -199,6 +199,11 @@ class SkillAgent:
         s = _normalize_url(source).lower()
         if s.startswith(("http://", "https://")):
             return False
+        # Absolute file paths must never be mis-classified as skill intents,
+        # even when the path contains words that match an intent trigger
+        # (e.g. "pdf" in "turing-enigma.pdf" matching the PDF skill intent).
+        if re.match(r'^[a-z]:[/\\]', s) or s.startswith('/'):
+            return True
         try:
             meta = self.detect_skill(source)
             if any(intent in s for intent in meta.triggers.intents):

--- a/synthadoc/skills/pdf/SKILL.md
+++ b/synthadoc/skills/pdf/SKILL.md
@@ -11,7 +11,6 @@ triggers:
   intents:
     - "pdf"
     - "research paper"
-    - "document"
 requires:
   - pypdf
   - pdfminer.six
@@ -50,7 +49,7 @@ asyncio.run(main())
 ## When this skill is used
 
 - Source path ends with `.pdf`
-- User intent contains: `pdf`, `research paper`, `document`
+- User intent contains: `pdf`, `research paper`
 
 ## Scripts
 

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -235,7 +235,7 @@ class AuditDB:
             db.row_factory = aiosqlite.Row
             async with db.execute(
                 "SELECT source_path, wiki_page, tokens, cost_usd, ingested_at "
-                "FROM ingests ORDER BY id ASC LIMIT ?",
+                "FROM ingests ORDER BY id DESC LIMIT ?",
                 (limit,),
             ) as cur:
                 rows = await cur.fetchall()

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -623,6 +623,51 @@ async def test_purpose_md_filters_out_of_scope_source(tmp_wiki, mock_provider, c
 
 
 @pytest.mark.asyncio
+async def test_skip_records_ingest_in_audit_db(tmp_wiki, mock_provider, cache):
+    """action=skip must still call record_ingest so the audit DB hash stays current.
+
+    Without this, a subsequent lint run will see the audit hash != disk hash and
+    mark the page stale even though nothing actually changed.
+    """
+    import itertools
+    from synthadoc.providers.base import CompletionResponse
+
+    (tmp_wiki / "wiki" / "purpose.md").write_text(
+        "This wiki covers AI only.", encoding="utf-8")
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    source = tmp_wiki / "raw_sources" / "cooking.md"
+    source.write_text("# Pasta Recipes\nHow to make carbonara.", encoding="utf-8")
+
+    entity_resp = CompletionResponse(
+        text='{"entities":["pasta"],"concepts":["cooking"],"tags":["food"]}',
+        input_tokens=10, output_tokens=5)
+    skip_resp = CompletionResponse(
+        text='{"reasoning":"Out of scope","action":"skip","target":"","new_slug":"","update_content":""}',
+        input_tokens=10, output_tokens=5)
+    mock_provider.complete.side_effect = itertools.cycle([entity_resp, skip_resp])
+
+    agent = IngestAgent(provider=mock_provider, store=store, search=search,
+                        log_writer=log, audit_db=audit, cache=cache, max_pages=15,
+                        wiki_root=tmp_wiki)
+    result = await agent.ingest(str(source))
+    assert result.skipped
+
+    # Audit DB must have a record for this source so future lint won't fire stale.
+    record = await audit.find_by_source_path(str(source))
+    assert record is not None, "skip action must still write an audit record"
+    import hashlib
+    expected_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+    assert record["source_hash"] == expected_hash, \
+        "audit record must store the current file hash so lint stale-check passes"
+
+
+@pytest.mark.asyncio
 async def test_purpose_md_absent_does_not_break_ingest(tmp_wiki, mock_provider, cache):
     """No purpose.md — ingest proceeds normally."""
     assert not (tmp_wiki / "wiki" / "purpose.md").exists()

--- a/tests/agents/test_lint_agent.py
+++ b/tests/agents/test_lint_agent.py
@@ -768,3 +768,31 @@ async def test_lint_archives_ghost_draft(tmp_wiki):
     assert report.lifecycle_archived >= 1
     # The real page should be promoted, not affected
     assert report.lifecycle_promoted >= 1
+
+
+@pytest.mark.asyncio
+async def test_lint_does_not_archive_staged_candidates(tmp_wiki):
+    """A draft DB entry whose file exists in wiki/candidates/ is a staged candidate,
+    not a ghost draft — lint must leave it alone."""
+    from synthadoc.storage.log import AuditDB
+    from synthadoc.storage.wiki import WikiStorage
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    audit = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await audit.init()
+
+    # Create the candidate file on disk
+    candidates_dir = tmp_wiki / "wiki" / "candidates"
+    candidates_dir.mkdir(parents=True, exist_ok=True)
+    (candidates_dir / "my-candidate.md").write_text(
+        "---\ntitle: My Candidate\nstatus: draft\n---\n\nContent.\n"
+    )
+    # Seed the DB as draft (as ingest would)
+    await audit.set_page_state("my-candidate", "draft", "ingest")
+
+    log = LogWriter(tmp_wiki / "wiki" / "log.md")
+    agent = LintAgent(provider=AsyncMock(), store=store, log_writer=log, audit_db=audit)
+    await agent.lint(adversarial=False)
+
+    state = await audit.get_page_state("my-candidate")
+    assert state["state"] == "draft", "staged candidate must not be archived by ghost-draft sweep"

--- a/tests/cli/test_audit_cli.py
+++ b/tests/cli/test_audit_cli.py
@@ -24,7 +24,7 @@ async def populated_audit_db(tmp_path):
 async def test_list_ingests_returns_records(populated_audit_db):
     records = await populated_audit_db.list_ingests(limit=10)
     assert len(records) == 3
-    assert records[0]["source_path"] == "/wiki/raw/doc0.pdf"
+    assert records[0]["source_path"] == "/wiki/raw/doc2.pdf"  # DESC order — newest first
     assert "tokens" in records[0]
     assert "cost_usd" in records[0]
     assert "ingested_at" in records[0]

--- a/tests/skills/test_skill_agent.py
+++ b/tests/skills/test_skill_agent.py
@@ -156,6 +156,23 @@ def test_needs_path_resolution_returns_true_for_relative_paths(tmp_wiki):
     assert agent.needs_path_resolution("uploads/batch-001") is True
 
 
+def test_needs_path_resolution_returns_true_for_absolute_paths_with_skill_extension(tmp_wiki):
+    """Absolute paths ending in .pdf (or .docx) must not be mis-classified as
+    skill intents even though 'pdf' is a registered intent trigger."""
+    from synthadoc.agents.skill_agent import SkillAgent
+    agent = SkillAgent(wiki_root=tmp_wiki)
+    # Windows absolute path
+    assert agent.needs_path_resolution(
+        r"C:\Users\user\wikis\my-wiki\raw_sources\report.pdf"
+    ) is True
+    # Unix absolute path
+    assert agent.needs_path_resolution(
+        "/home/user/wiki/raw_sources/paper.pdf"
+    ) is True
+    # Relative path with .pdf should still go through intent check (no change)
+    assert agent.needs_path_resolution("pdf document about AI") is False
+
+
 def test_needs_path_resolution_returns_false_for_web_search_intent(tmp_wiki):
     """Web search intent strings must never be resolved as local file paths."""
     from synthadoc.agents.skill_agent import SkillAgent

--- a/tests/skills/test_skill_agent.py
+++ b/tests/skills/test_skill_agent.py
@@ -52,6 +52,24 @@ def test_intent_dispatch_by_phrase(tmp_wiki):
     assert agent.detect_skill("web search quantum physics").name == "web_search"
 
 
+def test_web_search_intent_beats_pdf_documentation_substring(tmp_wiki):
+    """'search for: ... documentation ...' must route to web_search, not pdf.
+
+    The PDF skill's 'document' intent (now removed) matched 'documentation'
+    as a substring and stole routing from the more-specific 'search for' intent.
+    Longest-match in Pass 2 ensures the more-specific intent wins.
+    """
+    from synthadoc.agents.skill_agent import SkillAgent
+    agent = SkillAgent(wiki_root=tmp_wiki)
+    # Exact pattern from the live failure (search_decompose_agent sub-query)
+    assert agent.detect_skill(
+        "search for: IBM ASCC Harvard Mark I documentation site:ibm.com"
+    ).name == "web_search"
+    assert agent.detect_skill(
+        "search for: site:docs.python.org documentation"
+    ).name == "web_search"
+
+
 def test_intent_dispatch_no_match_raises(tmp_wiki):
     from synthadoc.agents.skill_agent import SkillAgent, SkillNotFoundError
     agent = SkillAgent(wiki_root=tmp_wiki)


### PR DESCRIPTION
What
  
  A few correctness fixes found during live testing on the history-of-computing wiki.

Why

  - alan-turing was persistently marked stale after every lint run, even with the source unchanged. Root cause: absolute PDF paths were misclassified as skill intents, so ingest hashed the path string (83 chars) instead of the file bytes, audit DB stored the wrong hash, lint saw a mismatch, and flagged stale on every run.
  - Staged candidate pages were being archived by the ghost-draft sweep, which only checked the main wiki/ directory for matching files.
  - Search sub-queries containing "documentation" were routed to the PDF skill instead of web_search, "document" in PDF's intent list matched the substring, and Pass 2 used first-registry-match rather than longest-match.
  - list_ingests returned oldest records first, making audit history read bottom-up.

Changes

  - skill_agent.py: short-circuit needs_path_resolution to True for absolute paths (Windows C:\… and Unix /…) before the intent scan, so PDF paths are never mis-routed to the skill intent check
  - skill_agent.py: detect_skill Pass 2 now picks the longest matching intent (consistent with Pass 1's URL longest-prefix rule), so "search for" (9 chars) beats "document" (8 chars) when both are present
  - pdf/SKILL.md: removed "document" from intent triggers - too generic, matched "documentation" as a substring across unrelated queries
  - lint_agent.py: ghost-draft sweep now checks wiki/candidates/<slug>.md before archiving; staged candidates are not ghost drafts
  - storage/log.py: list_ingests ORDER BY id DESC (newest first)
  - Tests: four new/updated tests covering each fix; test_list_ingests_returns_records updated for DESC order