### PR TITLE
Update cost per token for all supported providers

### DIFF
--- a/synthadoc/providers/pricing.py
+++ b/synthadoc/providers/pricing.py
@@ -3,41 +3,92 @@
 """Per-model LLM pricing table.
 
 Refresh at each major release. Update _LAST_UPDATED and the rates below.
-Sources (checked 2026-04-22):
-  Anthropic — https://docs.anthropic.com/en/docs/about-claude/pricing
-  OpenAI    — https://openai.com/api/pricing/
+Sources (checked 2026-07-19):
+  Anthropic — https://platform.claude.com/docs/en/docs/about-claude/models/overview
+  OpenAI    — https://developers.openai.com/api/docs/pricing
   Gemini    — https://ai.google.dev/gemini-api/docs/pricing
-  Groq      — https://groq.com/pricing
-  MiniMax   — https://platform.minimax.io/docs/pricing/overview
+  Groq      — https://groq.com/pricing/
+  MiniMax   — https://platform.minimax.io/docs/guides/pricing-paygo
+  DeepSeek  — https://api-docs.deepseek.com/quick_start/pricing
+  Qwen      — https://www.alibabacloud.com/help/en/model-studio/model-pricing
 """
 from __future__ import annotations
 
-_LAST_UPDATED = "2026-04-22"
+_LAST_UPDATED = "2026-07-19"
 
 # (input_usd_per_token, output_usd_per_token)
+# All rates are cache-miss / non-cached standard tier unless noted.
 _PRICING: dict[str, tuple[float, float]] = {
-    # Anthropic
-    "claude-opus-4-7":                       (5.00e-6, 25.00e-6),
-    "claude-sonnet-4-6":                     (3.00e-6, 15.00e-6),
-    "claude-haiku-4-5-20251001":             (1.00e-6,  5.00e-6),
-    # OpenAI
-    "gpt-4o":                                (2.50e-6, 10.00e-6),
-    "gpt-4o-mini":                           (0.15e-6,  0.60e-6),
-    # Gemini (via OpenAI-compatible endpoint)
-    "gemini-2.5-flash-lite":                 (0.075e-6, 0.30e-6),  # default; free: 30 RPM / 1,000 RPD
-    "gemini-2.5-flash":                      (0.30e-6,  2.50e-6),  # free: 10 RPM / 250 RPD
-    "gemini-1.5-flash":                      (0.075e-6, 0.30e-6),  # free: 15 RPM / 1,500 RPD
-    "gemini-2.0-flash":                      (0.10e-6,  0.40e-6),  # deprecated Jun 1 2026
-    "gemini-1.5-pro":                        (2.50e-6, 10.00e-6),
-    # MiniMax (via OpenAI-compatible endpoint) — text-only, no vision
-    "MiniMax-M2.5":                          (0.15e-6,  1.20e-6),
-    "MiniMax-M2.5-highspeed":               (0.15e-6,  1.20e-6),
-    "MiniMax-M2.7":                          (0.30e-6,  1.20e-6),
-    "MiniMax-M2.7-highspeed":               (0.30e-6,  1.20e-6),
-    # Groq
-    "llama-3.3-70b-versatile":               (0.59e-6,  0.79e-6),
-    "llama4-scout-17b-16e-instruct":         (0.11e-6,  0.34e-6),
-    "llama4-maverick-17b-128e-instruct":     (0.50e-6,  0.77e-6),
+    # ── Anthropic ────────────────────────────────────────────────────────────
+    "claude-fable-5":            (10.00e-6, 50.00e-6),  # current flagship (GA 2026-06-09)
+    "claude-opus-4-8":           ( 5.00e-6, 25.00e-6),  # recommended for agentic/enterprise
+    "claude-sonnet-5":           ( 3.00e-6, 15.00e-6),  # intro pricing $2/$10 through 2026-08-31
+    "claude-haiku-4-5-20251001": ( 1.00e-6,  5.00e-6),
+    # legacy — still available
+    "claude-opus-4-7":           ( 5.00e-6, 25.00e-6),
+    "claude-opus-4-6":           ( 5.00e-6, 25.00e-6),
+    "claude-sonnet-4-6":         ( 3.00e-6, 15.00e-6),
+
+    # ── OpenAI ───────────────────────────────────────────────────────────────
+    # GPT-5.x (current flagship family)
+    "gpt-5.6-sol":               ( 5.00e-6, 30.00e-6),
+    "gpt-5.6-terra":             ( 2.50e-6, 15.00e-6),
+    "gpt-5.6-luna":              ( 1.00e-6,  6.00e-6),
+    "gpt-5.5":                   ( 5.00e-6, 30.00e-6),
+    "gpt-5.4":                   ( 2.50e-6, 15.00e-6),
+    "gpt-5.4-mini":              ( 0.75e-6,  4.50e-6),
+    # GPT-4.x / reasoning
+    "gpt-4.1":                   ( 2.00e-6,  8.00e-6),
+    "gpt-4.1-mini":              ( 0.40e-6,  1.60e-6),
+    "gpt-4o":                    ( 2.50e-6, 10.00e-6),
+    "gpt-4o-mini":               ( 0.15e-6,  0.60e-6),
+    "o3":                        ( 2.00e-6,  8.00e-6),
+    "o4-mini":                   ( 1.10e-6,  4.40e-6),
+
+    # ── Gemini ───────────────────────────────────────────────────────────────
+    # Gemini 3.x (current)
+    "gemini-3.5-flash":          ( 1.50e-6,  9.00e-6),
+    "gemini-3.1-flash-lite":     ( 0.25e-6,  1.50e-6),
+    "gemini-3.1-pro-preview":    ( 2.00e-6, 12.00e-6),
+    # Gemini 2.5
+    "gemini-2.5-pro":            ( 1.25e-6, 10.00e-6),  # ≤200k input tier
+    "gemini-2.5-flash":          ( 0.30e-6,  2.50e-6),
+    "gemini-2.5-flash-lite":     ( 0.10e-6,  0.40e-6),
+    # Gemini 2.0 / 1.5 (older)
+    "gemini-2.0-flash":          ( 0.10e-6,  0.40e-6),  # deprecated 2026-06-01
+    "gemini-1.5-flash":          ( 0.075e-6, 0.30e-6),
+    "gemini-1.5-pro":            ( 2.50e-6, 10.00e-6),
+
+    # ── MiniMax ──────────────────────────────────────────────────────────────
+    # All rates include MiniMax's permanent 50% discount; highspeed = priority queue
+    "MiniMax-M3":                ( 0.30e-6,  1.20e-6),
+    "MiniMax-M2.7":              ( 0.30e-6,  1.20e-6),
+    "MiniMax-M2.7-highspeed":    ( 0.60e-6,  2.40e-6),
+    "MiniMax-M2.5":              ( 0.30e-6,  1.20e-6),
+    "MiniMax-M2.5-highspeed":    ( 0.60e-6,  2.40e-6),
+
+    # ── DeepSeek ─────────────────────────────────────────────────────────────
+    # deepseek-chat / deepseek-reasoner are aliases deprecated 2026-07-24;
+    # they map to deepseek-v4-flash non-thinking / thinking modes respectively.
+    "deepseek-v4-flash":         ( 0.14e-6,  0.28e-6),
+    "deepseek-v4-pro":           ( 0.435e-6, 0.87e-6),
+    "deepseek-chat":             ( 0.14e-6,  0.28e-6),  # → deepseek-v4-flash
+    "deepseek-reasoner":         ( 0.435e-6, 0.87e-6),  # → deepseek-v4-pro
+    "deepseek-v3":               ( 0.14e-6,  0.28e-6),  # legacy
+    "deepseek-r1":               ( 0.435e-6, 0.87e-6),  # legacy
+
+    # ── Qwen / DashScope (international / Singapore tier) ────────────────────
+    "qwen-turbo":                ( 0.05e-6,  0.20e-6),  # legacy; Alibaba recommends qwen-flash
+    "qwen-flash":                ( 0.25e-6,  1.50e-6),  # successor to qwen-turbo
+    "qwen-plus":                 ( 0.40e-6,  1.60e-6),
+    "qwen-max":                  ( 1.60e-6,  6.40e-6),
+    "qwq-32b":                   ( 0.80e-6,  2.40e-6),  # reasoning; same rate as qwq-plus
+    "qwq-plus":                  ( 0.80e-6,  2.40e-6),  # reasoning
+
+    # ── Groq ─────────────────────────────────────────────────────────────────
+    "llama-3.3-70b-versatile":              ( 0.59e-6,  0.79e-6),
+    "llama4-scout-17b-16e-instruct":        ( 0.11e-6,  0.34e-6),
+    "llama4-maverick-17b-128e-instruct":    ( 0.50e-6,  0.77e-6),
 }
 
 # Conservative fallback for models not in the table — avoids silent $0 underreporting

--- a/tests/providers/test_pricing.py
+++ b/tests/providers/test_pricing.py
@@ -1,19 +1,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
 import pytest
-from synthadoc.providers.pricing import estimate_cost
+from synthadoc.providers.pricing import _PRICING, _FALLBACK, estimate_cost
 
+
+# ---------------------------------------------------------------------------
+# Core mechanics
+# ---------------------------------------------------------------------------
 
 def test_known_model_uses_separate_input_output_rates():
     """claude-haiku input ($1/M) and output ($5/M) rates applied separately."""
     cost = estimate_cost("claude-haiku-4-5-20251001", input_tokens=1_000_000, output_tokens=1_000_000)
     assert abs(cost - 6.0) < 0.001  # $1 input + $5 output
-
-
-def test_known_model_gpt4o_mini():
-    """gpt-4o-mini: $0.15/M input, $0.60/M output."""
-    cost = estimate_cost("gpt-4o-mini", input_tokens=1_000_000, output_tokens=1_000_000)
-    assert abs(cost - 0.75) < 0.001  # $0.15 + $0.60
 
 
 def test_ollama_is_always_zero():
@@ -27,38 +25,355 @@ def test_unknown_model_uses_fallback_rate():
     assert cost > 0.0
 
 
+def test_fallback_rate_is_nonzero():
+    """Fallback must never silently report $0 for unknown paid models."""
+    assert _FALLBACK[0] > 0 and _FALLBACK[1] > 0
+
+
 def test_zero_tokens_returns_zero():
     cost = estimate_cost("gpt-4o", input_tokens=0, output_tokens=0)
     assert cost == 0.0
 
 
-def test_gemini_20_flash_rates():
-    """gemini-2.0-flash (deprecated Jun 2026): $0.10/M input, $0.40/M output."""
-    cost = estimate_cost("gemini-2.0-flash", input_tokens=1_000_000, output_tokens=1_000_000)
-    assert abs(cost - 0.50) < 0.001  # $0.10 + $0.40
+def test_pricing_table_has_no_zero_rates():
+    """Every entry in the table must have positive input AND output rates."""
+    for model, (inp, out) in _PRICING.items():
+        assert inp > 0, f"{model}: input rate is 0"
+        assert out > 0, f"{model}: output rate is 0"
+
+
+def test_pricing_table_output_ge_input():
+    """Output tokens should always cost at least as much as input for every model."""
+    for model, (inp, out) in _PRICING.items():
+        assert out >= inp, f"{model}: output rate {out} < input rate {inp}"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+def test_claude_fable5_rates():
+    """claude-fable-5: $10/M input, $50/M output."""
+    cost = estimate_cost("claude-fable-5", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 60.0) < 0.001
+
+
+def test_claude_opus_48_rates():
+    """claude-opus-4-8: $5/M input, $25/M output."""
+    cost = estimate_cost("claude-opus-4-8", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 30.0) < 0.001
+
+
+def test_claude_sonnet5_rates():
+    """claude-sonnet-5: $3/M input, $15/M output."""
+    cost = estimate_cost("claude-sonnet-5", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 18.0) < 0.001
+
+
+def test_claude_sonnet46_rates():
+    """claude-sonnet-4-6: $3/M input, $15/M output."""
+    cost = estimate_cost("claude-sonnet-4-6", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 18.0) < 0.001
+
+
+def test_claude_opus47_rates():
+    """claude-opus-4-7 (legacy): $5/M input, $25/M output."""
+    cost = estimate_cost("claude-opus-4-7", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 30.0) < 0.001
+
+
+def test_claude_haiku_rates():
+    """claude-haiku-4-5-20251001: $1/M input, $5/M output."""
+    cost = estimate_cost("claude-haiku-4-5-20251001", input_tokens=2_000_000, output_tokens=0)
+    assert abs(cost - 2.0) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+def test_gpt4o_rates():
+    """gpt-4o: $2.50/M input, $10/M output."""
+    cost = estimate_cost("gpt-4o", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 12.50) < 0.001
+
+
+def test_gpt4o_mini_rates():
+    """gpt-4o-mini: $0.15/M input, $0.60/M output."""
+    cost = estimate_cost("gpt-4o-mini", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.75) < 0.001
+
+
+def test_gpt41_rates():
+    """gpt-4.1: $2/M input, $8/M output."""
+    cost = estimate_cost("gpt-4.1", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 10.0) < 0.001
+
+
+def test_gpt41_mini_rates():
+    """gpt-4.1-mini: $0.40/M input, $1.60/M output."""
+    cost = estimate_cost("gpt-4.1-mini", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 2.0) < 0.001
+
+
+def test_o3_rates():
+    """o3: $2/M input, $8/M output."""
+    cost = estimate_cost("o3", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 10.0) < 0.001
+
+
+def test_o4_mini_rates():
+    """o4-mini: $1.10/M input, $4.40/M output."""
+    cost = estimate_cost("o4-mini", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 5.50) < 0.001
+
+
+def test_gpt56_sol_rates():
+    """gpt-5.6-sol: $5/M input, $30/M output."""
+    cost = estimate_cost("gpt-5.6-sol", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 35.0) < 0.001
+
+
+def test_gpt54_mini_rates():
+    """gpt-5.4-mini: $0.75/M input, $4.50/M output."""
+    cost = estimate_cost("gpt-5.4-mini", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 5.25) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+def test_gemini_35_flash_rates():
+    """gemini-3.5-flash: $1.50/M input, $9/M output."""
+    cost = estimate_cost("gemini-3.5-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 10.50) < 0.001
+
+
+def test_gemini_31_flash_lite_rates():
+    """gemini-3.1-flash-lite: $0.25/M input, $1.50/M output."""
+    cost = estimate_cost("gemini-3.1-flash-lite", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.75) < 0.001
+
+
+def test_gemini_25_pro_rates():
+    """gemini-2.5-pro: $1.25/M input, $10/M output."""
+    cost = estimate_cost("gemini-2.5-pro", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 11.25) < 0.001
 
 
 def test_gemini_25_flash_rates():
-    """gemini-2.5-flash (default): $0.30/M input, $2.50/M output."""
+    """gemini-2.5-flash: $0.30/M input, $2.50/M output."""
     cost = estimate_cost("gemini-2.5-flash", input_tokens=1_000_000, output_tokens=1_000_000)
-    assert abs(cost - 2.80) < 0.001  # $0.30 + $2.50
+    assert abs(cost - 2.80) < 0.001
+
+
+def test_gemini_25_flash_lite_rates():
+    """gemini-2.5-flash-lite: $0.10/M input, $0.40/M output (updated from $0.075)."""
+    cost = estimate_cost("gemini-2.5-flash-lite", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.50) < 0.001
+
+
+def test_gemini_20_flash_rates():
+    """gemini-2.0-flash (deprecated 2026-06-01): $0.10/M input, $0.40/M output."""
+    cost = estimate_cost("gemini-2.0-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.50) < 0.001
+
+
+def test_gemini_15_flash_rates():
+    """gemini-1.5-flash: $0.075/M input, $0.30/M output."""
+    cost = estimate_cost("gemini-1.5-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.375) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# MiniMax
+# ---------------------------------------------------------------------------
+
+def test_minimax_m3_rates():
+    """MiniMax-M3: $0.30/M input, $1.20/M output."""
+    cost = estimate_cost("MiniMax-M3", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.50) < 0.001
 
 
 def test_minimax_m25_rates():
-    """MiniMax-M2.5: $0.15/M input, $1.20/M output."""
+    """MiniMax-M2.5: $0.30/M input, $1.20/M output (updated from $0.15)."""
     cost = estimate_cost("MiniMax-M2.5", input_tokens=1_000_000, output_tokens=1_000_000)
-    assert abs(cost - 1.35) < 0.001  # $0.15 + $1.20
+    assert abs(cost - 1.50) < 0.001
+
+
+def test_minimax_m25_highspeed_rates():
+    """MiniMax-M2.5-highspeed: $0.60/M input, $2.40/M output (priority queue, 2× standard)."""
+    cost = estimate_cost("MiniMax-M2.5-highspeed", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 3.00) < 0.001
 
 
 def test_minimax_m27_rates():
     """MiniMax-M2.7: $0.30/M input, $1.20/M output."""
     cost = estimate_cost("MiniMax-M2.7", input_tokens=1_000_000, output_tokens=1_000_000)
-    assert abs(cost - 1.50) < 0.001  # $0.30 + $1.20
+    assert abs(cost - 1.50) < 0.001
 
 
-def test_minimax_highspeed_same_rates_as_standard():
-    """MiniMax highspeed variants share the same pricing as their standard counterparts."""
-    assert estimate_cost("MiniMax-M2.5-highspeed", 1_000_000, 1_000_000) == \
+def test_minimax_m27_highspeed_rates():
+    """MiniMax-M2.7-highspeed: $0.60/M input, $2.40/M output."""
+    cost = estimate_cost("MiniMax-M2.7-highspeed", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 3.00) < 0.001
+
+
+def test_minimax_highspeed_costs_more_than_standard():
+    """Highspeed (priority queue) must be pricier than standard for both M2.5 and M2.7."""
+    assert estimate_cost("MiniMax-M2.5-highspeed", 1_000_000, 1_000_000) > \
            estimate_cost("MiniMax-M2.5", 1_000_000, 1_000_000)
-    assert estimate_cost("MiniMax-M2.7-highspeed", 1_000_000, 1_000_000) == \
+    assert estimate_cost("MiniMax-M2.7-highspeed", 1_000_000, 1_000_000) > \
            estimate_cost("MiniMax-M2.7", 1_000_000, 1_000_000)
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek
+# ---------------------------------------------------------------------------
+
+def test_deepseek_v4_flash_rates():
+    """deepseek-v4-flash: $0.14/M input, $0.28/M output."""
+    cost = estimate_cost("deepseek-v4-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.42) < 0.001
+
+
+def test_deepseek_v4_pro_rates():
+    """deepseek-v4-pro: $0.435/M input, $0.87/M output."""
+    cost = estimate_cost("deepseek-v4-pro", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.305) < 0.001
+
+
+def test_deepseek_chat_alias_matches_v4_flash():
+    """deepseek-chat is an alias for deepseek-v4-flash — must have identical pricing."""
+    assert estimate_cost("deepseek-chat", 1_000_000, 1_000_000) == \
+           estimate_cost("deepseek-v4-flash", 1_000_000, 1_000_000)
+
+
+def test_deepseek_reasoner_alias_matches_v4_pro():
+    """deepseek-reasoner is an alias for deepseek-v4-pro — must have identical pricing."""
+    assert estimate_cost("deepseek-reasoner", 1_000_000, 1_000_000) == \
+           estimate_cost("deepseek-v4-pro", 1_000_000, 1_000_000)
+
+
+def test_deepseek_v3_legacy_rates():
+    """deepseek-v3 (legacy): same input/output rates as deepseek-v4-flash."""
+    cost = estimate_cost("deepseek-v3", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.42) < 0.001
+
+
+def test_deepseek_r1_legacy_rates():
+    """deepseek-r1 (legacy reasoning model): same rates as deepseek-v4-pro."""
+    cost = estimate_cost("deepseek-r1", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.305) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# Qwen / DashScope
+# ---------------------------------------------------------------------------
+
+def test_qwen_turbo_rates():
+    """qwen-turbo: $0.05/M input, $0.20/M output."""
+    cost = estimate_cost("qwen-turbo", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.25) < 0.001
+
+
+def test_qwen_flash_rates():
+    """qwen-flash: $0.25/M input, $1.50/M output."""
+    cost = estimate_cost("qwen-flash", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.75) < 0.001
+
+
+def test_qwen_plus_rates():
+    """qwen-plus: $0.40/M input, $1.60/M output."""
+    cost = estimate_cost("qwen-plus", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 2.00) < 0.001
+
+
+def test_qwen_max_rates():
+    """qwen-max: $1.60/M input, $6.40/M output."""
+    cost = estimate_cost("qwen-max", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 8.00) < 0.001
+
+
+def test_qwq_32b_rates():
+    """qwq-32b: $0.80/M input, $2.40/M output (reasoning model)."""
+    cost = estimate_cost("qwq-32b", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 3.20) < 0.001
+
+
+def test_qwq_plus_matches_qwq_32b():
+    """qwq-plus is the successor to qwq-32b — same pricing."""
+    assert estimate_cost("qwq-plus", 1_000_000, 1_000_000) == \
+           estimate_cost("qwq-32b", 1_000_000, 1_000_000)
+
+
+def test_qwen_tier_order():
+    """Qwen tiers must be priced in ascending order: turbo < flash < plus < max."""
+    t = estimate_cost("qwen-turbo", 1_000_000, 1_000_000)
+    f = estimate_cost("qwen-flash", 1_000_000, 1_000_000)
+    p = estimate_cost("qwen-plus",  1_000_000, 1_000_000)
+    m = estimate_cost("qwen-max",   1_000_000, 1_000_000)
+    assert t < f < p < m
+
+
+# ---------------------------------------------------------------------------
+# Groq
+# ---------------------------------------------------------------------------
+
+def test_groq_llama33_70b_rates():
+    """llama-3.3-70b-versatile: $0.59/M input, $0.79/M output."""
+    cost = estimate_cost("llama-3.3-70b-versatile", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.38) < 0.001
+
+
+def test_groq_llama4_scout_rates():
+    """llama4-scout-17b-16e-instruct: $0.11/M input, $0.34/M output."""
+    cost = estimate_cost("llama4-scout-17b-16e-instruct", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 0.45) < 0.001
+
+
+def test_groq_llama4_maverick_rates():
+    """llama4-maverick-17b-128e-instruct: $0.50/M input, $0.77/M output."""
+    cost = estimate_cost("llama4-maverick-17b-128e-instruct", input_tokens=1_000_000, output_tokens=1_000_000)
+    assert abs(cost - 1.27) < 0.001
+
+
+def test_groq_maverick_more_expensive_than_scout():
+    """Maverick should cost more than Scout per million tokens."""
+    assert estimate_cost("llama4-maverick-17b-128e-instruct", 1_000_000, 1_000_000) > \
+           estimate_cost("llama4-scout-17b-16e-instruct", 1_000_000, 1_000_000)
+
+
+# ---------------------------------------------------------------------------
+# Cross-provider sanity checks
+# ---------------------------------------------------------------------------
+
+def test_input_only_charges_input_rate():
+    """A call with output_tokens=0 should only charge the input rate."""
+    inp, _out = 10.00e-6, 50.00e-6  # claude-fable-5 rates
+    expected = 1_000_000 * inp
+    cost = estimate_cost("claude-fable-5", input_tokens=1_000_000, output_tokens=0)
+    assert abs(cost - expected) < 1e-9
+
+
+def test_output_only_charges_output_rate():
+    """A call with input_tokens=0 should only charge the output rate."""
+    _inp, out = 10.00e-6, 50.00e-6  # claude-fable-5 rates
+    expected = 500_000 * out
+    cost = estimate_cost("claude-fable-5", input_tokens=0, output_tokens=500_000)
+    assert abs(cost - expected) < 1e-9
+
+
+def test_flagship_hierarchy_across_providers():
+    """Each provider's flagship should cost more than its cheapest model."""
+    assert estimate_cost("claude-fable-5", 1_000_000, 1_000_000) > \
+           estimate_cost("claude-haiku-4-5-20251001", 1_000_000, 1_000_000)
+    assert estimate_cost("gpt-5.6-sol", 1_000_000, 1_000_000) > \
+           estimate_cost("gpt-4o-mini", 1_000_000, 1_000_000)
+    assert estimate_cost("qwen-max", 1_000_000, 1_000_000) > \
+           estimate_cost("qwen-turbo", 1_000_000, 1_000_000)
+    assert estimate_cost("deepseek-v4-pro", 1_000_000, 1_000_000) > \
+           estimate_cost("deepseek-v4-flash", 1_000_000, 1_000_000)
+    assert estimate_cost("MiniMax-M2.5-highspeed", 1_000_000, 1_000_000) > \
+           estimate_cost("MiniMax-M2.5", 1_000_000, 1_000_000)


### PR DESCRIPTION
48 models, imports clean. Here's what changed:

1. Anthropic — added claude-fable-5 ($10/$50), claude-opus-4-8 ($5/$25), claude-sonnet-5 ($3/$15), claude-opus-4-6 ($5/$25); existing claude-sonnet-4-6 and claude-haiku-4-5 prices unchanged.

2. OpenAI — added the full GPT-5.x family (gpt-5.6-sol/terra/luna, gpt-5.5, gpt-5.4, gpt-5.4-mini), gpt-4.1 ($2/$8), gpt-4.1-mini ($0.40/$1.60), o3 ($2/$8), o4-mini ($1.10/$4.40).

3. Gemini — added gemini-3.5-flash ($1.50/$9), gemini-3.1-flash-lite ($0.25/$1.50), gemini-3.1-pro-preview ($2/$12), gemini-2.5-pro ($1.25/$10); updated gemini-2.5-flash-lite from $0.075 → $0.10.

4. DeepSeek — added deepseek-v4-flash ($0.14/$0.28) and deepseek-v4-pro ($0.435/$0.87); kept deepseek-chat/deepseek-reasoner as alias entries (deprecated 2026-07-24); updated deepseek-r1 to use the V4 reasoning rate.

5. Qwen — added all four models: qwen-turbo ($0.05/$0.20), qwen-flash ($0.25/$1.50), qwen-plus ($0.40/$1.60), qwen-max ($1.60/$6.40), qwq-32b/qwq-plus ($0.80/$2.40).

6. MiniMax — MiniMax-M2.5 input updated $0.15 → $0.30; MiniMax-M2.5-highspeed corrected to $0.60/$2.40; added MiniMax-M3 ($0.30/$1.20).

7. Groq — unchanged (prices still match official page).

8. Add more unit tests to validate the cost.

Sources:
- Anthropic Models Overview (https://platform.claude.com/docs/en/docs/about-claude/models/overview)
- Gemini API Pricing (https://ai.google.dev/gemini-api/docs/pricing)
- DeepSeek Pricing (https://api-docs.deepseek.com/quick_start/pricing)
- Alibaba Cloud Model Studio Pricing (https://www.alibabacloud.com/help/en/model-studio/model-pricing)
- Groq Pricing (https://groq.com/pricing/)
- MiniMax Pricing (https://platform.minimax.io/docs/guides/pricing-paygo)
- OpenAI API Pricing (https://developers.openai.com/api/docs/pricing)