### PR TITLE
fix(tests): use SelectorEventLoop for Windows benchmark and stable UR…

### DIFF
--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -441,23 +441,24 @@ async def run_tests():
 
             # ── 13. synthadoc_ingest ─────────────────────────────────────────
             print("\n[13] synthadoc_ingest")
-            # ingest via a search intent with max_results=2 to cap child jobs
-            r = await call(session, "synthadoc_ingest",
-                           {"source": "search for: Harvard Mark I electromechanical computer 1944",
-                            "max_results": 2})
+            # ingest a direct, stable Wikipedia URL — avoids third-party timeouts
+            # that plagued the old "search for: Harvard Mark I" search-intent form
+            # (search results returned unreliable domains like devx.com that timed out)
+            _INGEST_URL = "https://en.wikipedia.org/wiki/Harvard_Mark_I"
+            r = await call(session, "synthadoc_ingest", {"source": _INGEST_URL})
             if "job_id" in r and "source" in r:
-                ok("synthadoc_ingest(search intent)", f"job_id={r['job_id']!r}")
-                info("Waiting for parent + ≤2 child jobs to reach terminal state (max 3 min)…")
+                ok("synthadoc_ingest(url)", f"job_id={r['job_id']!r}  source={r['source']!r}")
+                info("Waiting for ingest job to reach terminal state (max 3 min)…")
                 _done = await _wait_all_terminal(r["job_id"])
                 if _done:
-                    info("All ingest jobs reached terminal state")
+                    info("Ingest job reached terminal state")
                 else:
-                    warn("synthadoc_ingest(search intent)",
-                         "Jobs still running after 3 min — check the Jobs panel")
+                    warn("synthadoc_ingest(url)",
+                         "Job still running after 3 min — check the Jobs panel")
             elif "error" in r:
-                fail("synthadoc_ingest(search intent)", r["error"])
+                fail("synthadoc_ingest(url)", r["error"])
             else:
-                fail("synthadoc_ingest(search intent)", f"unexpected: {r}")
+                fail("synthadoc_ingest(url)", f"unexpected: {r}")
 
             # empty source — quality check
             r = await call(session, "synthadoc_ingest", {"source": ""})

--- a/tests/performance/test_query_cache_perf.py
+++ b/tests/performance/test_query_cache_perf.py
@@ -77,6 +77,15 @@ async def _make_cache(tmp_path: Path) -> CacheManager:
     return db
 
 
+def _new_sync_loop() -> asyncio.AbstractEventLoop:
+    # ProactorEventLoop (IOCP) on Windows hangs when run_until_complete() is
+    # called repeatedly in a tight loop alongside aiosqlite's worker thread.
+    # SelectorEventLoop avoids this; it works correctly on all Python versions.
+    if platform.system() == "Windows":
+        return asyncio.SelectorEventLoop()
+    return asyncio.new_event_loop()
+
+
 def _percentile(data: list[float], pct: float) -> float:
     idx = max(0, int(pct * len(data)) - 1)
     return sorted(data)[idx]
@@ -383,7 +392,7 @@ async def test_epoch_bump_invalidates_instantly(tmp_path):
 
 def test_cache_read_benchmark(benchmark, tmp_path):
     """Steady-state get_query() throughput — run with --benchmark-only."""
-    loop = asyncio.new_event_loop()
+    loop = _new_sync_loop()
     cache = loop.run_until_complete(_make_cache(tmp_path))
     k = make_query_cache_key("What is Moore's Law?", epoch=0)
     loop.run_until_complete(cache.set_query(k, epoch=0, result=_RESULT))
@@ -399,7 +408,7 @@ def test_cache_read_benchmark(benchmark, tmp_path):
 
 def test_cache_write_benchmark(benchmark, tmp_path):
     """Steady-state set_query() throughput — run with --benchmark-only."""
-    loop = asyncio.new_event_loop()
+    loop = _new_sync_loop()
     cache = loop.run_until_complete(_make_cache(tmp_path))
     counter = [0]
 


### PR DESCRIPTION
…windows timeout: test_query_cache_perf.py; test fetch failure for live ingest test

- Replace asyncio.new_event_loop() with SelectorEventLoop on Windows in benchmark tests; ProactorEventLoop (IOCP) hangs under repeated run_until_complete() calls alongside aiosqlite's worker thread
- Replace search-intent ingest in live MCP test with a direct Wikipedia URL to avoid non-deterministic third-party timeouts (devx.com ReadTimeout)