### PR TITLE
fix(citations): resolve out_of_range and YouTube broken_ref lint errors

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1158,6 +1158,13 @@ max_pages_per_ingest  = 15
 chunk_size            = 1500
 chunk_overlap         = 150
 fetch_timeout_seconds = 30   # seconds to wait for a URL response before retrying
+# Citation pass (Pass 4) tuning — these two settings work together:
+#   citation_source_lines — how many lines of the source the LLM sees when placing ^[...] markers.
+#                           Increase if lint reports out_of_range on long sources (transcripts, PDFs).
+#   citation_max_tokens   — output token budget for the annotated section returned by the LLM.
+#                           Increase if you raise citation_source_lines and have long wiki sections.
+# citation_source_lines = 400
+# citation_max_tokens = 8192
 
 [logs]
 level        = "INFO"
@@ -1238,6 +1245,8 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 | `search.vector` | bool | `false` | Enable semantic re-ranking; downloads `BAAI/bge-small-en-v1.5` (~130 MB) once on first enable |
 | `search.vector_top_candidates` | int | `20` | BM25 candidate pool size when vector re-ranking is active |
 | `ingest.max_source_chars` | int | `32000` | Character limit applied to each source before the LLM call. Sources exceeding this limit are truncated; the page's `sources:` frontmatter entry gets `truncated: true` and lint emits a warning. Override per-run with `--max-source-chars N`. _(v1.0.0)_ |
+| `ingest.citation_source_lines` | int | `400` | Number of source lines the LLM sees during Pass 4 (citation annotation). Increase if lint reports `out_of_range` on long sources such as transcripts or PDFs. Raise `citation_max_tokens` in proportion when increasing this value. |
+| `ingest.citation_max_tokens` | int | `8192` | Output token budget for the annotated section returned by Pass 4. Increase when `citation_source_lines` is raised or wiki sections are long, to avoid truncated annotations. |
 | `query.context_wiki_pct` | float | `0.60` | Fraction of the model context window reserved for wiki source pages. _(v1.0.0)_ |
 | `query.context_history_pct` | float | `0.20` | Fraction reserved for conversation history. _(v1.0.0)_ |
 | `query.context_system_pct` | float | `0.15` | Fraction reserved for system prompt and instructions. Parsed and validated but not yet enforced as a hard cap in v1.0.0. _(v1.0.0)_ |

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -382,6 +382,33 @@ def _append_source_ref(page: "WikiPage", ref: "SourceRef") -> None:
                 break
 
 
+def _propagate_source_update(
+    store: "WikiStorage", source_url: str, new_truncated: bool, new_size: int, skip_slug: str
+) -> None:
+    """After a force reingest, sync truncated/size on every OTHER page that still references source_url.
+
+    When the LLM chooses action=create for a re-ingested URL, the source moves to a new page
+    while the old page keeps a stale SourceRef(truncated=True).  This walks all other pages
+    and updates the flag so lint stops reporting a warning that the user already resolved.
+    """
+    for slug in store.list_slugs():
+        if slug == skip_slug:
+            continue
+        page = store.read_page(slug)
+        if not page:
+            continue
+        changed = False
+        for ref in (page.sources or []):
+            if ref.file == source_url and (ref.truncated != new_truncated or ref.size != new_size):
+                ref.truncated = new_truncated
+                ref.size = new_size
+                changed = True
+        if changed:
+            with store.page_lock(slug):
+                store.write_page(slug, page)
+            logger.debug("ingest: propagated truncation update to slug=%s source=%s", slug, source_url[:80])
+
+
 def _extract_key_data(source_text: str) -> list[str]:
     """Extract numerical facts, formulas, and rates from source text deterministically.
 
@@ -1183,6 +1210,12 @@ class IngestAgent:
                                 branch = await self._pick_routing_branch(slug, new_page, ri)
                                 ri.add_slug(slug, branch)
                                 ri.save(self._routing_path)
+
+        # On force reingest, propagate updated truncated/size to any other page that
+        # still holds a SourceRef for the same URL (e.g. the old page when the LLM
+        # chose action=create for a source it previously appended to a different page).
+        if bust_cache and final_slug and "://" in source:
+            _propagate_source_update(self._store, source, _truncated, _source_len, final_slug)
 
         if result.pages_created or result.pages_updated:
             await self._update_overview()

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -469,6 +469,7 @@ class IngestAgent:
             annotated = cached
         else:
             try:
+                _max_tok = int(getattr(getattr(self._cfg, "ingest", None), "citation_max_tokens", _CITATION_MAX_TOKENS))
                 resp = await self._provider.complete(
                     messages=[Message(
                         role="user",
@@ -479,7 +480,7 @@ class IngestAgent:
                         ),
                     )],
                     temperature=0.0,
-                    max_tokens=_CITATION_MAX_TOKENS,
+                    max_tokens=_max_tok,
                 )
                 raw = resp.text.strip() or section
                 # Bug A fix: length-based sanity check replaces exact first-line match.

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -110,11 +110,11 @@ _OVERVIEW_PROMPT = (
     "Pages:\n{pages}"
 )
 
-CITATION_PASS4_CACHE_VERSION = "v1"
+CITATION_PASS4_CACHE_VERSION = "v2"  # bumped: wider source window (400 lines) + hallucination guard
 ANALYSIS_CACHE_VERSION = "v2"  # bumped to include OKF type field
 DECISION_CACHE_VERSION = "v3"  # bumped to add entity-profile must-create rule (RULE 2b)
 _CITATION_EXCERPT_LEN = 100
-_MAX_CITATION_LINES = 120
+_MAX_CITATION_LINES = 400
 _MAX_CITE_LEN_RATIO = 0.8
 
 _CODE_BLOCK_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
@@ -166,6 +166,8 @@ _CITATION_PROMPT = (
     "  - Example: if the source filename is '{filename}' and the claim is on lines 7-9, write "
     "^[{filename}:7-9]\n\n"
     "Do not annotate headings, transition sentences, or [[wikilinks]].\n"
+    "IMPORTANT: Only cite line numbers that appear in the numbered source above. "
+    "If the relevant content is not visible in the excerpt, skip the citation for that paragraph.\n"
     "Return ONLY the annotated section — identical to the input except for added ^[...] markers.\n\n"
     "Source filename: {filename}\n\n"
     "Source text (lines numbered):\n{numbered_source}\n\n"

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -110,12 +110,13 @@ _OVERVIEW_PROMPT = (
     "Pages:\n{pages}"
 )
 
-CITATION_PASS4_CACHE_VERSION = "v2"  # bumped: wider source window (400 lines) + hallucination guard
+CITATION_PASS4_CACHE_VERSION = "v3"  # bumped: explicit max_tokens=8192 to avoid truncation on long sections
 ANALYSIS_CACHE_VERSION = "v2"  # bumped to include OKF type field
 DECISION_CACHE_VERSION = "v3"  # bumped to add entity-profile must-create rule (RULE 2b)
 _CITATION_EXCERPT_LEN = 100
 _MAX_CITATION_LINES = 400
 _MAX_CITE_LEN_RATIO = 0.8
+_CITATION_MAX_TOKENS = 8192   # output cap for citation pass — large enough for long transcript sections
 
 _CODE_BLOCK_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
 _BOLD_BULLET_NUM_RE = re.compile(
@@ -478,6 +479,7 @@ class IngestAgent:
                         ),
                     )],
                     temperature=0.0,
+                    max_tokens=_CITATION_MAX_TOKENS,
                 )
                 raw = resp.text.strip() or section
                 # Bug A fix: length-based sanity check replaces exact first-line match.

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -391,7 +391,7 @@ def _propagate_source_update(
     while the old page keeps a stale SourceRef(truncated=True).  This walks all other pages
     and updates the flag so lint stops reporting a warning that the user already resolved.
     """
-    for slug in store.list_slugs():
+    for slug in store.all_slugs():
         if slug == skip_slug:
             continue
         page = store.read_page(slug)

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -155,12 +155,14 @@ def _normalize_citation_markers(text: str) -> str:
     return _NONCANONICAL_CITE_RE.sub(_fix, text)
 
 
-def _scrub_source_citations(content: str, filename: str, total_lines: int) -> str:
-    """Remove or clamp ^[filename:start-end] markers in *content* that exceed total_lines.
+def _scrub_source_citations(content: str, filename: str, source_text: str) -> str:
+    """Remove or clamp ^[filename:start-end] markers in *content* that exceed the
+    actual line count of *source_text*.
 
     Called on existing page content before appending a new update section so that
     stale out-of-range citations left by previous reingests are cleaned up.
     """
+    total_lines = len(source_text.splitlines())
     fname_lower = filename.lower()
 
     def _fix(m: re.Match) -> str:
@@ -1029,8 +1031,7 @@ class IngestAgent:
                             key_section = "\n\n## Key Data\n\n" + "\n".join(f"- {item}" for item in _key_items)
                             section = section + key_section
                         # Scrub stale out-of-range citations from previous reingests
-                        _src_line_count = len(extracted.text.splitlines())
-                        page.content = _scrub_source_citations(page.content, p.name, _src_line_count)
+                        page.content = _scrub_source_citations(page.content, p.name, extracted.text)
                         # Pass 4: annotate only the new update section
                         section, citations = await self._annotate_citations(
                             section, extracted.text, p.name, bust_cache=bust_cache
@@ -1092,8 +1093,7 @@ class IngestAgent:
                                 key_section = "\n\n## Key Data\n\n" + "\n".join(f"- {item}" for item in _key_items)
                                 section = section + key_section
                             # Scrub stale out-of-range citations from previous reingests
-                            _src_line_count = len(extracted.text.splitlines())
-                            page.content = _scrub_source_citations(page.content, p.name, _src_line_count)
+                            page.content = _scrub_source_citations(page.content, p.name, extracted.text)
                             # Pass 4: annotate only the new section
                             section, citations = await self._annotate_citations(
                                 section, extracted.text, p.name, bust_cache=bust_cache

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -155,6 +155,27 @@ def _normalize_citation_markers(text: str) -> str:
     return _NONCANONICAL_CITE_RE.sub(_fix, text)
 
 
+def _scrub_source_citations(content: str, filename: str, total_lines: int) -> str:
+    """Remove or clamp ^[filename:start-end] markers in *content* that exceed total_lines.
+
+    Called on existing page content before appending a new update section so that
+    stale out-of-range citations left by previous reingests are cleaned up.
+    """
+    fname_lower = filename.lower()
+
+    def _fix(m: re.Match) -> str:
+        if m.group(1).lower() != fname_lower:
+            return m.group(0)
+        start, end = int(m.group(2)), int(m.group(3))
+        if start > total_lines:
+            return ""
+        if end > total_lines:
+            return f"^[{m.group(1)}:{start}-{total_lines}]"
+        return m.group(0)
+
+    return _CITATION_RE.sub(_fix, content)
+
+
 _CITATION_PROMPT = (
     "You are a citation annotator. Given a wiki page section and the source text it was "
     "compiled from, insert a citation marker at the END of each paragraph that makes a "
@@ -1007,6 +1028,9 @@ class IngestAgent:
                         if len(_key_items) >= _KEY_DATA_MIN_ITEMS:
                             key_section = "\n\n## Key Data\n\n" + "\n".join(f"- {item}" for item in _key_items)
                             section = section + key_section
+                        # Scrub stale out-of-range citations from previous reingests
+                        _src_line_count = len(extracted.text.splitlines())
+                        page.content = _scrub_source_citations(page.content, p.name, _src_line_count)
                         # Pass 4: annotate only the new update section
                         section, citations = await self._annotate_citations(
                             section, extracted.text, p.name, bust_cache=bust_cache
@@ -1067,6 +1091,9 @@ class IngestAgent:
                             if len(_key_items) >= _KEY_DATA_MIN_ITEMS:
                                 key_section = "\n\n## Key Data\n\n" + "\n".join(f"- {item}" for item in _key_items)
                                 section = section + key_section
+                            # Scrub stale out-of-range citations from previous reingests
+                            _src_line_count = len(extracted.text.splitlines())
+                            page.content = _scrub_source_citations(page.content, p.name, _src_line_count)
                             # Pass 4: annotate only the new section
                             section, citations = await self._annotate_citations(
                                 section, extracted.text, p.name, bust_cache=bust_cache

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -110,7 +110,7 @@ _OVERVIEW_PROMPT = (
     "Pages:\n{pages}"
 )
 
-CITATION_PASS4_CACHE_VERSION = "v3"  # bumped: explicit max_tokens=8192 to avoid truncation on long sections
+CITATION_PASS4_CACHE_VERSION = "v4"  # bumped: total_lines ceiling in prompt + post-processing clamp
 ANALYSIS_CACHE_VERSION = "v2"  # bumped to include OKF type field
 DECISION_CACHE_VERSION = "v3"  # bumped to add entity-profile must-create rule (RULE 2b)
 _CITATION_EXCERPT_LEN = 100
@@ -167,11 +167,12 @@ _CITATION_PROMPT = (
     "  - Example: if the source filename is '{filename}' and the claim is on lines 7-9, write "
     "^[{filename}:7-9]\n\n"
     "Do not annotate headings, transition sentences, or [[wikilinks]].\n"
-    "IMPORTANT: Only cite line numbers that appear in the numbered source above. "
+    "IMPORTANT: The source has exactly {total_lines} lines. "
+    "Never write a line number greater than {total_lines}. "
     "If the relevant content is not visible in the excerpt, skip the citation for that paragraph.\n"
     "Return ONLY the annotated section — identical to the input except for added ^[...] markers.\n\n"
     "Source filename: {filename}\n\n"
-    "Source text (lines numbered):\n{numbered_source}\n\n"
+    "Source text ({total_lines} lines, numbered):\n{numbered_source}\n\n"
     "Page section to annotate:\n{section}"
 )
 
@@ -453,9 +454,11 @@ class IngestAgent:
         # Bug C fix: truncate numbered source by line count, not character count.
         # Limit is configurable via [ingest] citation_source_lines in config.toml.
         _line_limit = int(getattr(getattr(self._cfg, "ingest", None), "citation_source_lines", _MAX_CITATION_LINES))
+        source_lines = source_text.splitlines()
+        total_lines = min(len(source_lines), _line_limit)
         numbered = "\n".join(
             f"{i+1}: {line}"
-            for i, line in enumerate(source_text.splitlines()[:_line_limit])
+            for i, line in enumerate(source_lines[:_line_limit])
         )
         body_hash = hashlib.sha256(section.encode()).hexdigest()
         ck = make_cache_key(
@@ -477,6 +480,7 @@ class IngestAgent:
                             filename=filename,
                             numbered_source=numbered,
                             section=section,
+                            total_lines=total_lines,
                         ),
                     )],
                     temperature=0.0,
@@ -531,6 +535,18 @@ class IngestAgent:
         # Normalize single-line and multi-range citations to canonical N-N format
         # before extraction so they are not silently dropped or flagged as malformed.
         annotated = _normalize_citation_markers(annotated)
+
+        # Safety clamp: remove citations whose start exceeds the source; clamp end
+        # to total_lines so the LLM cannot produce out_of_range markers even when
+        # it extrapolates chunk boundaries beyond the actual source length.
+        def _clamp(m: re.Match) -> str:
+            fname, start, end = m.group(1), int(m.group(2)), int(m.group(3))
+            if start > total_lines:
+                return ""
+            if end > total_lines:
+                end = total_lines
+            return f"^[{fname}:{start}-{end}]"
+        annotated = _CITATION_RE.sub(_clamp, annotated)
 
         # Bug B fix: case-insensitive filename comparison
         citations = [

--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -449,10 +449,12 @@ class IngestAgent:
                 )
             return section, []
 
-        # Bug C fix: truncate numbered source by line count, not character count
+        # Bug C fix: truncate numbered source by line count, not character count.
+        # Limit is configurable via [ingest] citation_source_lines in config.toml.
+        _line_limit = int(getattr(getattr(self._cfg, "ingest", None), "citation_source_lines", _MAX_CITATION_LINES))
         numbered = "\n".join(
             f"{i+1}: {line}"
-            for i, line in enumerate(source_text.splitlines()[:_MAX_CITATION_LINES])
+            for i, line in enumerate(source_text.splitlines()[:_line_limit])
         )
         body_hash = hashlib.sha256(section.encode()).hexdigest()
         ck = make_cache_key(

--- a/synthadoc/agents/lint_agent.py
+++ b/synthadoc/agents/lint_agent.py
@@ -72,6 +72,11 @@ LINT_SKIP_SLUGS: frozenset[str] = frozenset(
 # e.g. "- [[some-slug]] — description" or "* [[slug]]"
 _LIST_LINK_RE = re.compile(r"^\s*[-*+]\s+\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 
+# Extracts the 11-char video ID from any canonical YouTube URL form.
+_YOUTUBE_ID_RE = re.compile(
+    r"(?:youtube\.com/(?:watch\?v=|shorts/|live/|embed/|v/)|youtu\.be/)([A-Za-z0-9_-]{11})"
+)
+
 
 def _citation_source_names(file: str) -> set[str]:
     """Return all citation names a source may use, for backward-compatible lint checking.
@@ -81,9 +86,16 @@ def _citation_source_names(file: str) -> set[str]:
     were ingested with just the last segment.  Including both forms in the set
     ensures existing pages don't suddenly show broken_ref after the naming fix.
     For local files, return {Path(file).name}.
+    YouTube URLs are a special case: the ingest agent renames the sidecar to
+    "youtube-{video_id}" via suggested_slug, so SourceRef.file (the raw URL)
+    must map to that same slug here.
     """
     if "://" not in file:
         return {Path(file).name}
+    yt = _YOUTUBE_ID_RE.search(file)
+    if yt:
+        slug = re.sub(r"[^a-z0-9]+", "-", f"youtube-{yt.group(1)}".lower()).strip("-")
+        return {slug}
     bare = file.split("?")[0].rstrip("/")
     parts = [seg for seg in bare.split("/") if seg]
     segments = parts[2:] if len(parts) > 2 else parts[1:] if len(parts) > 1 else parts

--- a/synthadoc/agents/lint_agent.py
+++ b/synthadoc/agents/lint_agent.py
@@ -77,6 +77,14 @@ _YOUTUBE_ID_RE = re.compile(
     r"(?:youtube\.com/(?:watch\?v=|shorts/|live/|embed/|v/)|youtu\.be/)([A-Za-z0-9_-]{11})"
 )
 
+# Same character set allowed in sidecar filenames as _url_sidecar_name in ingest_agent.py.
+_URL_NAME_SAFE_RE = re.compile(r"[^A-Za-z0-9.\-]+")
+
+
+def _url_name_normalize(raw: str) -> str:
+    """Apply the same character filter as _url_sidecar_name in ingest_agent.py."""
+    return _URL_NAME_SAFE_RE.sub("-", raw).strip("-") or "url-source"
+
 
 def _citation_source_names(file: str) -> set[str]:
     """Return all citation names a source may use, for backward-compatible lint checking.
@@ -89,6 +97,9 @@ def _citation_source_names(file: str) -> set[str]:
     YouTube URLs are a special case: the ingest agent renames the sidecar to
     "youtube-{video_id}" via suggested_slug, so SourceRef.file (the raw URL)
     must map to that same slug here.
+    For all URL-based sources, names are normalized through _url_name_normalize
+    to match the transformation applied by _url_sidecar_name (e.g. underscores
+    in Wikipedia-style paths become hyphens).
     """
     if "://" not in file:
         return {Path(file).name}
@@ -101,9 +112,9 @@ def _citation_source_names(file: str) -> set[str]:
     segments = parts[2:] if len(parts) > 2 else parts[1:] if len(parts) > 1 else parts
     names: set[str] = set()
     if segments:
-        names.add(segments[-1])                              # old 1-segment form
+        names.add(_url_name_normalize(segments[-1]))                              # old 1-segment form
         if len(segments) >= 2:
-            names.add(f"{segments[-2]}-{segments[-1]}")     # new 2-segment form
+            names.add(_url_name_normalize(f"{segments[-2]}-{segments[-1]}"))     # new 2-segment form
     return names or {"url-source"}
 
 

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -53,9 +53,13 @@ default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}
 
 [ingest]
 max_pages_per_ingest = 15
-# Lines of source text sent to the LLM when placing citation markers (Pass 4).
-# Increase if lint reports out_of_range citations on long sources (transcripts, large PDFs).
+# Citation pass (Pass 4) tuning — these two settings work together:
+#   citation_source_lines — how many lines of the source the LLM sees when placing ^[...] markers.
+#                           Increase if lint reports out_of_range on long sources (transcripts, PDFs).
+#   citation_max_tokens   — output token budget for the annotated section returned by the LLM.
+#                           Increase if you raise citation_source_lines and have long wiki sections.
 # citation_source_lines = 400
+# citation_max_tokens = 8192
 
 [cost]
 soft_warn_usd = 0.50

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -53,6 +53,9 @@ default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}
 
 [ingest]
 max_pages_per_ingest = 15
+# Lines of source text sent to the LLM when placing citation markers (Pass 4).
+# Increase if lint reports out_of_range citations on long sources (transcripts, large PDFs).
+# citation_source_lines = 400
 
 [cost]
 soft_warn_usd = 0.50

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -86,6 +86,7 @@ class IngestConfig:
     staging_policy: str = "off"           # "off" | "all" | "threshold"
     staging_confidence_min: str = "high"  # "high" | "medium" | "low"
     max_source_chars: int = 32000         # chars read from a source before truncation (~8k tokens)
+    citation_source_lines: int = 400      # lines of source text shown to the citation LLM (Pass 4)
 
 
 @dataclass
@@ -326,6 +327,7 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
         staging_policy=ig.get("staging_policy", "off"),
         staging_confidence_min=ig.get("staging_confidence_min", "high"),
         max_source_chars=int(ig.get("max_source_chars", 32000)),
+        citation_source_lines=int(ig.get("citation_source_lines", 400)),
     )
 
     # --- query ---

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -87,6 +87,7 @@ class IngestConfig:
     staging_confidence_min: str = "high"  # "high" | "medium" | "low"
     max_source_chars: int = 32000         # chars read from a source before truncation (~8k tokens)
     citation_source_lines: int = 400      # lines of source text shown to the citation LLM (Pass 4)
+    citation_max_tokens: int = 8192       # output token budget for the citation LLM response
 
 
 @dataclass
@@ -328,6 +329,7 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
         staging_confidence_min=ig.get("staging_confidence_min", "high"),
         max_source_chars=int(ig.get("max_source_chars", 32000)),
         citation_source_lines=int(ig.get("citation_source_lines", 400)),
+        citation_max_tokens=int(ig.get("citation_max_tokens", 8192)),
     )
 
     # --- query ---

--- a/tests/agents/test_ingest_agent.py
+++ b/tests/agents/test_ingest_agent.py
@@ -1997,7 +1997,10 @@ async def test_pass4_result_recorded_in_claim_citations(tmp_wiki, db, cache):
     )
 
     source = tmp_wiki / "raw_sources" / "research.md"
-    source.write_text("Neural networks are powerful tools.", encoding="utf-8")
+    source.write_text(
+        "Neural networks are powerful tools.\nThey learn from data.\nDeep learning is a subset.",
+        encoding="utf-8",
+    )
 
     with patch.object(IngestAgent, "_update_overview", AsyncMock()):
         result = await agent.ingest(str(source))
@@ -2546,6 +2549,7 @@ def test_citation_prompt_example_uses_actual_filename():
         filename="my-source.txt",
         numbered_source=numbered,
         section="Some claim from the source.",
+        total_lines=9,
     )
     # The formatted prompt must include the concrete filename in the example
     assert "^[my-source.txt:7-9]" in formatted, \

--- a/tests/agents/test_lint_agent.py
+++ b/tests/agents/test_lint_agent.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 Paul Chen / axoviq.com
 import pytest
 from unittest.mock import AsyncMock
-from synthadoc.agents.lint_agent import LintAgent, LintReport, find_orphan_slugs, _fix_dangling_wikilinks, LINT_SKIP_SLUGS, LINT_SKIP_SOURCE_SLUGS, _parse_adversarial_response, _check_page_citations, read_current_lint_state
+from synthadoc.agents.lint_agent import LintAgent, LintReport, find_orphan_slugs, _fix_dangling_wikilinks, LINT_SKIP_SLUGS, LINT_SKIP_SOURCE_SLUGS, _parse_adversarial_response, _check_page_citations, _citation_source_names, read_current_lint_state
 from synthadoc.providers.base import CompletionResponse
 from synthadoc.storage.wiki import WikiStorage, WikiPage, SourceRef
 from synthadoc.storage.log import LogWriter, AuditDB
@@ -561,6 +561,41 @@ def test_check_citations_reversed_range(tmp_path):
     )
     issues = _check_page_citations("t", page, extracted_dir=tmp_path)
     assert any(i["reason"] == "malformed" for i in issues)
+
+
+def test_citation_source_names_youtube_watch():
+    """YouTube watch URL maps to 'youtube-{slugified_id}', matching ingest suggested_slug."""
+    names = _citation_source_names("https://www.youtube.com/watch?v=O5nskjZ_GoI")
+    assert names == {"youtube-o5nskjz-goi"}
+
+
+def test_citation_source_names_youtube_shorts():
+    names = _citation_source_names("https://www.youtube.com/shorts/dQw4w9WgXcQ")
+    assert names == {"youtube-dqw4w9wgxcq"}
+
+
+def test_citation_source_names_youtube_does_not_produce_watch():
+    """Ensure old broken derivation ('watch') is no longer returned for YouTube URLs."""
+    names = _citation_source_names("https://www.youtube.com/watch?v=O5nskjZ_GoI")
+    assert "watch" not in names
+
+
+def test_check_citations_youtube_no_broken_ref(tmp_path):
+    """Citations annotated as youtube-... should not be flagged broken_ref."""
+    extracted = tmp_path / "extracted"
+    extracted.mkdir()
+    txt = extracted / "youtube-o5nskjz-goi.txt"
+    txt.write_text("line1\nline2\nline3\n")
+    page = WikiPage(
+        title="T", tags=[], content="Fact.^[youtube-o5nskjz-goi:1-2]",
+        status="active", confidence="high",
+        sources=[SourceRef(
+            file="https://www.youtube.com/watch?v=O5nskjZ_GoI",
+            hash="x", size=1, ingested="2026-01-01",
+        )],
+    )
+    issues = _check_page_citations("t", page, extracted_dir=extracted)
+    assert issues == []
 
 
 # ── read_current_lint_state ───────────────────────────────────────────────────

--- a/tests/agents/test_lint_agent.py
+++ b/tests/agents/test_lint_agent.py
@@ -563,6 +563,17 @@ def test_check_citations_reversed_range(tmp_path):
     assert any(i["reason"] == "malformed" for i in issues)
 
 
+def test_citation_source_names_plain_url():
+    """Regular URL: underscores normalized to hyphens, matching _url_sidecar_name output."""
+    names = _citation_source_names("https://en.wikipedia.org/wiki/Alan_Turing")
+    # ingest produces "wiki-Alan-Turing" (underscore → hyphen); both 1- and 2-segment forms present
+    assert "wiki-Alan-Turing" in names
+    assert "Alan-Turing" in names
+    # raw underscore form must NOT be present — that would never match the sidecar filename
+    assert "Alan_Turing" not in names
+    assert "wiki-Alan_Turing" not in names
+
+
 def test_citation_source_names_youtube_watch():
     """YouTube watch URL maps to 'youtube-{slugified_id}', matching ingest suggested_slug."""
     names = _citation_source_names("https://www.youtube.com/watch?v=O5nskjZ_GoI")


### PR DESCRIPTION
What

Fixes three citation problems surfaced by lint - out_of_range markers surviving force reingest, broken_ref false positives on YouTube-sourced pages, and a stale truncation warning persisting after the source was re-ingested onto a new page.

Why

After ingesting long sources (transcripts, PDFs), the citation LLM occasionally wrote line numbers beyond the actual source length, producing out_of_range lint errors. Force reingesting the source didn't clear them because the old content was appended to, not replaced. YouTube citations failed broken_ref because the citation name derived from the URL didn't match the sidecar filename the ingest agent produced. The truncation warning bug appeared when a force reingest caused the LLM to create a new page for the URL, leaving the old page holding a stale SourceRef(truncated=True).

Changes

- Lint: YouTube broken_ref fix: _citation_source_names now detects YouTube URLs and maps them to youtube-{video-id}, matching the sidecar filename ingest produces; URL path segments are normalized through the same character filter as _url_sidecar_name

- Ingest: out_of_range three-layer fix:
  - Raised Pass 4 source window from 120 → 400 lines; added {total_lines} ceiling to the citation prompt so the LLM can't hallucinate line numbers beyond the source
  - Added post-processing clamp in _annotate_citations() as a hard safety net after normalization
  - New _scrub_source_citations() helper scrubs stale out-of-range markers from existing page content before appending new update sections

- Ingest: stale truncation fix: New _propagate_source_update() walks all other pages after a force reingest and syncs truncated/size on any SourceRef pointing to the same URL

- Config: Two new [ingest] tuning knobs - citation_source_lines (default 400) and citation_max_tokens (default 8192) — exposed in IngestConfig, the config template, and docs/design.md

- Cache: CITATION_PASS4_CACHE_VERSION bumped to v4 to invalidate stale cached citations

- Tests: New tests for _citation_source_names covering plain URLs, YouTube watch/shorts, and end-to-end broken_ref absence; existing tests updated for the new total_lines prompt field and expanded mock source