### PR TITLE
fix(scaffold): add Staging/Candidates section to agent skill file tem…

### DIFF
--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -91,6 +91,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.

--- a/synthadoc/demos/ai-research/AGENTS.md
+++ b/synthadoc/demos/ai-research/AGENTS.md
@@ -92,6 +92,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.

--- a/synthadoc/demos/ai-research/CLAUDE.md
+++ b/synthadoc/demos/ai-research/CLAUDE.md
@@ -92,6 +92,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.

--- a/synthadoc/demos/ai-research/GEMINI.md
+++ b/synthadoc/demos/ai-research/GEMINI.md
@@ -92,6 +92,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.

--- a/synthadoc/demos/history-of-computing/AGENTS.md
+++ b/synthadoc/demos/history-of-computing/AGENTS.md
@@ -91,6 +91,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.

--- a/synthadoc/demos/history-of-computing/CLAUDE.md
+++ b/synthadoc/demos/history-of-computing/CLAUDE.md
@@ -91,6 +91,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.

--- a/synthadoc/demos/history-of-computing/GEMINI.md
+++ b/synthadoc/demos/history-of-computing/GEMINI.md
@@ -91,6 +91,22 @@ Checks: orphan pages, dangling links, truncated sources, contradictions, adversa
 review, citation accuracy. Automatically archives pages whose source files have been deleted.
 After archiving, cascade cleanup removes all `[[slug]]` links pointing to the archived page.
 
+## Staging / Candidates
+
+When staging is enabled (`synthadoc staging policy all` or `threshold`), newly ingested pages
+land in `wiki/candidates/` as drafts instead of going straight to `wiki/`. Review and act on
+them before they appear in query results.
+
+```bash
+synthadoc staging policy              # show current policy (off | all | threshold)
+synthadoc candidates list -w <wiki>   # list pages awaiting review
+synthadoc candidates promote <slug> -w <wiki>   # accept — moves page to wiki/
+synthadoc candidates discard <slug> -w <wiki>   # reject — deletes the candidate
+```
+
+If an ingest seems to have produced no page, check `synthadoc candidates list` — the page may
+be waiting in the staging queue.
+
 ## Lifecycle
 
 Slug is a positional argument. `--reason` is required for all transitions.


### PR DESCRIPTION
…plates

CLAUDE.md, GEMINI.md, and AGENTS.md generated by `synthadoc scaffold` had no mention of the candidates staging workflow. When staging is enabled, ingested pages land in wiki/candidates/ as drafts — but agents had no knowledge of synthadoc candidates list/promote/discard, leaving them unable to find or act on staged pages.

Added a ## Staging / Candidates section to _AGENT_INSTRUCTION_BODY in _init.py (the scaffold template source), and backfilled both demo wikis (history-of-computing, ai-research) so the fix is available immediately without requiring a scaffold re-run.