### PR TITLE
fix: load_purpose_context hardening; unit tests fix and document update from review

### DIFF
--- a/docs/badges.json
+++ b/docs/badges.json
@@ -2,7 +2,7 @@
   "cli_commands": 50,
   "obsidian_commands": 14,
   "skills": 9,
-  "hooks": 2,
+  "hooks": 1,
   "coverage": 91,
   "coverage_color": "brightgreen",
   "mcp_tools": 12,

--- a/docs/design.md
+++ b/docs/design.md
@@ -413,6 +413,30 @@ Serialises the wiki to one of five formats with zero additional LLM calls. Invok
 
 **GraphML tool compatibility:** The file includes both a standard `label` data key (read by Gephi and Cytoscape) and a `y:ShapeNode/y:NodeLabel` element (read by yEd). No position data is embedded — run the tool's own layout algorithm after import.
 
+### ActionAgent
+
+Dispatches action-intent queries from the chat UI (e.g. "activate a draft page", "show lint report", "archive a stale page", "run scaffold"). Parses the user's free-text intent into a structured action via an LLM extraction prompt, then executes the action against the wiki and returns a human-readable result. When the intent is ambiguous (e.g. "activate a page" without specifying which), sets `needs_clarification=True` and returns a prompt and candidate list for the web UI to render as chip buttons.
+
+### ScaffoldAgent
+
+Generates and updates the wiki's structural pages. Reads all current wiki pages and asks the LLM to organise them into 5–8 domain-appropriate categories, then writes `wiki/index.md` (category index with wikilinks), `wiki/purpose.md` (scope statement), and `AGENTS.md` (ingest and query guidelines). Also stamps a `categories:` field on each page's YAML frontmatter. When `ROUTING.md` already exists, regenerates it to stay in sync with the updated index structure.
+
+### RewriteAgent
+
+Rewrites follow-up questions in multi-turn conversations into self-contained, standalone form before BM25 retrieval. Converts context-dependent phrases ("What came after that?", "Tell me more about his early life") into explicit questions ("What came after Alan Turing's work at Bletchley Park?") so keyword retrieval targets the correct pages without relying on conversation context. Only invoked when conversation history is non-empty. See also: [Multi-turn Conversation](#multi-turn-conversation).
+
+### SummarizeAgent
+
+Compresses the oldest conversation turns into a single `[Session summary: …]` assistant turn when a session exceeds `conversation_history_turns`. Prevents unbounded context growth across long sessions. Emits a `notice` SSE event the first time compression occurs so the user can see that earlier context was condensed. See also: [Multi-turn Conversation](#multi-turn-conversation).
+
+### ContextAgent
+
+Builds token-budgeted context packs for MCP tool consumers. See [Section 20 — Context Packs](#20-context-packs) for full detail.
+
+### SearchDecomposeAgent
+
+Decomposes a web search intent into 1–4 terse keyword search strings optimised for authoritative source retrieval. Uses a separate prompt from `QueryAgent`'s question decomposition — search decomposition asks "what distinct search strings would find the best sources?" (terse keyword phrases) rather than "what distinct questions does this ask?" (natural-language sub-questions). See [Web search fan-out](#web-search-fan-out) in the IngestAgent section.
+
 ---
 
 ## 5. Skills System
@@ -766,7 +790,7 @@ The HTTP server runs a background task that polls `jobs.db` every 2 seconds and 
 
 **Package:** `synthadoc-obsidian` (TypeScript)  
 **Location:** `obsidian-plugin/` in the repo  
-**Version:** 0.6.0
+**Version:** 1.0.1
 
 Each vault configures its server URL in plugin settings (default `http://127.0.0.1:7070`).
 
@@ -787,7 +811,7 @@ Reload the plugin (toggle off/on) after copying — a full Obsidian restart is n
 | `Synthadoc: View Page Provenance` _(v0.5.0)_ | Sortable, paginated table of every claim citation recorded across the wiki — page, claim excerpt, source file, line range, and ingest timestamp. Draggable; all cell content is selectable and copyable. Click any row to open the Source Viewer showing the exact source lines with ±5 lines of context. For PDF sources a page-jump button opens the native PDF viewer at the correct page. |
 | `Synthadoc: Manage Page Lifecycle` _(v0.6.0)_ | Sortable, filterable, paginated table of all wiki pages with their current lifecycle state (`draft`, `active`, `contradicted`, `stale`, `archived`) and last transition timestamp. State filter checkboxes narrow the table; click column headers to sort. Each row shows valid transition buttons — click a button to trigger a transition; a reason dialog appears before committing. Clicking a draft or stale badge on the lint modal or jobs panel opens this table pre-filtered to that state. |
 | `Synthadoc: Jobs...` | Modal with status-filter checkboxes (pending, in_progress, completed, failed, skipped, dead, cancelled), sortable results table (click **Status**, **Operation**, or **Created** headers to sort ascending; click again to reverse; ▲/▼ indicates active sort, ⇅ indicates unsorted; default: newest first), error detail rows for failed/dead/cancelled jobs, pagination (25 per page), auto-refresh countdown, a **Retry selected** button (enabled when ≥ 1 selected job is failed/dead/cancelled) and a **Delete selected** button (enabled when ≥ 1 job is selected). A **Purge old jobs** footer row lets you set a day threshold and remove old completed/dead jobs in one click. |
-| `Synthadoc: Routing: manage ROUTING.md...` | Modal panel with three buttons. **Init** creates ROUTING.md from the current index.md branch structure (enabled only when ROUTING.md does not exist). **Validate** reports dangling slugs — pages listed in ROUTING.md that no longer exist in the wiki (enabled only when ROUTING.md exists). **Clean** removes dangling slugs from ROUTING.md (enabled only when ROUTING.md exists). After each action the result appears inline with per-entry `[Branch] [[slug]]` detail rows. |
+| `Synthadoc: Routing: manage ROUTING.md...` | Modal panel with three buttons. **Init** creates ROUTING.md from the current index.md branch structure (enabled only when ROUTING.md does not exist). **Validate** reports two things: dangling slugs (pages listed in ROUTING.md that no longer exist in the wiki) and unassigned slugs (pages that exist in index.md but are not listed in any ROUTING.md branch). Enabled only when ROUTING.md exists. **Clean** removes dangling slugs from ROUTING.md (enabled only when ROUTING.md exists). After each action the result appears inline with per-entry `[Branch] [[slug]]` detail rows. |
 | `Synthadoc: Staging: manage staging policy...` | Modal panel showing the current policy state. A segmented control switches between **Off**, **All**, and **Threshold**. When **Threshold** is selected, a second segmented control sets the minimum confidence (**High** / **Medium** / **Low**). A **Save** button persists the change via the HTTP API and updates the inline status. A footer link opens the Candidates modal directly. |
 | `Synthadoc: Candidates: review candidate pages...` | Paginated table (50 per page) of all staged candidate pages. Each row shows the slug, a colour-coded confidence badge, and a checkbox. **Promote All** and **Discard All** act on every candidate; **Promote Selected** and **Discard Selected** act on checked rows. The table reloads automatically after each action. A footer link opens the Staging policy modal. |
 | `Synthadoc: Context: build context pack...` | Modal with a goal/question text area, a token budget field (default 4000), and a **Build Context Pack** button (`Ctrl/Cmd+Enter` also triggers). The server decomposes the goal, retrieves and ranks wiki pages via BM25, and packs them within the budget. The result is rendered as cited Markdown in a read-only text area. **Copy to Clipboard** copies the content to the OS clipboard. **Save as .md** downloads the Markdown file with a slug-derived filename. |
@@ -847,15 +871,15 @@ synthadoc
 │   ├── cancel [-w wiki] [--yes]
 │   └── purge --older-than <days> [-w wiki]
 ├── routing
-│   ├── init [--wiki-root <path>]                 — generate ROUTING.md from index.md branch structure
-│   ├── validate [--wiki-root <path>]             — report dangling slugs and cross-branch duplicates
-│   └── clean [--wiki-root <path>]               — remove dangling slugs from ROUTING.md
+│   ├── init [-w wiki]                            — generate ROUTING.md from index.md branch structure
+│   ├── validate [-w wiki]                        — report dangling slugs and cross-branch duplicates
+│   └── clean [-w wiki]                           — remove dangling slugs from ROUTING.md
 ├── staging
-│   └── policy [off|all|threshold] [--min-confidence high|medium|low] [--wiki-root <path>]
+│   └── policy [off|all|threshold] [--min-confidence high|medium|low] [-w wiki]
 ├── candidates
-│   ├── list [--wiki-root <path>]
-│   ├── promote <slug>|--all [--wiki-root <path>]
-│   └── discard <slug>|--all [--wiki-root <path>]
+│   ├── list [-w wiki]
+│   ├── promote <slug>|--all [-w wiki]
+│   └── discard <slug>|--all [-w wiki]
 ├── context
 │   └── build "<goal>" [-w wiki] [--tokens N] [--output <file>]
 ├── export -f <fmt> [-o <path>] [-s <state>] [-w wiki]    — llms.txt, llms-full.txt, graphml, json, okf
@@ -1141,7 +1165,7 @@ max_file_mb  = 5
 backup_count = 5
 
 [hooks]
-on_ingest_complete = "python hooks/auto_commit.py"                        # non-blocking
+on_ingest_complete = "python hooks/git-auto-commit.py"                    # non-blocking
 on_lint_complete   = { cmd = "python hooks/notify.py", blocking = true }  # blocking
 
 [web_search]
@@ -1208,7 +1232,7 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 | `audit.url_staleness_days` | int | `0` | Days after which URL-sourced pages are automatically marked `stale` if the source URL has not been re-ingested. `0` = disabled. |
 | `logs.level` | str | `"INFO"` | Console log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
 | `logs.max_file_mb` | int | `5` | Rotate `synthadoc.log` at this size (MB) |
-| `logs.backup_count` | int | `5` | Rotated log files to keep; total disk ≈ `max_file_mb × backup_count` |
+| `logs.backup_count` | int | `5` | Rotated log files to keep; total disk ≈ `max_file_mb × (backup_count + 1)` |
 | `web_search.provider` | str | `"tavily"` | Web search provider (currently only `tavily` supported) |
 | `web_search.max_results` | int | `20` | Maximum results fetched per web search query |
 | `search.vector` | bool | `false` | Enable semantic re-ranking; downloads `BAAI/bge-small-en-v1.5` (~130 MB) once on first enable |
@@ -1232,8 +1256,8 @@ Hooks are shell commands executed when lifecycle events fire. They are configure
 # .synthadoc/config.toml
 
 [hooks]
-on_ingest_complete = "python scripts/auto_commit.py"                        # non-blocking
-on_lint_complete   = { cmd = "python scripts/notify.py", blocking = true }  # blocking
+on_ingest_complete = "python hooks/git-auto-commit.py"                     # non-blocking
+on_lint_complete   = { cmd = "python hooks/notify.py", blocking = true }   # blocking
 ```
 
 ### Blocking vs. non-blocking
@@ -1569,7 +1593,7 @@ Spans cover: full operation tree (orchestrator → agent → LLM calls → stora
 
 ### Network exposure
 
-HTTP and MCP servers bind to `127.0.0.1` at OS socket level. Not configurable. No remote access without a separate reverse proxy (which the user must explicitly set up).
+HTTP and MCP servers bind to `127.0.0.1` by default. The bind address is configurable via `server.host` in `config.toml` (e.g. `host = "0.0.0.0"` to expose on all interfaces for LAN access). No built-in authentication — restrict via firewall when exposing beyond loopback. Remote access without a reverse proxy is not recommended on shared or networked machines.
 
 ### HTTP DoS
 
@@ -1771,10 +1795,10 @@ Pages may carry an `aliases:` list in YAML frontmatter. `QueryAgent._expand_alia
 | Command | Description |
 |---|---|
 | `synthadoc routing init` | Generate ROUTING.md from current index.md branch structure |
-| `synthadoc routing validate` | Report dangling slugs (dry run) |
+| `synthadoc routing validate` | Report dangling slugs and unassigned slugs (dry run) |
 | `synthadoc routing clean` | Remove dangling slugs from ROUTING.md |
 
-All commands accept `--wiki-root <path>`.
+All commands accept `-w <wiki>` / `--wiki <wiki>` to target a specific wiki.
 
 ### Obsidian plugin
 
@@ -2480,7 +2504,7 @@ Hint chips are rendered below each answer and in the empty-state panel before th
 
 ### Multi-turn Conversation
 
-Each `GET /query/stream` call may include a `session_id` (UUID from `POST /sessions`). When a session_id is present, the HTTP server loads conversation history from `audit.db` (up to `conversation_history_turns` most recent turns, default 10) and passes it to `QueryAgent.run_stream()`.
+Each `GET /query/stream` call may include a `session_id` (UUID from `POST /sessions`). When a session_id is present, the HTTP server loads conversation history from `audit.db` (up to `conversation_history_turns` most recent turns, default 5) and passes it to `QueryAgent.run_stream()`.
 
 **Follow-up question rewriting.** When history is non-empty, a `RewriteAgent` rewrites the user's follow-up question into a self-contained form before BM25 retrieval. This converts context-dependent phrases ("What came after that?" or "Tell me more about his early life") into standalone questions ("What came after Alan Turing's work at Bletchley Park?") so keyword retrieval targets the right pages.
 
@@ -2513,7 +2537,7 @@ The left navigation bar in the web UI is driven by `GET /sessions` (returns up t
 
 ```toml
 [query]
-conversation_history_turns = 10   # turns to include in each request (default: 10; 0 = disable history)
+conversation_history_turns = 5    # turns to include in each request (default: 5; 0 = disable history)
 ```
 
 ### CLI command
@@ -2956,7 +2980,7 @@ Edit `<wiki-root>/AGENTS.md` to give the LLM domain-specific instructions — te
 - **SSE shutdown stability** — a log filter installed on `uvicorn.error` at startup suppresses three benign error classes that appear when the server exits while SSE connections are open: `asyncio.CancelledError`, `KeyboardInterrupt`, and the `RuntimeError("Expected ASGI message 'http.response.body'…")` that Starlette's error middleware raises after cancellation. Actual errors during normal operation are unaffected.
 ### v0.8.0 (Community Edition)
 
-- **Multi-turn conversation** — the web chat UI maintains conversation history across turns within a session. History is stored in `audit.db` per session and loaded server-side on each request (up to `conversation_history_turns` turns, default 10). Follow-up questions are rewritten into standalone form by a dedicated rewrite component before BM25 retrieval, so context-dependent phrases ("What came after that?") resolve correctly. When the session exceeds the turn limit, a summarization component compresses the oldest turns into a `[Session summary]` entry; a `notice` SSE event is emitted the first time compression occurs.
+- **Multi-turn conversation** — the web chat UI maintains conversation history across turns within a session. History is stored in `audit.db` per session and loaded server-side on each request (up to `conversation_history_turns` turns, default 5). Follow-up questions are rewritten into standalone form by a dedicated rewrite component before BM25 retrieval, so context-dependent phrases ("What came after that?") resolve correctly. When the session exceeds the turn limit, a summarization component compresses the oldest turns into a `[Session summary]` entry; a `notice` SSE event is emitted the first time compression occurs.
 - **Clarify event** — when an action-intent query is ambiguous (e.g. "activate a draft page" without specifying which page), the server emits a `clarify` SSE event with a disambiguation prompt and candidate page list instead of routing to the synthesis pipeline. The web UI renders candidates as numbered chip buttons; the user can tap a chip or type a page name to complete the action.
 - **Two new SSE events** — `clarify` (`{prompt, candidates, action}`) for action disambiguation; `notice` (`{text}`) for system messages such as history compression.
 - **Configuration** — `[chat] conversation_history_turns = 5` controls how many prior turns are included in each request. Set to `0` to disable conversation history. `clarify_lookback = 5` controls how many prior assistant turns to scan when detecting a clarify continuation (chip click after an ambiguous action query); configurable independently of `conversation_history_turns`.

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -2199,7 +2199,7 @@ The knowledge graph visualises how your wiki pages connect through `[[wikilinks]
 Run lint to trigger graph construction (if you completed Step 6, the graph is already ready):
 
 ```bash
-synthadoc lint -w history-of-computing
+synthadoc lint run -w history-of-computing
 ```
 
 Lint prints a summary line when the graph is built:
@@ -2281,7 +2281,7 @@ Once you promote a page to `active` status, it is protected against silent
 overwriting. If a new source contradicts an active page, Synthadoc flags it
 for your review rather than replacing the page's content automatically.
 
-To promote a page: `synthadoc lifecycle promote <slug>`
+To promote a page to active: `synthadoc lifecycle activate <slug>`
 
 ---
 
@@ -2397,7 +2397,7 @@ All commands are accessible via the Command Palette (`Ctrl/Cmd+P` → type `Synt
 
 | Command                  | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Synthadoc: Export Wiki` | Modal with a format dropdown (`json`, `llms.txt`, `llms-full.txt`, `graphml`), a full-width output path field pre-filled with today's date and the correct extension, and a status filter selector. A brief description at the top explains what each format contains. Click **Export** to write the file to your vault's `exports/` folder; the file opens automatically. For GraphML format, a **View Graph** button also appears for an inline Cytoscape.js preview — nodes are coloured by lifecycle state (active=green, draft=yellow, stale=orange, contradicted=red, archived=grey) and edges represent wikilinks. To load the graph in a dedicated tool, export to file and open in **yEd**, **Gephi**, or **Cytoscape**. |
+| `Synthadoc: Export Wiki` | Modal with a format dropdown (`okf`, `json`, `llms.txt`, `llms-full.txt`, `graphml`), a full-width output path field pre-filled with today's date and the correct extension, and a status filter selector. A brief description at the top explains what each format contains. Click **Export** to write the file to your vault's `exports/` folder; the file opens automatically. For GraphML format, a **View Graph** button also appears for an inline Cytoscape.js preview — nodes are coloured by lifecycle state (active=green, draft=yellow, stale=orange, contradicted=red, archived=grey) and edges represent wikilinks. To load the graph in a dedicated tool, export to file and open in **yEd**, **Gephi**, or **Cytoscape**. |
 
 > **UX note:** All modals are draggable and support full text selection and copy-paste.
 
@@ -2474,7 +2474,7 @@ Switch by editing `<wiki-root>/.synthadoc/config.toml` and restarting the server
 | `openai`      | `OPENAI_API_KEY`    | No — pay-per-token                                | Yes             |
 | `qwen`        | `QWEN_API_KEY`      | Yes — 1M free tokens (90-day trial), then paid    | Model-dependent |
 | `deepseek`    | `DEEPSEEK_API_KEY`  | No — very affordable pricing                      | No              |
-| `claude-code` | _(none)_            | Yes — uses your Claude Code subscription, no key  | Yes             |
+| `claude-code` | _(none)_            | Yes — uses your Claude Code subscription, no key  | No              |
 | `opencode`    | _(none)_            | Yes — uses your Opencode subscription, no key     | No              |
 
 > CLI providers (`claude-code`, `opencode`) require no API key but need the tool installed and authenticated in your terminal. Web search still requires `TAVILY_API_KEY`. See [Appendix G](#appendix-g--using-a-coding-tool-as-your-llm-provider) for setup details.

--- a/scripts/update_badges.py
+++ b/scripts/update_badges.py
@@ -84,6 +84,12 @@ def count_agents() -> int:
     )
 
 
+def count_hooks() -> int:
+    """Count hook scripts (.py files) in the hooks/ directory."""
+    hooks_dir = ROOT / "hooks"
+    return sum(1 for p in hooks_dir.glob("*.py"))
+
+
 def read_coverage(coverage_json: Path) -> int:
     """Return total coverage as an integer (e.g. 87).
 
@@ -120,6 +126,7 @@ def main() -> None:
         "skills": count_skills(),
         "mcp_tools": count_mcp_tools(),
         "agents": count_agents(),
+        "hooks": count_hooks(),
     }
 
     badges_path = ROOT / "docs" / "badges.json"

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -658,11 +658,10 @@ class QueryAgent:
 
     def _load_purpose_context(self) -> str:
         """Return purpose.md as a pinned preamble for synthesis, or '' if absent."""
-        # system budget (context_system_pct) not yet enforced as a hard cap — reserved for v1.1
         page = self._store.read_page("purpose")
         if not page:
             return ""
-        return f"### Wiki Scope (purpose.md)\n{page.content[:12000]}"
+        return f"### Wiki Scope (purpose.md)\n{page.content[:self._char_budgets['system']]}"
 
     def _build_wiki_context(self, candidates) -> str:
         """Greedy-fill wiki context up to the wiki char budget.

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -661,7 +661,14 @@ class QueryAgent:
         page = self._store.read_page("purpose")
         if not page:
             return ""
-        return f"### Wiki Scope (purpose.md)\n{page.content[:self._char_budgets['system']]}"
+        budget = self._char_budgets["system"]
+        if len(page.content) > budget:
+            logger.warning(
+                "purpose.md truncated to %d chars (context_system_pct budget); "
+                "full content is %d chars — increase context_system_pct or shorten purpose.md",
+                budget, len(page.content),
+            )
+        return f"### Wiki Scope (purpose.md)\n{page.content[:budget]}"
 
     def _build_wiki_context(self, candidates) -> str:
         """Greedy-fill wiki context up to the wiki char budget.

--- a/synthadoc/core/context_budget.py
+++ b/synthadoc/core/context_budget.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 _CHARS_PER_TOKEN = 4
 
 _MODEL_CONTEXT_WINDOWS: dict[str, int] = {
-    "claude-opus-4":       200_000,
-    "claude-sonnet-4":     200_000,
+    "claude-opus-4":     1_000_000,
+    "claude-sonnet-4":   1_000_000,
     "claude-haiku-4":      200_000,
     "gpt-4o":              128_000,
     "gpt-4-turbo":         128_000,
@@ -15,8 +15,9 @@ _MODEL_CONTEXT_WINDOWS: dict[str, int] = {
     "gpt-3.5-turbo":        16_385,
     "deepseek-v3":         128_000,
     "deepseek-r1":         128_000,
+    "deepseek-v4":       1_000_000,
     "minimax/text-01":   1_000_000,
-    "minimax/abab6.5":     245_760,
+    "minimax/abab6.5":     204_800,
 }
 _DEFAULT_CONTEXT_WINDOW = 128_000
 

--- a/synthadoc/core/context_budget.py
+++ b/synthadoc/core/context_budget.py
@@ -34,7 +34,14 @@ def resolve_context_window(model: str, config_override: int) -> int:
 
 
 def compute_char_budgets(model: str, cfg) -> dict[str, int]:
-    """Return char budgets for wiki/history/system/index given model + QueryConfig."""
+    """Return char budgets for wiki/history/system/index given model + QueryConfig.
+
+    wiki    — enforced in QueryAgent._build_wiki_context()
+    history — enforced in QueryAgent._trim_history()
+    system  — enforced in QueryAgent._load_purpose_context() (purpose.md preamble)
+    index   — computed but not yet enforced; routing index is a structured object,
+              not raw text injected into prompts
+    """
     window = resolve_context_window(model, cfg.context_window)
     return {
         "wiki":    int(window * (cfg.context_wiki_pct    / 100) * _CHARS_PER_TOKEN),

--- a/synthadoc/core/context_budget.py
+++ b/synthadoc/core/context_budget.py
@@ -6,13 +6,17 @@ from __future__ import annotations
 _CHARS_PER_TOKEN = 4
 
 _MODEL_CONTEXT_WINDOWS: dict[str, int] = {
-    "claude-opus-4":    200_000,
-    "claude-sonnet-4":  200_000,
-    "claude-haiku-4":   200_000,
-    "gpt-4o":           128_000,
-    "gpt-4-turbo":      128_000,
-    "gpt-4":            8_192,
-    "gpt-3.5-turbo":    16_385,
+    "claude-opus-4":       200_000,
+    "claude-sonnet-4":     200_000,
+    "claude-haiku-4":      200_000,
+    "gpt-4o":              128_000,
+    "gpt-4-turbo":         128_000,
+    "gpt-4":                 8_192,
+    "gpt-3.5-turbo":        16_385,
+    "deepseek-v3":         128_000,
+    "deepseek-r1":         128_000,
+    "minimax/text-01":   1_000_000,
+    "minimax/abab6.5":     245_760,
 }
 _DEFAULT_CONTEXT_WINDOW = 128_000
 

--- a/tests/agents/test_query_agent.py
+++ b/tests/agents/test_query_agent.py
@@ -2499,6 +2499,48 @@ async def test_no_gap_for_purpose_of_this_wiki(tmp_wiki):
     assert provider.complete.call_count == 2
 
 
+# ── _load_purpose_context truncation warning ──────────────────────────────────
+
+def test_purpose_context_warns_when_truncated(tmp_wiki, caplog):
+    """logger.warning fires when purpose.md exceeds the system char budget."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+
+    long_content = "x" * 5000
+    (tmp_wiki / "wiki" / "purpose.md").write_text(long_content, encoding="utf-8")
+
+    agent = QueryAgent(provider=provider, store=store, search=search)
+    agent._char_budgets["system"] = 100  # force a tiny budget so truncation is guaranteed
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="synthadoc.agents.query_agent"):
+        result = agent._load_purpose_context()
+
+    assert len(result) <= len("### Wiki Scope (purpose.md)\n") + 100
+    assert any("truncated" in r.message for r in caplog.records)
+
+
+def test_purpose_context_no_warning_when_fits(tmp_wiki, caplog):
+    """No warning when purpose.md content fits within the system char budget."""
+    store = WikiStorage(tmp_wiki / "wiki")
+    search = HybridSearch(store, tmp_wiki / ".synthadoc" / "embeddings.db")
+    provider = AsyncMock()
+
+    short_content = "This wiki covers AI topics."
+    (tmp_wiki / "wiki" / "purpose.md").write_text(short_content, encoding="utf-8")
+
+    agent = QueryAgent(provider=provider, store=store, search=search)
+    agent._char_budgets["system"] = 10_000  # well above the content length
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="synthadoc.agents.query_agent"):
+        result = agent._load_purpose_context()
+
+    assert short_content in result
+    assert not any("truncated" in r.message for r in caplog.records)
+
+
 # ── _parse_lookback_days ──────────────────────────────────────────────────────
 
 def test_parse_lookback_days_week():

--- a/tests/cli/test_routing_cli.py
+++ b/tests/cli/test_routing_cli.py
@@ -67,6 +67,17 @@ def test_routing_validate_clean_reports_ok(tmp_path):
     assert "clean" in result.output
 
 
+def test_routing_validate_reports_unassigned(tmp_path):
+    w = _make_wiki(tmp_path)
+    # alan-turing is assigned; grace-hopper and von-neumann-architecture are not
+    (w / "ROUTING.md").write_text("## People\n- [[alan-turing]]\n")
+    result = runner.invoke(app, ["routing", "validate", "--wiki", str(w)])
+    assert result.exit_code == 0, result.output
+    assert "not assigned" in result.output
+    assert "grace-hopper" in result.output
+    assert "von-neumann-architecture" in result.output
+
+
 def test_routing_clean_removes_dangling(tmp_path):
     w = _make_wiki(tmp_path)
     (w / "ROUTING.md").write_text(ROUTING_WITH_DANGLING)

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -6,7 +6,7 @@ from synthadoc.config import QueryConfig
 
 
 def test_resolve_context_window_claude_sonnet():
-    assert resolve_context_window("claude-sonnet-4-6", 0) == 200_000
+    assert resolve_context_window("claude-sonnet-4-6", 0) == 1_000_000
 
 
 def test_resolve_context_window_gpt4o():
@@ -31,10 +31,10 @@ def test_resolve_context_window_gpt4_exact():
 def test_compute_char_budgets_defaults():
     cfg = QueryConfig()
     budgets = compute_char_budgets("claude-sonnet-4-6", cfg)
-    assert budgets["wiki"] == int(200_000 * 0.60 * 4)
-    assert budgets["history"] == int(200_000 * 0.20 * 4)
-    assert budgets["system"] == int(200_000 * 0.15 * 4)
-    assert budgets["index"] == int(200_000 * 0.05 * 4)
+    assert budgets["wiki"] == int(1_000_000 * 0.60 * 4)
+    assert budgets["history"] == int(1_000_000 * 0.20 * 4)
+    assert budgets["system"] == int(1_000_000 * 0.15 * 4)
+    assert budgets["index"] == int(1_000_000 * 0.05 * 4)
 
 
 def test_compute_char_budgets_respects_custom_pcts():


### PR DESCRIPTION
- Fixes 12 doc/code issues found in the review of README.md, design.md, and user-quick-start-guide.md
- Corrects tutorial-breaking commands (`lifecycle activate`, `lint run`), wrong flag docs (`--wiki`), and stale defaults (`conversation_history_turns`, plugin version, hook paths)
- Fixes `_load_purpose_context()` to respect the `context_system_pct` budget (was ignoring config)
- Adds `count_agents()` and `count_hooks()` to `update_badges.py` so CI enforces badge accuracy for both
- Adds CLI integration test for `routing validate` unassigned-slugs output path