### PR TITLE
fix(gap detection): eliminate false-positive knowledge gap chips across analytical query types

### DIFF
--- a/docs/example/aquaflow/README.md
+++ b/docs/example/aquaflow/README.md
@@ -28,18 +28,27 @@ The ingest agent decides autonomously whether each source should create a new pa
 
 ## Prerequisites
 
+- Python 3.11+ — [download at python.org](https://www.python.org/downloads/). `pip install synthadoc` will fail immediately on older versions; Python itself is never installed automatically by pip.
 - Synthadoc installed (`pip install synthadoc` or editable dev install — see the [main README](../../../README.md#installation))
-- A supported LLM API key with sufficient quota — Anthropic, OpenAI, or MiniMax paid tiers are recommended. Free-tier models such as Gemini Free or Groq Free have daily rate limits that are too low to complete the batch ingest of eight documents in a single session and will cause jobs to fail mid-run.
-- Python 3.11+
+- A supported LLM API key with sufficient quota — [MiniMax](https://platform.minimax.io/), [Qwen](https://bailian.console.aliyun.com/), [Anthropic](https://console.anthropic.com/), or [OpenAI](https://platform.openai.com/api-keys) paid tiers are recommended (ordered lowest to highest cost). Free-tier models such as Gemini Free or Groq Free have daily rate limits that are too low to complete the batch ingest of eight documents in a single session and will cause jobs to fail mid-run. See the [main README — Set your API keys](../../../README.md#set-your-api-keys) for the full provider list including free-tier options.
+- **Obsidian** *(optional)* — [download at obsidian.md](https://obsidian.md). Required only if you want to follow the Obsidian plugin path in Steps 6–10. Every step also provides an equivalent terminal command; Obsidian is not needed to complete the walkthrough.
+
+> **Windows users:** Commands in this walkthrough use Unix-style paths (`~/wikis`). In **Command Prompt** substitute `%USERPROFILE%\wikis`; in **PowerShell** `~\wikis` works directly. Multi-line `\` continuations used in the bash blocks do not work in Command Prompt — use the single-line Windows form shown where applicable.
 
 ---
 
 ## Step 1 — Install the wiki domain
 
+**macOS / Linux / PowerShell:**
 ```bash
 synthadoc install aquaflow \
   --target ~/wikis \
   --domain "Private equity M&A due diligence — LBO modeling, quality of earnings, covenant analysis, ESG, and legal DD"
+```
+
+**Windows Command Prompt:**
+```cmd
+synthadoc install aquaflow --target %USERPROFILE%\wikis --domain "Private equity M&A due diligence — LBO modeling, quality of earnings, covenant analysis, ESG, and legal DD"
 ```
 
 **What this does:**
@@ -168,14 +177,16 @@ To run in the background and keep your terminal free:
 synthadoc serve --background
 ```
 
-Verify the server is up:
+Verify the server is up. The startup banner prints the actual port on the **`Port:`** line — use that number in the URL. The default is `7070`:
 
 ```bash
 curl http://127.0.0.1:7070/health
 # → {"status":"ok"}
 ```
 
-Leave this running for the remaining steps.
+If you configured a different port in `config.toml`, substitute it: `curl http://127.0.0.1:<port>/health`.
+
+Keep the server running for the rest of this walkthrough. Steps 6–10 (ingest, scaffold, lint, routing, and query) all submit jobs through this server — they will fail with a connection error if it is stopped.
 
 ---
 
@@ -185,15 +196,20 @@ Ingest all eight sources. You can do this from the terminal or the Obsidian plug
 
 **Terminal — batch ingest the entire folder:**
 
+First change to the wiki root, then run the ingest:
+
 ```bash
+cd ~/wikis/aquaflow
 synthadoc ingest raw_sources/
 ```
+
+**Windows Command Prompt:** `cd %USERPROFILE%\wikis\aquaflow`
 
 **Obsidian plugin — batch ingest from the command palette:**
 
 1. Open the wiki vault in Obsidian — select the wiki root folder (`~/wikis/aquaflow/`)
 2. Press `Cmd/Ctrl+P` → search **Synthadoc: Ingest...** → Enter
-3. Select the **All raw_sources** tab → click **Run**
+3. Select the **All raw_sources** tab → click **Ingest all**
 
 The plugin sends the same ingest job to the running server — behaviour is identical to the CLI.
 
@@ -221,7 +237,7 @@ Page lifecycle:
   draft   8
 ```
 
-> **Force re-ingest:** If you update a source file or want to regenerate a page, the dedup guard is bypassed and the page is regenerated. Run it from the terminal with `synthadoc ingest <file> --force`, or from the Obsidian plugin: `Cmd/Ctrl+P` → **Synthadoc: Ingest...** → **All raw_sources** tab → check **Force re-ingest** → click **Run**. The `sources` list on the page automatically deduplicates by `(file, hash)` — re-ingesting the same unchanged file never adds a duplicate source entry.
+> **Force re-ingest:** If you update a source file or want to regenerate a page, the dedup guard is bypassed and the page is regenerated. Run it from the terminal with `synthadoc ingest <file> --force`, or from the Obsidian plugin: `Cmd/Ctrl+P` → **Synthadoc: Ingest...** → **All raw_sources** tab → check **Force re-ingest** → click **Ingest all**. The `sources` list on the page automatically deduplicates by `(file, hash)` — re-ingesting the same unchanged file never adds a duplicate source entry.
 
 ---
 

--- a/docs/example/aquaflow/README.md
+++ b/docs/example/aquaflow/README.md
@@ -409,7 +409,7 @@ Expected: Contract review (permits, concessions, service agreements), environmen
 
 **Q5. What EBITDA multiple range is cited for water infrastructure exit valuations?**
 
-Expected: 7–12x EBITDA depending on growth, margin quality, and revenue predictability. PFAS-exposed water treatment companies noted as commanding premiums to traditional industrial multiples given regulatory tailwinds. Sources cited: `leveraged-buyout-lbo`, `exit-strategies-and-valuation-benchmarks`.
+Expected: Sector range 7.0x (low) to 12.5x (high) with a 9.0x median; mid-market water treatment comparables cluster at 8.5–11x EV/EBITDA. PFAS-exposed companies command premiums to traditional industrial multiples given regulatory tailwinds. Source cited: `exit-strategies-and-valuation-benchmarks`.
 
 ---
 

--- a/docs/example/aquaflow/README.md
+++ b/docs/example/aquaflow/README.md
@@ -4,7 +4,7 @@
 
 The scenario: AquaFlow Capital is evaluating an LBO of AquaFlow Systems Inc., a mid-market water treatment equipment company. Eight deal documents are sitting in a folder — company profile, sector analysis, LBO mechanics, covenant framework, QoE guide, ESG standards, legal DD process, and exit benchmarks. By the end of this walkthrough, all eight are ingested into a working knowledge wiki, lint-validated, and queryable in natural language, including Chinese.
 
-Steps 1–3 (install, configure, register) require a terminal. From Step 6 onward, ingest, scaffold, and lint can all run from either the terminal or the Obsidian plugin command palette — both paths are shown where relevant. Queries run through the Synthadoc web UI in Step 10.
+Steps 1–3 (install, configure, register) require a terminal. From Step 6 onward, ingest, scaffold, and lint can all run from either the terminal or the Obsidian plugin command palette — both paths are shown where relevant. Queries run through the Synthadoc web UI in Step 11.
 
 ---
 
@@ -186,7 +186,7 @@ curl http://127.0.0.1:7070/health
 
 If you configured a different port in `config.toml`, substitute it: `curl http://127.0.0.1:<port>/health`.
 
-Keep the server running for the rest of this walkthrough. Steps 6–10 (ingest, scaffold, lint, routing, and query) all submit jobs through this server — they will fail with a connection error if it is stopped.
+Keep the server running for the rest of this walkthrough. Steps 6–11 (ingest, scaffold, lint, routing, citations, and query) all submit jobs through this server — they will fail with a connection error if it is stopped.
 
 ---
 
@@ -338,20 +338,7 @@ synthadoc routing clean
 
 ---
 
-## Step 10 — Open the web UI and run queries
-
-With the server running from Step 5, open the web UI:
-
-```bash
-synthadoc web
-```
-
-Your browser opens automatically at `http://127.0.0.1:7070`. The web UI has two entry points:
-
-- **Chat** — type a natural-language question; the answer streams back token by token with inline citations
-- **Knowledge Graph** — a D3.js visualisation of all pages and their wikilink relationships; click any node to use that page as the scoped entry point for your query
-
-### Citations
+## Step 10 — Review citations
 
 Every answer includes inline citations in the format `^[filename:L-L]`, where `filename` is the source document and `L-L` is the line range in that file. In the web UI these render as superscripts you can hover or click to see the original passage. In Obsidian they render as footnotes. Citations give you a direct audit trail from every claim back to the source line — essential for M&A due diligence where verifiability matters.
 
@@ -363,13 +350,28 @@ Open the command palette → **Synthadoc: View Page Provenance**. A sortable, pa
 
 ```bash
 # All citations for one page
-synthadoc audit citations --page leveraged-buyout-lbo
+synthadoc audit citations --page quality-of-earnings
 
 # Citations that failed validation across the whole wiki
 synthadoc audit citations --broken
 ```
 
-![Page Provenance panel in Obsidian showing citation audit trail for the LBO page](png/page-level-citation.png)
+![Page Provenance panel in Obsidian showing citation audit trail for the QoE page](png/page-level-citation.png)
+
+---
+
+## Step 11 — Open the web UI and run queries
+
+With the server running from Step 5, open the web UI:
+
+```bash
+synthadoc web
+```
+
+Your browser opens automatically at `http://127.0.0.1:7070`. The web UI has two entry points:
+
+- **Chat** — type a natural-language question; the answer streams back token by token with inline citations
+- **Knowledge Graph** — a D3.js visualisation of all pages and their wikilink relationships; click any node to use that page as the scoped entry point for your query
 
 ---
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -128,6 +128,14 @@ _STOPWORDS = frozenset({
     "step", "steps", "stage", "stages", "phase", "phases",
     "approach", "approaches", "method", "methods", "technique", "techniques",
     "process", "processes", "procedure", "procedures",
+    # Comparative/analytical framers: "How does X compare to Y?", "What does
+    # that imply for Z?", "What does X suggest about Y?" — these describe the
+    # type of reasoning requested, not content wiki pages repeat ≥2 times.
+    "compare", "compares", "compared", "comparison", "comparisons",
+    "imply", "implies", "implied", "implication", "implicates",
+    "suggest", "suggests", "suggested", "suggestion",
+    "indicate", "indicates", "indicated", "indication",
+    "infer", "infers", "inferred", "inference",
     # Contribution/achievement verbs common in biographical queries
     # ("What did X contribute to Y?", "What did X achieve?") — wiki pages
     # describe actions with specific verbs ("invented", "built") instead.

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -116,12 +116,18 @@ _STOPWORDS = frozenset({
     "shape", "drive", "change", "enable", "allow", "improve", "evolve",
     "influence", "affect", "impact", "cause", "result", "matter", "relate",
     "connect", "involve", "emerge", "remain",
-    # Analysis/evaluation verbs introduced by sub-question decomposition
-    # ("How is X assessed?", "How do we evaluate Y?") — these never repeat
-    # twice in a wiki page about the topic and produce Signal 5 false positives.
+    # Analysis/evaluation verbs and structural framing nouns introduced by
+    # sub-question decomposition ("How is X assessed?", "What are the components
+    # of Y?") — these never repeat twice in a wiki page and cause Signal 5
+    # false positives when they become the discriminating term.
     "assess", "assessed", "evaluate", "evaluated", "determine", "determined",
     "measure", "measured", "identify", "identified", "analyze", "analysed",
     "analyze", "analyzed", "examine", "examined", "review", "reviewed",
+    "component", "components", "aspect", "aspects", "element", "elements",
+    "feature", "features", "factor", "factors", "part", "parts",
+    "step", "steps", "stage", "stages", "phase", "phases",
+    "approach", "approaches", "method", "methods", "technique", "techniques",
+    "process", "processes", "procedure", "procedures",
     # Contribution/achievement verbs common in biographical queries
     # ("What did X contribute to Y?", "What did X achieve?") — wiki pages
     # describe actions with specific verbs ("invented", "built") instead.

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -157,13 +157,19 @@ _STOPWORDS = frozenset({
     "metric", "metrics", "kpi", "kpis", "indicator", "indicators",
     "statistic", "statistics", "figure", "figures",
     # Structural query framers: "Give me an overview/summary/breakdown/profile of X."
-    # "What are the workstreams/considerations/criteria for Y?" — M&A jargon that
-    # describes how the user wants the answer structured, not recurring page content.
+    # "What are the workstreams/considerations/criteria/package for Y?" — M&A jargon
+    # that describes how the user wants the answer structured, not recurring page content.
     "overview", "summary", "summaries", "breakdown", "breakdowns",
     "profile", "profiles", "highlight", "highlights",
     "workstream", "workstreams",
     "consideration", "considerations",
     "criterion", "criteria",
+    "package", "packages",
+    "structure", "structures",
+    # Norm-seeking framers: "What is typical/standard/common for X?" — these ask for
+    # general practice, not content that pages repeat ≥2 times.
+    "typical", "standard", "common", "usual", "normal",
+    "general", "generally", "typically", "commonly", "usually",
     # Temporal-horizon qualifiers: "near-term", "long-term", "short-term" etc.
     # Hyphens are replaced with spaces during bare-form extraction, so these
     # become two-word key terms like "near term".  Wiki pages rarely repeat a

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -116,6 +116,12 @@ _STOPWORDS = frozenset({
     "shape", "drive", "change", "enable", "allow", "improve", "evolve",
     "influence", "affect", "impact", "cause", "result", "matter", "relate",
     "connect", "involve", "emerge", "remain",
+    # Analysis/evaluation verbs introduced by sub-question decomposition
+    # ("How is X assessed?", "How do we evaluate Y?") — these never repeat
+    # twice in a wiki page about the topic and produce Signal 5 false positives.
+    "assess", "assessed", "evaluate", "evaluated", "determine", "determined",
+    "measure", "measured", "identify", "identified", "analyze", "analysed",
+    "analyze", "analyzed", "examine", "examined", "review", "reviewed",
     # Contribution/achievement verbs common in biographical queries
     # ("What did X contribute to Y?", "What did X achieve?") — wiki pages
     # describe actions with specific verbs ("invented", "built") instead.

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -1045,16 +1045,16 @@ class QueryAgent:
                     for _t in _specific:
                         if _t in _t_norm:
                             _title_covered.add(_t)
-            _defining_term_absent = (
-                bool(_specific)
-                and len(_term_doc_freq) >= 2
-                and any(
-                    _term_qualifying_pages[t] == 0
-                    and _specific[t] <= _signal5_doc_freq_cap
-                    and t not in _title_covered
-                    for t in _term_qualifying_pages
-                )
-            )
+            _signal5_triggers = [
+                t for t in _term_qualifying_pages
+                if _term_qualifying_pages[t] == 0
+                and _specific[t] <= _signal5_doc_freq_cap
+                and t not in _title_covered
+            ]
+            if _signal5_triggers:
+                logger.debug("signal5 candidates: %r (cap=%d, title_covered=%r)",
+                             _signal5_triggers, _signal5_doc_freq_cap, sorted(_title_covered))
+            _defining_term_absent = bool(_specific) and len(_term_doc_freq) >= 2 and bool(_signal5_triggers)
             # Signal 6: a specific acronym or proper-name abbreviation typed
             # ALL-CAPS in the query (USB, TCP, ENIAC, AI…) has zero occurrences
             # across all retrieved pages — the wiki simply does not cover this

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -130,13 +130,19 @@ _STOPWORDS = frozenset({
     "approach", "approaches", "method", "methods", "technique", "techniques",
     "process", "processes", "procedure", "procedures",
     # Comparative/analytical framers: "How does X compare to Y?", "What does
-    # that imply for Z?", "What does X suggest about Y?" — these describe the
-    # type of reasoning requested, not content wiki pages repeat ≥2 times.
+    # that imply for Z?", "What does X suggest about Y?", "How do X translate
+    # into Y?" — these describe the type of reasoning requested, not content
+    # wiki pages repeat ≥2 times.
     "compare", "compares", "compared", "comparison", "comparisons",
     "imply", "implies", "implied", "implication", "implicates",
     "suggest", "suggests", "suggested", "suggestion",
     "indicate", "indicates", "indicated", "indication",
     "infer", "infers", "inferred", "inference",
+    "translate", "translates", "translated", "translation",
+    # Category abbreviations used in sub-questions by LLM decomposition but
+    # not specific named entities: "M&A deal", "ESG risks in M&A" etc.
+    # Signal 6 (acronym absent) should not fire for these domain category terms.
+    "m&a",
     # Contribution/achievement verbs common in biographical queries
     # ("What did X contribute to Y?", "What did X achieve?") — wiki pages
     # describe actions with specific verbs ("invented", "built") instead.
@@ -1000,8 +1006,11 @@ class QueryAgent:
         if not _contains_cjk:
             for _w in question.split():
                 _bare = _w.lower().rstrip("s'?!.,").replace("-", " ")
+                # Check both the bare form AND the original lowercased word: "does"
+                # strips to "doe" which is not in _STOPWORDS, but "does" is.
                 if ((len(_w) >= 4 or (len(_w) >= 2 and _w.upper() == _w))
-                        and _bare not in _STOPWORDS):
+                        and _bare not in _STOPWORDS
+                        and _w.lower() not in _STOPWORDS):
                     _key_terms.add(_bare)
                     _q_term_freq[_bare] = _q_term_freq.get(_bare, 0) + 1
                     _stripped = _w.rstrip("s'?!.,")

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -595,9 +595,13 @@ class QueryAgent:
         gap_sentinel: bool = False,
         history: list[dict] | None = None,
     ) -> str:
-        """Build the LLM synthesis prompt. gap_sentinel=True adds the [GAP] marker
-        instruction used by run() for post-synthesis gap override; run_stream() omits it.
-        When history is provided it is prepended as a conversation context block."""
+        """Build the LLM synthesis prompt.
+
+        gap_sentinel adds the [GAP] marker instruction for post-synthesis gap override
+        (Guard B).  Callers leave it False so _detect_gap() is the sole gap arbiter —
+        instructing the LLM to self-signal gaps produces false positives when the query
+        framing is slightly different from the wiki's phrasing (e.g. "near-term demand"
+        vs. "regulatory drivers").  When history is provided it is prepended."""
         prefix = _history_block(history) if history else ""
         if gap:
             return prefix + (
@@ -931,7 +935,6 @@ class QueryAgent:
         synthesis_prompt = self._build_synthesis_prompt(
             question, context,
             gap=_gap, system_ctx=_system_ctx, is_live_data=_is_live_data,
-            gap_sentinel=True,
             history=_trimmed_history if _trimmed_history else None,
         )
 
@@ -1246,7 +1249,6 @@ class QueryAgent:
         synthesis_prompt = self._build_synthesis_prompt(
             question, context,
             gap=_gap, system_ctx=_system_ctx, is_live_data=_is_live_data,
-            gap_sentinel=True,
             history=_trimmed_history if _trimmed_history else None,
         )
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -149,9 +149,13 @@ _STOPWORDS = frozenset({
     "metric", "metrics", "kpi", "kpis", "indicator", "indicators",
     "statistic", "statistics", "figure", "figures",
     # Structural query framers: "Give me an overview/summary/breakdown/profile of X."
-    # These describe the requested form of the answer, not recurring page content.
+    # "What are the workstreams/considerations/criteria for Y?" — M&A jargon that
+    # describes how the user wants the answer structured, not recurring page content.
     "overview", "summary", "summaries", "breakdown", "breakdowns",
     "profile", "profiles", "highlight", "highlights",
+    "workstream", "workstreams",
+    "consideration", "considerations",
+    "criterion", "criteria",
     # Temporal-horizon qualifiers: "near-term", "long-term", "short-term" etc.
     # Hyphens are replaced with spaces during bare-form extraction, so these
     # become two-word key terms like "near term".  Wiki pages rarely repeat a

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -1024,12 +1024,25 @@ class QueryAgent:
                 min(_term_qualifying_pages.values()) if _term_qualifying_pages else 0
             )
             _signal5_doc_freq_cap = max(2, (_n_cands + 2) // 3)
+            # Pages whose title contains the term are considered dedicated to it even
+            # when the body doesn't repeat the term ≥ MIN_FREQ times.  This suppresses
+            # the false positive where a "Methodology Guide" page doesn't repeat the
+            # word "methodology" twice in its body — the title is sufficient coverage.
+            _title_covered: set[str] = set()
+            for _r in candidates:
+                _tp = self._store.read_page(_r.slug)
+                if _tp:
+                    _t_norm = _tp.title.lower().replace("-", " ")
+                    for _t in _specific:
+                        if _t in _t_norm:
+                            _title_covered.add(_t)
             _defining_term_absent = (
                 bool(_specific)
                 and len(_term_doc_freq) >= 2
                 and any(
                     _term_qualifying_pages[t] == 0
                     and _specific[t] <= _signal5_doc_freq_cap
+                    and t not in _title_covered
                     for t in _term_qualifying_pages
                 )
             )

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -592,16 +592,9 @@ class QueryAgent:
         gap: bool,
         system_ctx: str,
         is_live_data: bool,
-        gap_sentinel: bool = False,
         history: list[dict] | None = None,
     ) -> str:
-        """Build the LLM synthesis prompt.
-
-        gap_sentinel adds the [GAP] marker instruction for post-synthesis gap override
-        (Guard B).  Callers leave it False so _detect_gap() is the sole gap arbiter —
-        instructing the LLM to self-signal gaps produces false positives when the query
-        framing is slightly different from the wiki's phrasing (e.g. "near-term demand"
-        vs. "regulatory drivers").  When history is provided it is prepended."""
+        """Build the LLM synthesis prompt. When history is provided it is prepended."""
         prefix = _history_block(history) if history else ""
         if gap:
             return prefix + (
@@ -638,17 +631,12 @@ class QueryAgent:
                 f"Do not reference or cite wiki page content.\n\n"
                 f"Question: {question}\n\nData:\n{context}"
             )
-        gap_instruction = (
-            "If the pages do not contain enough information to answer the question, "
-            "start your response with exactly '[GAP]' on its own line, then explain what's missing.\n\n"
-        ) if gap_sentinel else ""
         return prefix + (
             f"Answer using ONLY these wiki pages. Cite with [[PageTitle]].\n"
             f"Extract and include all specific facts from the pages — dates, years, numbers, and names — "
             f"even when they appear briefly or in passing. Do not claim a fact is absent unless it is "
             f"genuinely missing from every page below.\n"
             f"Do not cite the Wiki Scope section — it is background context only, not a citable source.\n\n"
-            f"{gap_instruction}"
             f"Question: {question}\n\nPages:\n{context}"
         )
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -633,6 +633,7 @@ class QueryAgent:
             )
         return prefix + (
             f"Answer using ONLY these wiki pages. Cite with [[PageTitle]].\n"
+            f"Respond in the same language as the Question.\n"
             f"Extract and include all specific facts from the pages — dates, years, numbers, and names — "
             f"even when they appear briefly or in passing. Do not claim a fact is absent unless it is "
             f"genuinely missing from every page below.\n"

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -143,6 +143,15 @@ _STOPWORDS = frozenset({
     "highest", "lowest", "largest", "smallest", "biggest", "greater", "lesser",
     "higher", "lower", "worst", "better", "worse", "fastest", "slowest",
     "strongest", "weakest", "richest", "cheapest", "expensive",
+    # Measurement-framing nouns: "What are the key metrics/KPIs/figures for X?"
+    # Users request data using these wrapper words; wiki pages contain the data
+    # itself (revenue, EBITDA, rates) without needing to repeat the wrapper ≥2 times.
+    "metric", "metrics", "kpi", "kpis", "indicator", "indicators",
+    "statistic", "statistics", "figure", "figures",
+    # Structural query framers: "Give me an overview/summary/breakdown/profile of X."
+    # These describe the requested form of the answer, not recurring page content.
+    "overview", "summary", "summaries", "breakdown", "breakdowns",
+    "profile", "profiles", "highlight", "highlights",
 })
 
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -152,6 +152,13 @@ _STOPWORDS = frozenset({
     # These describe the requested form of the answer, not recurring page content.
     "overview", "summary", "summaries", "breakdown", "breakdowns",
     "profile", "profiles", "highlight", "highlights",
+    # Temporal-horizon qualifiers: "near-term", "long-term", "short-term" etc.
+    # Hyphens are replaced with spaces during bare-form extraction, so these
+    # become two-word key terms like "near term".  Wiki pages rarely repeat a
+    # horizon phrase ≥2 times and it carries no retrieval signal anyway.
+    "near term", "long term", "short term", "mid term", "medium term",
+    "near run", "long run", "short run",
+    "near future", "long future",
 })
 
 

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -177,6 +177,9 @@ _STOPWORDS = frozenset({
     # general practice, not content that pages repeat ≥2 times.
     "typical", "standard", "common", "usual", "normal",
     "general", "generally", "typically", "commonly", "usually",
+    # Passive/auxiliary verb forms: "covenants are used to…" — past-tense auxiliaries
+    # don't strip to base form via rstrip and rarely appear ≥2 times in wiki pages.
+    "used", "uses", "use",
     # Temporal-horizon qualifiers: "near-term", "long-term", "short-term" etc.
     # Hyphens are replaced with spaces during bare-form extraction, so these
     # become two-word key terms like "near term".  Wiki pages rarely repeat a
@@ -825,7 +828,11 @@ class QueryAgent:
         routing_warning = ""
         if scoped_slugs is not None:
             max_score = max((r.score for r in candidates), default=0.0)
-            scoped_weak = max_score < self._gap_score_threshold
+            # Use 1.5× the gap threshold so borderline scoped results (score between
+            # gap_threshold and 1.5×) also fall back.  This avoids Signal 6 false
+            # positives where routing picks domain-A pages for a cross-domain query
+            # and the domain-B acronym has doc_freq=0 in those pages.
+            scoped_weak = max_score < self._gap_score_threshold * 1.5
             if scoped_weak:
                 # Routing-scoped results are below threshold — fall back to full corpus.
                 full_per_sub = await asyncio.gather(

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -116,6 +116,7 @@ _STOPWORDS = frozenset({
     "shape", "drive", "change", "enable", "allow", "improve", "evolve",
     "influence", "affect", "impact", "cause", "result", "matter", "relate",
     "connect", "involve", "emerge", "remain",
+    "consistent", "align", "reflect", "correspond",
     # Analysis/evaluation verbs and structural framing nouns introduced by
     # sub-question decomposition ("How is X assessed?", "What are the components
     # of Y?") — these never repeat twice in a wiki page and cause Signal 5
@@ -1079,7 +1080,15 @@ class QueryAgent:
             if _signal5_triggers:
                 logger.debug("signal5 candidates: %r (cap=%d, title_covered=%r)",
                              _signal5_triggers, _signal5_doc_freq_cap, sorted(_title_covered))
-            _defining_term_absent = bool(_specific) and len(_term_doc_freq) >= 2 and bool(_signal5_triggers)
+            # Signal 5 coverage gate: only fire when fewer than 75% of candidates are
+            # on-topic.  When the wiki broadly covers the query (≥ 75% on-topic pages
+            # and strong retrieval score), a term with qualifying_pages=0 is almost
+            # always a query-framing word, not a content gap — Guard B (post-synthesis)
+            # handles residual gaps in that regime.  The 75% threshold is higher than
+            # Signal 4's 50% gate so Signal 5 can still fire at moderate coverage
+            # (e.g., 4/8 on-topic pages) where the wiki has genuinely thin depth.
+            _signal5_active = _pages_with_overlap < _n_cands * 3 // 4
+            _defining_term_absent = _signal5_active and bool(_specific) and len(_term_doc_freq) >= 2 and bool(_signal5_triggers)
             # Signal 6: a specific acronym or proper-name abbreviation typed
             # ALL-CAPS in the query (USB, TCP, ENIAC, AI…) has zero occurrences
             # across all retrieved pages — the wiki simply does not cover this

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -1052,7 +1052,7 @@ class QueryAgent:
         gap = self._gap_score_threshold > 0 and (
             (len(candidates) < 3 and not used_tf_fallback)
             or (bool(_key_terms) and max_score < self._gap_score_threshold)  # skip when no content words
-            or _pages_with_overlap < 2
+            or (_pages_with_overlap < 2 and max_score < self._gap_score_threshold)  # one strong page is enough
             or _any_term_missing
             or _defining_term_absent
             or _acronym_absent

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -1028,9 +1028,9 @@ async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
     - Signal 2: gap_score_threshold=0.01 → no fire
     - Signal 3: 2 pages have error/correction ≥ 2 → on_topic_pages=2 ≥ 2 → no fire
     - Signal 4: all 3 terms have doc_freq > 0 → no zero-freq → no fire
-    - Signal 5: guard A: on_topic_pages=2 < n_cands//2=4 → coverage is thin;
-                guard B: "quantum" doc_freq=2 < threshold(3) → genuinely absent;
-                → gap=True ✓
+    - Signal 5: "quantum" doc_freq=2 < threshold(3), qualifying=0, and "quantum"
+                does not appear in any page title → title_covered suppression
+                does not apply → gap=True ✓
 
     bm25_search is mocked so BM25 IDF behaviour does not affect this test.
     """
@@ -1087,9 +1087,12 @@ async def test_gap_signal5_defining_term_barely_present(tmp_wiki):
     ]
     agent = QueryAgent(provider=provider, store=store, search=search,
                        gap_score_threshold=0.01)  # signal 2 disabled
-    with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
+    # score=5.0 >> threshold: proves Signal 5 fires based on title coverage, not score.
+    # "quantum" is absent from every page title → title_covered does not suppress it.
+    with patch.object(agent._search, "bm25_search",
+                      return_value=_fake_results(all_slugs, score=5.0)):
         result = await agent.query("What is quantum error correction?")
-    # "quantum": doc_freq=2 < threshold(3), qualifying=0 → signal 5 fires.
+    # "quantum": doc_freq=2 < threshold(3), qualifying=0, not in any title → signal 5 fires.
     assert result.knowledge_gap is True
     assert len(result.suggested_searches) >= 1
 

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -1364,29 +1364,28 @@ async def test_gap_signal5_high_docfreq_reference_term_does_not_fire(tmp_wiki):
 
 @pytest.mark.asyncio
 async def test_gap_signal5_fires_when_on_topic_pages_equals_half_and_term_low_docfreq(tmp_wiki):
-    """Regression: signal 5 must fire when on_topic_pages = n_cands//2 exactly
-    (old guard A blocked it) and the discriminating term has low doc_freq and
-    qualifying_pages=0.
+    """Signal 5 fires when on_topic_pages = n_cands//2 (50%) and the discriminating
+    term has low doc_freq and qualifying_pages=0.
 
     Real-world case: 'judge agent methodologies' query against a wiki that covers
     agent/judge well but never dedicates content to 'methodologies'.
     8 pages retrieved; 4 are on-topic for 'agent'/'judge' — exactly n_cands//2.
 
+    Signal 5's coverage gate fires when pages_with_overlap < n_cands * 3 // 4 (75%).
+    With 4/8 on-topic (50%), 4 < 6 → gate passes → Signal 5 can fire.
+    'methodologie' doc_freq=2 < cap(3), qualifying=0, not in any title → gap=True ✓
+
     NOTE: the query must NOT use 'agent-as-a-judge' (hyphenated) because the
     tokeniser turns the whole phrase into the compound key term 'agent as a judge',
     which won't match individual words in page content and fires signal 3 instead.
-
-    Old guard A: 4 < 4 = False → blocked signal 5 → gap=False (bug).
-    Fix: guard A removed from signal 5; guard B alone applies.
-    'methodologie' doc_freq=2 < threshold(3) and qualifying=0 → gap=True ✓
 
     Signal breakdown:
     - Signal 1: 8 candidates ≥ 3 → no fire
     - Signal 2: gap_score_threshold=0.01 → no fire
     - Signal 3: on_topic_pages=4 ≥ 2 → no fire
     - Signal 4: _signal4_active=False (4<4=False); also no term has doc_freq=0
-    - Signal 5 (fixed): guard A removed; 'methodologie' doc_freq=2 < cap(3),
-      qualifying=0 → gap=True ✓
+    - Signal 5: 75% gate passes (4<6); 'methodologie' doc_freq=2 < cap(3),
+      qualifying=0, not title-covered → gap=True ✓
     """
     store = WikiStorage(tmp_wiki / "wiki")
     # 4 pages: 'agent' ≥ 4 times, 'judge' ≥ 3 times; 'methodologie' absent.

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -866,13 +866,14 @@ async def test_gap_signal3_boundary_exactly_two_on_topic_pages(tmp_wiki):
 
 @pytest.mark.asyncio
 async def test_gap_signal3_boundary_one_on_topic_page(tmp_wiki):
-    """Signal 3 DOES trigger when only one retrieved page covers the discriminating
-    term with sufficient frequency (1 < 2 → gap).
+    """Signal 3 fires when only one retrieved page covers the discriminating term
+    AND max_score is below the gap threshold (weak overall match).
 
-    bm25_search is mocked so BM25 IDF behaviour does not affect this test.
+    score=0.005 < gap_score_threshold=0.01 so both Signal 2 and Signal 3 contribute.
+    The important invariant is: thin coverage + weak score → gap.
     """
     store = WikiStorage(tmp_wiki / "wiki")
-    # Only 1 page has "orchid" ≥ 3 times; 4 pages are off-topic.
+    # Only 1 page has "orchid" ≥ 2 times; 4 pages are off-topic.
     store.write_page("orchid-page", WikiPage(
         title="Orchid Care", tags=["orchid"],
         content=(
@@ -900,11 +901,61 @@ async def test_gap_signal3_boundary_one_on_topic_page(tmp_wiki):
     ]
     agent = QueryAgent(provider=provider, store=store, search=search,
                        gap_score_threshold=0.01)
-    with patch.object(agent._search, "bm25_search", return_value=_fake_results(all_slugs)):
+    # score=0.005 is below the threshold — weak match + 1 on-topic page → gap fires.
+    with patch.object(agent._search, "bm25_search",
+                      return_value=_fake_results(all_slugs, score=0.005)):
         result = await agent.query("What orchid plants grow well indoors?")
-    # "orchid" is the discriminating term; only 1 page has it ≥ 2 times → 1 < 2 → gap.
     assert result.knowledge_gap is True
     assert len(result.suggested_searches) >= 1
+
+
+@pytest.mark.asyncio
+async def test_no_gap_single_dedicated_page_strong_score(tmp_wiki):
+    """Signal 3 must NOT fire when exactly one page covers the query topic but
+    that page scores strongly (max_score >= gap_score_threshold).
+
+    Regression for the QoE false-positive: a focused wiki with one dedicated page
+    per topic should not generate gap chips when that page is a strong match.
+    The old condition '_pages_with_overlap < 2' fired unconditionally; the fix
+    adds 'and max_score < threshold' so a high-scoring single page suppresses gap.
+    """
+    store = WikiStorage(tmp_wiki / "wiki")
+    # 1 dedicated QoE page; 4 unrelated finance pages.
+    store.write_page("quality-of-earnings-qoe", WikiPage(
+        title="Quality of Earnings (QoE) — Methodology Guide", tags=["qoe"],
+        content=(
+            "Quality of earnings methodology assesses sustainability of EBITDA. "
+            "The quality of earnings methodology normalizes revenue through a GAAP bridge. "
+            "Earnings quality red flags are identified in quality of earnings reports. "
+            "This earnings methodology produces a report used in LBO modeling."
+        ),
+        status="active", confidence="high", sources=[],
+    ))
+    for i in range(4):
+        store.write_page(f"finance-page-{i}", WikiPage(
+            title="LBO Model", tags=["lbo"],
+            content="Leveraged buyout model mechanics. Debt tranches and covenants.",
+            status="active", confidence="high", sources=[],
+        ))
+    all_slugs = ["quality-of-earnings-qoe"] + [f"finance-page-{i}" for i in range(4)]
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+    provider.complete.side_effect = [
+        CompletionResponse(text='["Quality of Earnings methodology"]',
+                           input_tokens=5, output_tokens=5),
+        CompletionResponse(
+            text="Quality of earnings is a methodology for assessing EBITDA sustainability.",
+            input_tokens=80, output_tokens=20,
+        ),
+    ]
+    agent = QueryAgent(provider=provider, store=store, search=search,
+                       gap_score_threshold=0.01)
+    # score=5.0 >> threshold — strong match, single dedicated page → no gap.
+    with patch.object(agent._search, "bm25_search",
+                      return_value=_fake_results(all_slugs, score=5.0)):
+        result = await agent.query("Quality of earnings methodology")
+    assert result.knowledge_gap is False
+    assert result.suggested_searches == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
What

Systematically eliminates false-positive "Knowledge Gap Detected" chips that appeared on well-answered queries in domain wikis, validated end-to-end against the AquaFlow M&A demo wiki.

Why

Gap detection uses pre-synthesis signals to decide whether the wiki lacks content. Several signals were over-triggering on query-framing words (words that describe how the user wants the answer, not what the wiki should contain). Sub-question decomposition made this worse by introducing analytical vocabulary ("compare", "imply", "workstream") that never appears ≥2 times in wiki page bodies. The result: correct, well-cited answers were paired with a gap chip and enrichment suggestions pointing at content that already existed.

Changes

i. Signal 5: structural fix (2 commits):
- Title-coverage suppression: if the discriminating term appears in any candidate page's title, Signal 5 no longer fires for it (fix(gap): suppress Signal 5 when discriminating term appears in a page title)
- 75% coverage gate: Signal 5 now requires pages_with_overlap < n_cands * 3 // 4; when ≥75% of candidates are on-topic the wiki clearly covers the query and Signal 5 framing-word false positives are suppressed - Guard B (post-synthesis) covers residual gaps in that regime

ii. Stop list expansion (7 commits): Added six new categories of query-framing words to _STOPWORDS:
- Analysis/evaluation verbs already present; extended with sub-question decomposition vocabulary
- Relational framers: consistent, align, reflect, correspond
- Comparative/analytical framers: compare, imply, indicate, infer, suggest
- Measurement wrappers: metric, kpi, indicator, statistic, figure, overview, summary, breakdown
- M&A structural framers: workstream, consideration, criterion, package, structure
- Norm-seeking qualifiers: typical, standard, common, usual, general
- Temporal-horizon qualifiers: near term, long term, short term (post hyphen→space substitution)

iii. Signal 3: single dedicated page fix:
- Suppresses gap when one page scores strongly and coverage is thin, preventing false positives on focused single-source queries

iv. AquaFlow README (2 commits):
- Reordered prerequisites; added Windows CMD compatibility callout and dual code blocks
- Citations promoted to Step 10 (before web UI); fixed broken page slug in CLI audit example; corrected "Ingest all" button label in two places; renumbered web UI to Step 11