### PR TITLE
fix(ingest,lint): URL sidecar collision, YouTube naming, broken-ref f…

### DIFF
--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -279,6 +279,27 @@ def _slugify(title: str) -> str:
     return slug or "page-" + hashlib.md5(title.encode()).hexdigest()[:8]
 
 
+def _url_sidecar_name(url: str) -> str:
+    """Derive a collision-resistant sidecar name from a URL.
+
+    Uses the last two non-empty path segments joined with '-' so that URLs
+    sharing the same terminal segment (e.g. /profile/dennis-ritchie vs
+    /biography/dennis-ritchie) get distinct sidecar files and citation names.
+    Single-segment paths fall back to that segment alone.
+    """
+    bare = url.split("?")[0].rstrip("/")
+    parts = [seg for seg in bare.split("/") if seg]
+    # parts[0] = "https:", parts[1] = domain — skip both
+    segments = parts[2:] if len(parts) > 2 else parts[1:] if len(parts) > 1 else parts
+    if len(segments) >= 2:
+        name = f"{segments[-2]}-{segments[-1]}"
+    elif segments:
+        name = segments[-1]
+    else:
+        name = "url-source"
+    return re.sub(r"[^A-Za-z0-9.\-]", "-", name).strip("-")[:80] or "url-source"
+
+
 def _strip_leading_frontmatter(content: str) -> str:
     """Remove a leading YAML frontmatter block from LLM-generated page content.
 
@@ -686,7 +707,7 @@ class IngestAgent:
         # For URL / non-file sources p, src_hash, src_size are not set above.
         # Provide safe defaults so the audit call at the end always succeeds.
         if not self._needs_file_check(source):
-            p = Path(source.split("?")[0].rstrip("/").split("/")[-1] or "url-source")
+            p = Path(_url_sidecar_name(source))
             _canonical = _canonical_source(source)
             src_hash = hashlib.sha256(_canonical.encode()).hexdigest()
             src_size = len(_canonical.encode())
@@ -746,6 +767,15 @@ class IngestAgent:
         if extracted.metadata.get("child_sources"):
             result.child_sources = extracted.metadata["child_sources"]
             return result
+
+        # If the skill returned a cleaner slug (e.g. YouTube's "youtube-{video_id}"),
+        # use it as p so the sidecar and citation filename are meaningful and unique.
+        # Without this, all YouTube URLs share the same sidecar name "watch" (from
+        # the URL path segment "watch?v=…").
+        if is_url(source) and not _is_web_search:
+            _meta_slug = extracted.metadata.get("suggested_slug", "")
+            if _meta_slug:
+                p = Path(_slugify(_meta_slug))
 
         # Write text sidecar so the Obsidian Source Viewer can display extracted content.
         #   local file  → not is_url, not _is_web_search → sidecar from source path

--- a/synthadoc/agents/lint_agent.py
+++ b/synthadoc/agents/lint_agent.py
@@ -73,6 +73,28 @@ LINT_SKIP_SLUGS: frozenset[str] = frozenset(
 _LIST_LINK_RE = re.compile(r"^\s*[-*+]\s+\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 
 
+def _citation_source_names(file: str) -> set[str]:
+    """Return all citation names a source may use, for backward-compatible lint checking.
+
+    Ingest agent now uses the last two URL path segments for collision resistance
+    (e.g. biography-dennis-ritchie instead of dennis-ritchie), but older pages
+    were ingested with just the last segment.  Including both forms in the set
+    ensures existing pages don't suddenly show broken_ref after the naming fix.
+    For local files, return {Path(file).name}.
+    """
+    if "://" not in file:
+        return {Path(file).name}
+    bare = file.split("?")[0].rstrip("/")
+    parts = [seg for seg in bare.split("/") if seg]
+    segments = parts[2:] if len(parts) > 2 else parts[1:] if len(parts) > 1 else parts
+    names: set[str] = set()
+    if segments:
+        names.add(segments[-1])                              # old 1-segment form
+        if len(segments) >= 2:
+            names.add(f"{segments[-2]}-{segments[-1]}")     # new 2-segment form
+    return names or {"url-source"}
+
+
 def _check_page_citations(
     slug: str, page: WikiPage, extracted_dir: Path
 ) -> list[dict]:
@@ -83,7 +105,9 @@ def _check_page_citations(
     - broken_ref: filename not listed in page.sources[]
     - out_of_range: line_end exceeds actual line count of the extracted .txt file
     """
-    source_basenames = {Path(s.file).name for s in (page.sources or [])}
+    source_basenames: set[str] = set()
+    for s in (page.sources or []):
+        source_basenames.update(_citation_source_names(s.file))
     issues: list[dict] = []
     seen_citations: set[str] = set()
 
@@ -101,8 +125,12 @@ def _check_page_citations(
             issues.append({"slug": slug, "citation": citation, "reason": "broken_ref"})
             continue
 
-        # Check line range against extracted .txt if available
+        # Check line range against extracted .txt. Sidecars are always written as
+        # <stem>.txt (ingest strips the original extension and appends .txt), so
+        # try the citation filename directly first, then fall back to stem + ".txt".
         txt_path = Path(extracted_dir) / filename
+        if not txt_path.exists():
+            txt_path = Path(extracted_dir) / (Path(filename).stem + ".txt")
         if txt_path.exists():
             try:
                 line_count = txt_path.read_text(encoding="utf-8").count("\n") + 1

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -82,6 +82,18 @@ no Obsidian runtime needed.  Organized by the 14 plugin commands + ribbon icon.
   • lifecycle   : one archived page is transitioned round-trip
                   (archived → draft → active → archived).
   • staging     : policy saved, changed for one call, then restored.
+  • [2] ingest  : ingests https://en.wikipedia.org/wiki/ENIAC; newly-created
+                  pages are deleted after the test (pages_created only —
+                  pre-existing pages that were updated are not reverted).
+  • [6] scaffold: scaffold generates candidate pages; newly-created candidates
+                  are deleted after the test.
+  • sanitizer   : writes _live_test_sanitizer.txt, ingests it, then deletes
+                  the source file and any newly-created wiki page(s) / extracted
+                  sidecar.  Pre-existing pages updated by the ingest are not
+                  reverted (content merge is non-destructive).
+  • truncation  : writes _live_test_truncation.txt, ingests it, then deletes
+                  the source file and any newly-created wiki page(s) / extracted
+                  sidecar.
   All other calls are read-only or idempotent.
 """
 import argparse
@@ -178,6 +190,54 @@ def DELETE(path: str, timeout: int = 10) -> tuple[int, dict | str]:
 
 
 _TERMINAL_STATES = {"completed", "failed", "cancelled", "dead", "skipped"}
+
+
+def _cleanup_job_pages(job_id: str) -> list[str]:
+    """Delete wiki pages that were newly created (not pre-existing) by a job.
+
+    Only removes pages listed in pages_created — pages_updated were pre-existing
+    and reverting them would require restoring their original content.
+    Returns the list of slugs that were deleted.
+    """
+    wiki_root = _discover_wiki_root()
+    if not wiki_root:
+        return []
+    code, body = GET(f"/jobs/{job_id}")
+    if code != 200 or not isinstance(body, dict):
+        return []
+    result = body.get("result") or {}
+    created_slugs: list[str] = result.get("pages_created") or []
+    wiki_dir = wiki_root / "wiki"
+    candidates_dir = wiki_dir / "candidates"
+    deleted: list[str] = []
+    for slug in created_slugs:
+        for d in (wiki_dir, candidates_dir):
+            p = d / f"{slug}.md"
+            if p.exists():
+                p.unlink()
+                deleted.append(slug)
+    return deleted
+
+
+def _cleanup_test_ingest(job_id: str, src_file: pathlib.Path) -> None:
+    """Remove wiki pages and extracted sidecars written by a live test ingest job.
+
+    Deletes pages newly created by the job (not pre-existing pages that were
+    updated), plus any .synthadoc/extracted/<basename> sidecar and companion
+    pagemap JSON, so test runs leave no artifacts behind.
+    """
+    _cleanup_job_pages(job_id)
+    wiki_root = _discover_wiki_root()
+    if not wiki_root:
+        return
+    # Remove extracted sidecar for the test source file
+    extracted = wiki_root / ".synthadoc" / "extracted" / src_file.name
+    if extracted.exists():
+        extracted.unlink()
+    # Remove a companion pagemap JSON if present (PDF sources)
+    pagemap = extracted.with_suffix(".pagemap.json")
+    if pagemap.exists():
+        pagemap.unlink()
 
 
 def _wait_for_terminal(job_id: str, max_wait: int = 300, interval: int = 3) -> str | None:
@@ -407,6 +467,7 @@ def _test_truncation_flag() -> None:
         "microprogramming. EDSAC directly inspired LEO I (1951), the first business computer.",
         encoding="utf-8",
     )  # ~710 chars — exceeds max_source_chars=500 override; topic unlikely to be in the wiki
+    job_id: str | None = None
     try:
         code, body = POST("/jobs/ingest", {"source": str(src), "force": True, "max_source_chars": 500})
         assert code == 200, f"POST /jobs/ingest returned HTTP {code}: {str(body)[:120]}"
@@ -431,6 +492,9 @@ def _test_truncation_flag() -> None:
                     return
         raise AssertionError("No page has truncated=true in sources[] frontmatter")
     finally:
+        # Clean up before deleting the source file (sidecar lookup uses src.name)
+        if job_id:
+            _cleanup_test_ingest(job_id, src)
         src.unlink(missing_ok=True)
 
 
@@ -458,6 +522,7 @@ def _test_sanitizer() -> None:
         "every two years, a trend that held for over five decades.",
         encoding="utf-8",
     )
+    job_id: str | None = None
     try:
         code, body = POST("/jobs/ingest", {"source": str(src), "force": True})
         assert code == 200, f"POST /jobs/ingest returned HTTP {code}: {str(body)[:120]}"
@@ -481,6 +546,9 @@ def _test_sanitizer() -> None:
                 f"Injection phrase found in body of {p.name} — sanitizer not working"
         print("[OK] sanitizer: injection phrase not found in any page body")
     finally:
+        # Clean up before deleting the source file (sidecar lookup uses src.name)
+        if job_id:
+            _cleanup_test_ingest(job_id, src)
         src.unlink(missing_ok=True)
 
 
@@ -854,6 +922,11 @@ def main() -> None:
             ok("GET /jobs/{id}", f"status={body['status']}")
         else:
             fail("GET /jobs/{id}", f"HTTP {code}: {str(body)[:120]}")
+        # Remove any pages that were newly created by the ENIAC ingest (pre-existing
+        # pages that were updated are left untouched — we cannot restore their prior content)
+        deleted = _cleanup_job_pages(ingest_job_id)
+        if deleted:
+            info(f"[2] ingest cleanup: deleted newly-created page(s): {deleted}")
 
     code, body = GET("/jobs")
     if code == 200 and isinstance(body, list):
@@ -953,10 +1026,16 @@ def main() -> None:
     print("\n[6] synthadoc-scaffold — api.scaffold()")
 
     code, body, scaffold_final = _submit_job("/jobs/scaffold", {"domain": "history of computing"})
-    if code == 200 and isinstance(body, dict) and "job_id" in body:
-        ok("POST /jobs/scaffold", f"job_id={body['job_id'][:8]}… status={scaffold_final}")
+    scaffold_job_id: str | None = body.get("job_id") if isinstance(body, dict) else None
+    if code == 200 and scaffold_job_id:
+        ok("POST /jobs/scaffold", f"job_id={scaffold_job_id[:8]}… status={scaffold_final}")
     else:
         fail("POST /jobs/scaffold", f"HTTP {code}: {str(body)[:120]}")
+    # Scaffold creates candidate pages — delete any that are purely new test artifacts
+    if scaffold_job_id:
+        deleted = _cleanup_job_pages(scaffold_job_id)
+        if deleted:
+            info(f"[6] scaffold cleanup: deleted newly-created candidate(s): {deleted}")
 
     # ── [7] synthadoc-audit ───────────────────────────────────────────────────
     print("\n[7] synthadoc-audit — api.auditHistory(), api.auditCosts(), api.queryHistory(), api.auditEvents()")


### PR DESCRIPTION
…alse positives, live test cleanup

- ingest_agent: use last 2 URL path segments for sidecar names (_url_sidecar_name) so URLs sharing a terminal segment (e.g. /profile/dennis-ritchie vs /biography/dennis-ritchie) no longer overwrite each other's sidecars
- ingest_agent: override p with skill-provided suggested_slug after extraction so YouTube URLs produce meaningful unique names (youtube-<id>) instead of all sharing "watch" as the sidecar/citation filename
- lint_agent: add _citation_source_names() returning both old 1-segment and new 2-segment forms for backward-compatible broken_ref detection
- lint_agent: fix sidecar path lookup to fall back to stem+".txt" so out_of_range checks actually find sidecars written by the ingest agent
- lint_agent: fix source_basenames to strip URL query strings so citations like ^[detail.php:N-N] are not falsely flagged as broken_ref
- live_plugin_test: add _cleanup_job_pages() and _cleanup_test_ingest() helpers that delete only pages_created (not pages_updated) after each test ingest; wire cleanup into truncation, sanitizer, ENIAC, and scaffold test sections; update module docstring to accurately describe all side effects