### PR TITLE
fix(gap): Signal 7 + [MISSING:] sentinel to surface Enrich chips for absent entities

### DIFF
--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -305,6 +305,26 @@ def _guard_c_suppress(gap: bool, answer: str, caller: str) -> bool:
     return gap
 
 
+_MISSING_RE = re.compile(r'\[MISSING:\s*([^\]]+)\]\s*$', re.MULTILINE)
+
+
+def _extract_missing_slugs(text: str) -> tuple[list[str], str]:
+    """Extract and strip a [MISSING: slug1, slug2] sentinel appended by the LLM.
+
+    When the synthesis prompt (gap=True branch) asks the LLM to identify absent
+    topics, it appends this marker on its own line.  Guard C may still suppress
+    _gap for a well-cited answer; this sentinel re-enables chip generation for
+    the explicitly-identified missing pages regardless.
+
+    Returns (slugs, cleaned_text).  Returns ([], text) when no sentinel is found.
+    """
+    m = _MISSING_RE.search(text)
+    if not m:
+        return [], text
+    slugs = [s.strip() for s in m.group(1).split(",") if s.strip()]
+    return slugs, text[: m.start()].rstrip()
+
+
 class QueryAgent:
     def __init__(self, provider: LLMProvider, store: WikiStorage,
                  search: HybridSearch,
@@ -515,7 +535,11 @@ class QueryAgent:
             return prefix + (
                 f"The wiki does not yet have a page on this topic. "
                 f"Answer the question using your general knowledge, then note in one sentence "
-                f"that the wiki does not currently cover this topic and suggest the user enriches it.\n\n"
+                f"that the wiki does not currently cover this topic and suggest the user enriches it.\n"
+                f"If the wiki is missing dedicated pages for specific topics central to this question, "
+                f"append on its own line at the very end: [MISSING: topic1, topic2] using short "
+                f"lowercase hyphenated slugs, e.g. [MISSING: iphone, mobile-computing]. "
+                f"Omit the [MISSING] line if the wiki already covers the topic adequately.\n\n"
                 f"Question: {question}\n\n"
                 f"Wiki pages available (unrelated to this question):\n{context}"
             )
@@ -855,6 +879,16 @@ class QueryAgent:
 
         _gap = _guard_c_suppress(_gap, answer_text, "query")
 
+        # [MISSING: ...] sentinel — re-enable gap and chip generation even when
+        # Guard C suppressed it for a well-cited answer.  Strip the marker from
+        # the displayed text so clients never see it.
+        _missing_slugs, answer_text = _extract_missing_slugs(answer_text)
+        if _missing_slugs and not _gap:
+            _gap = True
+            if not _suggested:
+                _suggested = [s.replace("-", " ") for s in _missing_slugs]
+            logger.debug("query: [MISSING] sentinel re-enabled gap — %s", _missing_slugs)
+
         logger.info("query answered — %d page(s) cited, %d tokens",
                     len(citations), resp2.total_tokens)
         return QueryResult(
@@ -1126,6 +1160,10 @@ class QueryAgent:
             len(context), len(candidates),
         )
         full_answer = ""
+        # Hold-back buffer: text accumulated since the last newline, held only when
+        # the line starts with "[" — the sole prefix for "[MISSING: ...]" sentinels.
+        # Non-"[" fragments are flushed immediately so normal streaming is unaffected.
+        _last_line_buf = ""
         async for token in self._provider.complete_stream(
             messages=[Message(role="user", content=synthesis_prompt)],
             temperature=0.0,
@@ -1138,7 +1176,18 @@ class QueryAgent:
                 )
                 _first_token = False
             full_answer += token
-            yield {"event": "token", "data": {"text": token}}
+            combined = _last_line_buf + token
+            if "\n" in combined:
+                parts = combined.split("\n")
+                yield {"event": "token", "data": {"text": "\n".join(parts[:-1]) + "\n"}}
+                _last_line_buf = parts[-1]
+            elif not combined.startswith("["):
+                # Cannot be a [MISSING: ...] sentinel — yield immediately.
+                yield {"event": "token", "data": {"text": combined}}
+                _last_line_buf = ""
+            else:
+                # Starts with "[" — could be the sentinel; hold until newline or end.
+                _last_line_buf = combined
 
         if not _first_token:
             logger.info(
@@ -1151,6 +1200,14 @@ class QueryAgent:
             fallback = "(No response was generated. Please try again.)"
             yield {"event": "token", "data": {"text": fallback}}
             full_answer = fallback
+            _last_line_buf = ""
+
+        # Extract [MISSING: ...] sentinel before Guard B/C so they see clean text.
+        # If the sentinel is present, _last_line_buf holds it — don't emit that line.
+        # If absent, flush _last_line_buf to the client now.
+        _missing_slugs, full_answer = _extract_missing_slugs(full_answer)
+        if not _missing_slugs and _last_line_buf:
+            yield {"event": "token", "data": {"text": _last_line_buf}}
 
         # Guard B: post-synthesis gap detection — same logic as run().
         # Fires when _detect_gap() missed (pre-synthesis, guard A) but the LLM
@@ -1162,19 +1219,28 @@ class QueryAgent:
 
         _gap = _guard_c_suppress(_gap, full_answer, "run_stream")
 
+        # [MISSING: ...] sentinel — re-enable gap and chip generation even when
+        # Guard C suppressed it for a well-cited answer.
+        if _missing_slugs and not _gap:
+            _gap = True
+            logger.debug("run_stream: [MISSING] sentinel re-enabled gap — %s", _missing_slugs)
+
         yield {"event": "citations", "data": {"citations": [] if _gap else citations}}
 
         if _gap:
-            try:
-                # Use the standalone retrieval_question so gap suggestions are meaningful
-                # when the user asked a context-dependent follow-up (e.g. "tell me more
-                # about his death" → rewritten to "How did Alan Turing die?").
-                _suggested = await SearchDecomposeAgent(self._provider).decompose(
-                    retrieval_question, domain_context=_purpose_ctx
-                )
-            except Exception as _exc:
-                logger.warning("run_stream: gap decompose failed, falling back to original question: %s", _exc)
-                _suggested = [retrieval_question]
+            if _missing_slugs:
+                _suggested = [s.replace("-", " ") for s in _missing_slugs]
+            else:
+                try:
+                    # Use the standalone retrieval_question so gap suggestions are meaningful
+                    # when the user asked a context-dependent follow-up (e.g. "tell me more
+                    # about his death" → rewritten to "How did Alan Turing die?").
+                    _suggested = await SearchDecomposeAgent(self._provider).decompose(
+                        retrieval_question, domain_context=_purpose_ctx
+                    )
+                except Exception as _exc:
+                    logger.warning("run_stream: gap decompose failed, falling back to original question: %s", _exc)
+                    _suggested = [retrieval_question]
             logger.debug("run_stream: yielding gap event (%d searches)", len(_suggested))
             yield {"event": "gap", "data": {"suggested_searches": _suggested}}
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -305,7 +305,11 @@ def _guard_c_suppress(gap: bool, answer: str, caller: str) -> bool:
     return gap
 
 
-_MISSING_RE = re.compile(r'\[MISSING:\s*([^\]]+)\]\s*$', re.MULTILINE)
+# Matches [MISSING: slug1, slug2] on its own line.
+# ']' is optional — LLMs sometimes omit the closing bracket.
+# '^' anchor (MULTILINE) ensures we only match at the start of a line,
+# preventing accidental matches in mid-sentence wikilink patterns.
+_MISSING_RE = re.compile(r'^\[MISSING:\s*([^\]\n]+?)(?:\])?\s*$', re.MULTILINE)
 
 
 def _extract_missing_slugs(text: str) -> tuple[list[str], str]:
@@ -316,13 +320,21 @@ def _extract_missing_slugs(text: str) -> tuple[list[str], str]:
     _gap for a well-cited answer; this sentinel re-enables chip generation for
     the explicitly-identified missing pages regardless.
 
+    Handles two LLM failure modes:
+    - Missing closing ']' (']' is optional in the pattern).
+    - Sentinel placed mid-response (before a Sources section) rather than at
+      the very end; content after the sentinel is preserved in cleaned_text.
+
     Returns (slugs, cleaned_text).  Returns ([], text) when no sentinel is found.
     """
     m = _MISSING_RE.search(text)
     if not m:
         return [], text
     slugs = [s.strip() for s in m.group(1).split(",") if s.strip()]
-    return slugs, text[: m.start()].rstrip()
+    before = text[: m.start()].rstrip()
+    after = text[m.end() :].lstrip("\n")
+    cleaned = (before + "\n" + after).strip() if after else before
+    return slugs, cleaned
 
 
 class QueryAgent:
@@ -533,15 +545,18 @@ class QueryAgent:
         prefix = _history_block(history) if history else ""
         if gap:
             return prefix + (
-                f"The wiki does not yet have a page on this topic. "
-                f"Answer the question using your general knowledge, then note in one sentence "
-                f"that the wiki does not currently cover this topic and suggest the user enriches it.\n"
-                f"If the wiki is missing dedicated pages for specific topics central to this question, "
-                f"append on its own line at the very end: [MISSING: topic1, topic2] using short "
-                f"lowercase hyphenated slugs, e.g. [MISSING: iphone, mobile-computing]. "
-                f"Omit the [MISSING] line if the wiki already covers the topic adequately.\n\n"
+                f"The wiki does not yet have a dedicated page on this topic. "
+                f"Answer the question using the wiki pages below and your general knowledge. "
+                f"Note in one sentence that the wiki lacks a dedicated page and suggest the user enriches it.\n"
+                f"If specific topics central to this question have no dedicated wiki page, "
+                f"add this line as the ABSOLUTE LAST line of your response — after Sources, "
+                f"after all citations, after everything else:\n"
+                f"[MISSING: topic1, topic2]\n"
+                f"Use short lowercase hyphenated slugs. The closing ] is required. "
+                f"Example: [MISSING: iphone, mobile-computing]\n"
+                f"Omit the [MISSING] line if the wiki already covers all topics adequately.\n\n"
                 f"Question: {question}\n\n"
-                f"Wiki pages available (unrelated to this question):\n{context}"
+                f"Wiki pages available:\n{context}"
             )
         if system_ctx:
             return prefix + (

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -875,7 +875,7 @@ class QueryAgent:
         self, question: str, candidates: list[SearchResult], max_score: float,
         used_tf_fallback: bool = False,
     ) -> tuple[bool, str, int, int]:
-        """Full 5-signal knowledge gap detection.
+        """Full 7-signal knowledge gap detection.
 
         Returns (gap, discriminating_term, pages_with_overlap, min_specific_qualifying).
         Called by both run() and run_stream() so they share identical detection logic.
@@ -893,6 +893,9 @@ class QueryAgent:
             for c in question
         )
         _key_terms: set[str] = set()
+        # How many times each key term appears in the question / joined sub-questions.
+        # Used by Signal 7 to detect prominent absent entities.
+        _q_term_freq: dict[str, int] = {}
         # All-uppercase terms with bare length 2-5 (USB, TCP, AI, ENIAC…).
         # Tracked separately so signal 6 can fire when a specific acronym or
         # proper-name abbreviation is completely absent from all retrieved pages
@@ -904,6 +907,7 @@ class QueryAgent:
                 if ((len(_w) >= 4 or (len(_w) >= 2 and _w.upper() == _w))
                         and _bare not in _STOPWORDS):
                     _key_terms.add(_bare)
+                    _q_term_freq[_bare] = _q_term_freq.get(_bare, 0) + 1
                     _stripped = _w.rstrip("s'?!.,")
                     if _stripped and _stripped.upper() == _stripped and 2 <= len(_bare) <= 5:
                         _acronym_key_terms.add(_bare)
@@ -976,8 +980,25 @@ class QueryAgent:
                 _term_doc_freq.get(t, 0) == 0
                 for t in _acronym_key_terms
             )
+            # Signal 7: a key term appears in the query but has zero occurrences in
+            # every retrieved page, AND overall coverage is genuinely thin (< 65 % of
+            # candidates are on-topic).  The coverage gate distinguishes genuine gaps
+            # from word-form misses: if the wiki covers the topic but uses a different
+            # form (e.g. "Canadian" vs "Canada", "garden" vs "backyard"), most pages
+            # are still on-topic (≥ 65 %) and the gate stays closed.  65 % is
+            # deliberately lower than the 80 % used by Signal 4 — this catches the
+            # iPhone-style case where ~45–60 % of pages have generic term overlap (from
+            # "mobile", "computing" etc.) but the specific entity is absent.
+            _prominent_term_absent = (
+                _pages_with_overlap < _n_cands * 0.65
+                and any(
+                    _q_term_freq.get(t, 0) >= 1 and _term_doc_freq.get(t, 0) == 0
+                    for t in _key_terms
+                )
+            )
         else:
             _acronym_absent = False
+            _prominent_term_absent = False
 
         gap = self._gap_score_threshold > 0 and (
             (len(candidates) < 3 and not used_tf_fallback)
@@ -986,6 +1007,7 @@ class QueryAgent:
             or _any_term_missing
             or _defining_term_absent
             or _acronym_absent
+            or _prominent_term_absent
         )
         logger.info(
             "query retrieval — pages=%d, max_score=%.2f, "

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -1543,6 +1543,134 @@ async def test_gap_signal5_fires_at_exact_docfreq_cap_boundary(tmp_wiki):
     assert len(result.suggested_searches) >= 1
 
 
+@pytest.mark.asyncio
+async def test_gap_signal7_prominent_entity_absent(tmp_wiki):
+    """Signal 7: gap fires when a key entity term is present in the query but has
+    zero occurrences across all retrieved pages, and overall coverage is below 80%.
+
+    Real-world case: "iPhone" in a history-of-computing wiki.
+    8 of 15 pages mention "mobile" extensively (keeping on_topic_pages=8, which is
+    53% — below the 80% coverage gate). "iPhone" is completely absent (doc_freq=0),
+    mixed-case so Signal 6 (ALL-CAPS only) cannot fire, and appears once in the
+    sub-questions.  Signals 4 and 5 are both suppressed.  Signal 7 catches it.
+
+    Signal breakdown:
+    - Signal 1: 15 candidates ≥ 3 → no fire
+    - Signal 2: gap_score_threshold=0.01 → no fire
+    - Signal 3: on_topic_pages=8 ≥ 2 → no fire
+    - Signal 4: _signal4_active = 8 < 7 → False → no fire
+    - Signal 5: "iphone" doc_freq=0 → excluded from _covered → never seen → no fire
+    - Signal 6: "iphone" is mixed-case → not in _acronym_key_terms → no fire
+    - Signal 7: coverage 8/15=53% < 80%; "iphone" in query, doc_freq=0 → gap=True ✓
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+
+    # 8 pages with extensive "mobile" content — these count as on-topic for the query.
+    mobile_content = (
+        "Mobile computing transformed the technology industry. Mobile devices brought "
+        "computing to users everywhere. The computing industry adapted to mobile "
+        "platforms. Mobile interfaces changed how computing systems interact with users."
+    )
+    for i in range(8):
+        store.write_page(f"mobile-page-{i}", WikiPage(
+            title=f"Mobile Computing {i}", tags=["history"],
+            content=mobile_content,
+            status="active", confidence="high", sources=[],
+        ))
+    # 7 pages about general computing with no mobile-specific content.
+    for i in range(7):
+        store.write_page(f"general-page-{i}", WikiPage(
+            title=f"Computing History {i}", tags=["history"],
+            content=(
+                "Alan Turing proposed the Turing machine as a model of computation. "
+                "John von Neumann designed the stored-program architecture."
+            ),
+            status="active", confidence="high", sources=[],
+        ))
+
+    all_slugs = [f"mobile-page-{i}" for i in range(8)] + [f"general-page-{i}" for i in range(7)]
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    # decompose() returns 2 sub-questions; "iPhone" appears once (as in the live case).
+    provider.complete.side_effect = [
+        CompletionResponse(
+            text=(
+                '["What was the significance of the iPhone in the history of computing? '
+                'How did the rise of mobile computing impact the history of computing?"]'
+            ),
+            input_tokens=10, output_tokens=20,
+        ),
+        # SearchDecomposeAgent call for suggestions (gap triggered):
+        CompletionResponse(
+            text='["iPhone history timeline", "Apple mobile computing 2007"]',
+            input_tokens=8, output_tokens=8,
+        ),
+        CompletionResponse(
+            text="No iPhone information found in this wiki.",
+            input_tokens=80, output_tokens=15,
+        ),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)  # signal 2 disabled
+    with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
+        result = await agent.query(
+            "What was the significance of the iPhone and the rise of mobile computing?"
+        )
+    # Signal 7: coverage 8/15 < 80%; "iphone" in query, doc_freq=0 across all pages.
+    assert result.knowledge_gap is True
+    assert len(result.suggested_searches) >= 1
+
+
+@pytest.mark.asyncio
+async def test_gap_signal7_no_false_positive_when_entity_present(tmp_wiki):
+    """Signal 7 must NOT fire when the repeated entity term exists in retrieved pages.
+
+    Same query structure (entity repeated ≥2× in sub-questions), but the wiki has
+    pages that actually contain the entity term — doc_freq > 0 → Signal 7 cannot fire.
+    All other signals also stay silent (adequate coverage), so gap=False.
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+
+    # Pages that actually cover "turing" (the entity in question).
+    turing_content = (
+        "Alan Turing proposed the Turing machine as a theoretical model of computation. "
+        "Turing's work on computability laid the foundation for modern computer science. "
+        "The Turing test remains a benchmark for machine intelligence. "
+        "Turing contributed to cryptography at Bletchley Park during World War II."
+    )
+    for i in range(8):
+        store.write_page(f"turing-page-{i}", WikiPage(
+            title=f"Alan Turing {i}", tags=["history"],
+            content=turing_content,
+            status="active", confidence="high", sources=[],
+        ))
+
+    all_slugs = [f"turing-page-{i}" for i in range(8)]
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    # Sub-questions repeat "turing" / "Turing" multiple times.
+    provider.complete.side_effect = [
+        CompletionResponse(
+            text=(
+                '["What did Turing contribute to computer science? '
+                'How did Turing develop the Turing machine? '
+                'What was Turing\'s role in World War II cryptography?"]'
+            ),
+            input_tokens=10, output_tokens=15,
+        ),
+        CompletionResponse(
+            text="Alan Turing was a pioneering computer scientist.",
+            input_tokens=80, output_tokens=15,
+        ),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)  # signal 2 disabled
+    with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
+        result = await agent.query("What were Alan Turing's main contributions?")
+    # "turing" appears in all 8 pages → doc_freq=8 > 0 → Signal 7 does not fire.
+    assert result.knowledge_gap is False
+
+
 # ── CJK (Chinese / Japanese / Korean) coverage ───────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -1671,6 +1671,103 @@ async def test_gap_signal7_no_false_positive_when_entity_present(tmp_wiki):
     assert result.knowledge_gap is False
 
 
+# ── [MISSING: ...] sentinel ───────────────────────────────────────────────────
+
+def test_extract_missing_slugs_present():
+    """[MISSING: slug1, slug2] is extracted and stripped from the answer text."""
+    from synthadoc.agents.query_agent import _extract_missing_slugs
+    text = "Good answer citing [[page]].\n\n[MISSING: iphone, mobile-computing]"
+    slugs, cleaned = _extract_missing_slugs(text)
+    assert slugs == ["iphone", "mobile-computing"]
+    assert "[MISSING:" not in cleaned
+    assert "Good answer" in cleaned
+
+
+def test_extract_missing_slugs_absent():
+    """Returns empty list and original text when no [MISSING:] sentinel is present."""
+    from synthadoc.agents.query_agent import _extract_missing_slugs
+    text = "Good answer with no sentinel."
+    slugs, cleaned = _extract_missing_slugs(text)
+    assert slugs == []
+    assert cleaned == "Good answer with no sentinel."
+
+
+def test_extract_missing_slugs_single():
+    """Single slug without comma is still extracted correctly."""
+    from synthadoc.agents.query_agent import _extract_missing_slugs
+    text = "Answer text.\n[MISSING: iphone]"
+    slugs, cleaned = _extract_missing_slugs(text)
+    assert slugs == ["iphone"]
+    assert cleaned == "Answer text."
+
+
+@pytest.mark.asyncio
+async def test_missing_sentinel_generates_enrich_chips_after_guard_c(tmp_wiki):
+    """[MISSING: ...] appended by the LLM re-enables gap chips even when Guard C
+    suppressed _gap for a well-cited answer.  The sentinel must NOT appear in
+    the token stream emitted to clients."""
+    # Answer body: >800 chars + a [[wikilink]] citation → Guard C HIGH_CONF path.
+    body = "Detailed answer about mobile computing history. " * 22  # ~1056 chars
+    llm_tokens = [body + "[[some-page]]\n\n", "[MISSING: iphone, mobile-computing]"]
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    # Empty wiki → 0 candidates → Signal 1 fires → _gap=True pre-synthesis.
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.return_value = CompletionResponse(
+        text='["What was the significance of the iPhone?"]',
+        input_tokens=5, output_tokens=5,
+    )
+
+    async def _gap_stream(**kw):
+        for tok in llm_tokens:
+            yield tok
+
+    provider.complete_stream = _gap_stream
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)
+
+    events = await _collect_events(agent.run_stream("What was the iPhone's significance?"))
+
+    token_text = "".join(
+        e["data"]["text"] for e in events if e.get("event") == "token"
+    )
+    gap_events = [e for e in events if e.get("event") == "gap"]
+
+    assert "[MISSING:" not in token_text, "sentinel must not be streamed to clients"
+    assert len(gap_events) == 1, "gap event must fire"
+    assert gap_events[0]["data"]["suggested_searches"] == ["iphone", "mobile computing"]
+
+
+@pytest.mark.asyncio
+async def test_missing_sentinel_absent_guard_c_suppresses_normally(tmp_wiki):
+    """When no [MISSING:] sentinel is present and Guard C suppresses, no gap chips appear."""
+    # Answer body: >800 chars + citation → Guard C HIGH_CONF suppresses gap.
+    body = "Detailed answer about computing history. " * 22
+    llm_tokens = [body + "[[some-page]]"]
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.return_value = CompletionResponse(
+        text='["What was the significance of mobile computing?"]',
+        input_tokens=5, output_tokens=5,
+    )
+
+    async def _gap_stream(**kw):
+        for tok in llm_tokens:
+            yield tok
+
+    provider.complete_stream = _gap_stream
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)
+
+    events = await _collect_events(agent.run_stream("What is mobile computing?"))
+
+    gap_events = [e for e in events if e.get("event") == "gap"]
+    assert len(gap_events) == 0, "Guard C suppressed gap — no chips should appear"
+
+
 # ── CJK (Chinese / Japanese / Korean) coverage ───────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -1701,6 +1701,31 @@ def test_extract_missing_slugs_single():
     assert cleaned == "Answer text."
 
 
+def test_extract_missing_slugs_missing_closing_bracket():
+    """LLMs sometimes omit the closing ']' — extraction must still succeed."""
+    from synthadoc.agents.query_agent import _extract_missing_slugs
+    text = "Good answer.\n\n[MISSING: iphone, mobile-computing"
+    slugs, cleaned = _extract_missing_slugs(text)
+    assert slugs == ["iphone", "mobile-computing"]
+    assert "[MISSING:" not in cleaned
+
+
+def test_extract_missing_slugs_mid_response_preserves_trailing_content():
+    """When the sentinel appears mid-response (e.g. before a Sources section),
+    text after the sentinel must be preserved in the cleaned answer."""
+    from synthadoc.agents.query_agent import _extract_missing_slugs
+    text = (
+        "Detailed answer.\n\n"
+        "[MISSING: iphone]\n\n"
+        "Sources: [[page1]], [[page2]]"
+    )
+    slugs, cleaned = _extract_missing_slugs(text)
+    assert slugs == ["iphone"]
+    assert "[MISSING:" not in cleaned
+    assert "Sources:" in cleaned
+    assert "Detailed answer" in cleaned
+
+
 @pytest.mark.asyncio
 async def test_missing_sentinel_generates_enrich_chips_after_guard_c(tmp_wiki):
     """[MISSING: ...] appended by the LLM re-enables gap chips even when Guard C


### PR DESCRIPTION
What
  Fixes two related knowledge-gap detection failures: a false negative where mixed-case entity terms (e.g. "iPhone") were invisible to all six pre-synthesis gap signals, and a silent suppression where Guard C correctly identified a well-cited answer but discarded the LLM's own gap note without generating Enrich chips.

Why
  Queries like "What was the significance of the iPhone?" returned gap=False because "iphone" had doc_freq=0,  completely absent from every retrieved page, making it invisible to Signals 4 and 5 (which only operate on terms with at least one wiki occurrence). Guard B could catch it via the [GAP] sentinel, but only when the LLM refused to answer. When the wiki had enough related pages for the LLM to synthesize a substantive response, Guard C suppressed the gap and no ingest recommendation was ever shown, even when the LLM itself wrote "the wiki has no dedicated page on iPhone."

Changes
  i. Signal 7: pre-synthesis gap detection for absent entities (query_agent.py)
     - Added _q_term_freq dict counting how many times each key term appears in the joined sub-questions.
     - Signal 7 fires when: a key term has doc_freq=0 across all wiki pages AND fewer than 65% of retrieved candidates are on-topic (coverage gate distinguishes genuine gaps from word-form misses like "Canada"/"Canadian").
     - Threshold ≥1 occurrence in sub-questions catches entities in 2-sub-question decompositions.

   ii. [MISSING: ...] sentinel: post-synthesis chip generation (query_agent.py)
      - _extract_missing_slugs(): new helper extracting and stripping [MISSING: slug1, slug2] from answer text; handles missing ] (LLM formatting failure) and mid-response placement (sentinel before Sources section).
      - Synthesis prompt (gap=True branch) now instructs the LLM to append the sentinel as the absolute last line, after all citations.
      - Hold-back buffer in run_stream(): lines starting with [ are held until stream end and silently dropped if they match the sentinel, the marker never reaches CLI, web UI, or Obsidian.
      - After Guard C runs, if _missing_slugs is non-empty: _gap is re-enabled and a gap event fires with suggested_searches derived from the slugs; same logic in query() (non-streaming path). 

   iii. Tests (test_query_agent.py)
      - test_gap_signal7_prominent_entity_absent: 8/15 pages on-topic (53%), "iphone" in sub-questions, doc_freq=0 → gap=True.
      - test_gap_signal7_no_false_positive_when_entity_present: 8/8 on-topic, "turing" has doc_freq=8 → gap=False.
      - test_extract_missing_slugs_*: 5 unit tests covering present/absent sentinel, single slug, missing ], and mid-response placement.
      - test_missing_sentinel_generates_enrich_chips_after_guard_c: full streaming integration — confirms sentinel is not in token stream and gap event fires with correct slugs.
      - test_missing_sentinel_absent_guard_c_suppresses_normally: confirms Guard C suppression is not regressed.