### PR TITLE
docs: AquaFlow benchmark cross-links and AI agents badge

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -23,6 +23,7 @@
 [![Coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.coverage&label=Coverage&suffix=%25&color=brightgreen)](https://github.com/axoviq-ai/synthadoc/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/axoviq-ai/synthadoc/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-yellow.svg)](https://www.python.org/)
+[![Agents](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.agents&label=AI%20agents&color=crimson)](https://github.com/axoviq-ai/synthadoc/tree/main/synthadoc/agents)
 [![Skills](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.skills&label=Skills&color=purple)](https://github.com/axoviq-ai/synthadoc/tree/main/synthadoc/skills)
 [![Hooks](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.hooks&label=Hook%20events&color=teal)](https://github.com/axoviq-ai/synthadoc/tree/main/hooks)
 [![CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.cli_commands&label=CLI%20commands&color=darkblue)](https://github.com/axoviq-ai/synthadoc)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 [![Coverage](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.coverage&label=Coverage&suffix=%25&color=brightgreen)](https://github.com/axoviq-ai/synthadoc/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://github.com/axoviq-ai/synthadoc/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-yellow.svg)](https://www.python.org/)
+[![Agents](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.agents&label=AI%20agents&color=crimson)](https://github.com/axoviq-ai/synthadoc/tree/main/synthadoc/agents)
 [![Skills](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.skills&label=Skills&color=purple)](https://github.com/axoviq-ai/synthadoc/tree/main/synthadoc/skills)
 [![Hooks](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.hooks&label=Hook%20events&color=teal)](https://github.com/axoviq-ai/synthadoc/tree/main/hooks)
 [![CLI](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Faxoviq-ai%2Fsynthadoc%2Fbadges%2Fdocs%2Fbadges.json&query=%24.cli_commands&label=CLI%20commands&color=darkblue)](https://github.com/axoviq-ai/synthadoc)

--- a/docs/badges.json
+++ b/docs/badges.json
@@ -5,5 +5,6 @@
   "hooks": 2,
   "coverage": 91,
   "coverage_color": "brightgreen",
-  "mcp_tools": 12
+  "mcp_tools": 12,
+  "agents": 11
 }

--- a/docs/example/aquaflow/README.md
+++ b/docs/example/aquaflow/README.md
@@ -521,5 +521,6 @@ Pages move through five states: `draft` → `active` → `stale` → `contradict
 
 ## Further reading
 
+- [AquaFlow LLM Query Benchmark](evaluation/report/llm-query-benchmark.md) — query accuracy evaluation across all 15 sample queries, scored by provider and complexity tier
 - [User Quick-Start Guide](../../user-quick-start-guide.md) — full feature walkthrough including Obsidian plugin, scheduling, ROUTING.md, context packs, export formats, MCP, and backup/restore
 - [Design document](../../design.md) — architecture, data model, and system design

--- a/docs/example/aquaflow/evaluation/report/llm-query-benchmark.md
+++ b/docs/example/aquaflow/evaluation/report/llm-query-benchmark.md
@@ -1,6 +1,6 @@
 # AquaFlow LLM Query Benchmark
 
-**Wiki:** AquaFlow Systems PE/M&A due diligence demo  
+**Wiki:** AquaFlow Systems PE/M&A due diligence  
 **Date:** 2026-07-09  
 **Evaluator:** `docs/example/aquaflow/evaluation/scripts/eval_queries.py`
 
@@ -9,9 +9,9 @@
 ## Overview
 
 This report benchmarks three LLMs against 15 PE/M&A due diligence questions drawn from the
-AquaFlow demo wiki. Questions Q1–Q10 are in English; Q11–Q15 are in Mandarin Chinese. Each
+[AquaFlow wiki](../../readme.md). Questions Q1–Q10 are in English; Q11–Q15 are in Mandarin Chinese. Each
 answer is scored by case-insensitive substring match against a curated fact list (282 facts
-total). Grading follows a two-tier framework:
+total; defined per-question in [`eval_queries.py`](../scripts/eval_queries.py)). Grading follows a two-tier framework:
 
 | Grade | Threshold | Meaning |
 |-------|-----------|---------|

--- a/scripts/update_badges.py
+++ b/scripts/update_badges.py
@@ -73,6 +73,17 @@ def count_skills() -> int:
     )
 
 
+def count_agents() -> int:
+    """Count Agent classes defined in synthadoc/agents/*.py."""
+    import re
+    agents_dir = ROOT / "synthadoc" / "agents"
+    pattern = re.compile(r"^class \w+Agent[:(]", re.MULTILINE)
+    return sum(
+        len(pattern.findall(p.read_text(encoding="utf-8")))
+        for p in agents_dir.glob("*.py")
+    )
+
+
 def read_coverage(coverage_json: Path) -> int:
     """Return total coverage as an integer (e.g. 87).
 
@@ -108,6 +119,7 @@ def main() -> None:
         "obsidian_commands": count_obsidian_commands(),
         "skills": count_skills(),
         "mcp_tools": count_mcp_tools(),
+        "agents": count_agents(),
     }
 
     badges_path = ROOT / "docs" / "badges.json"


### PR DESCRIPTION
- Added AquaFlow LLM Query Benchmark as the first link in the Further reading section of docs/example/aquaflow/readme.md.
- Polished llm-query-benchmark.md overview: removed "demo" from wiki name and sentence, linked "AquaFlow wiki" back to the walkthrough README, and linked the 282-fact reference to eval_queries.py where the facts are defined.
- Added a dynamic AI agents badge to README.md (before Skills), backed by a new count_agents() function in update_badges.py that auto-counts Agent class definitions so the badge stays accurate as agents are added or removed.