### PR TITLE
fix(quota): suppress stack traces on Qwen 403 and Claude Code session…

### DIFF
--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -136,6 +136,16 @@ def _classify_llm_error(exc: Exception) -> "HTTPException | None":
             status_code=402,
             detail=f"LLM provider payment required (402): {detail}. Top up your account balance at your provider's billing page and retry.",
         )
+    if code == 403:
+        body = getattr(exc, "body", None) or {}
+        err_msg = ""
+        if isinstance(body, dict):
+            err_msg = body.get("error", {}).get("message", "")
+        detail = err_msg or str(exc)
+        return HTTPException(
+            status_code=403,
+            detail=f"LLM provider quota or permission error (403): {detail}. {_SWITCH}",
+        )
     if code == 429:
         msg = str(exc)
         _SWITCH_429 = "Switch to another provider by editing [agents] in .synthadoc/config.toml and restarting the server (options: anthropic, openai, gemini, groq, minimax, deepseek, ollama)."

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -236,6 +236,7 @@ class ClaudeCodeCLIProvider(CodingToolCLIProvider):
             "claude ai usage limit", "you've reached your",
             "credit balance is too low", "insufficient credits",
             "credit balance", "out of credits",
+            "session limit",  # "You've hit your session limit · resets ..."
         ))
 
 

--- a/synthadoc/providers/openai.py
+++ b/synthadoc/providers/openai.py
@@ -188,6 +188,21 @@ class OpenAIProvider(LLMProvider):
                     self._config.provider, self._timeout,
                 )
                 raise
+            except _openai.PermissionDeniedError as exc:
+                # Some providers (e.g. Qwen/DashScope) return 403 with an
+                # AllocationQuota error code when the free-tier quota is exhausted.
+                body = exc.body if isinstance(exc.body, dict) else {}
+                err_type = (body.get("error", {}).get("type") or "").lower()
+                err_code = (body.get("error", {}).get("code") or "").lower()
+                if "allocationquota" in err_type or "allocationquota" in err_code or "quota" in str(exc).lower():
+                    err_msg = body.get("error", {}).get("message") or str(exc)
+                    logger.error(
+                        "Quota exhausted for %s (403) — %s",
+                        self._config.provider, err_msg,
+                    )
+                    from synthadoc.errors import DailyQuotaExhaustedException
+                    raise DailyQuotaExhaustedException(self._config.provider) from exc
+                raise
             except _openai.RateLimitError as exc:
                 if self._is_daily_quota_error(exc):
                     logger.error(

--- a/tests/providers/test_coding_tool_providers.py
+++ b/tests/providers/test_coding_tool_providers.py
@@ -126,6 +126,7 @@ def test_claude_is_quota_exhausted_true():
     provider = _make_claude_provider()
     assert provider._is_quota_exhausted("Claude AI usage limit reached") is True
     assert provider._is_quota_exhausted("You've reached your usage cap") is True
+    assert provider._is_quota_exhausted("You've hit your session limit · resets 2:30pm") is True
 
 
 def test_claude_is_quota_exhausted_false():

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -334,6 +334,52 @@ async def test_openai_provider_daily_quota_raises_immediately_without_retry():
     sleep_mock.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_openai_provider_403_allocation_quota_raises_daily_quota():
+    """Qwen-style 403 PermissionDeniedError with AllocationQuota code must convert
+    to DailyQuotaExhaustedException — no stack trace, no retry."""
+    import openai
+    from synthadoc.providers.openai import OpenAIProvider
+    from synthadoc.errors import DailyQuotaExhaustedException
+    cfg = AgentConfig(provider="qwen", model="qwen-plus",
+                      base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    qwen_body = {
+        "error": {
+            "message": "The free quota has been exhausted.",
+            "type": "AllocationQuota.FreeTierOnly",
+            "code": "AllocationQuota.FreeTierOnly",
+        }
+    }
+    perm_exc = openai.PermissionDeniedError(
+        message="quota exhausted", response=MagicMock(status_code=403), body=qwen_body)
+
+    with patch.object(provider._client.chat.completions, "create", side_effect=perm_exc):
+        with pytest.raises(DailyQuotaExhaustedException):
+            await provider.complete(messages=[Message(role="user", content="hi")])
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_403_genuine_permission_error_reraises():
+    """A 403 that is NOT quota-related (e.g. model access denied) must re-raise
+    PermissionDeniedError unchanged so the caller can handle it."""
+    import openai
+    from synthadoc.providers.openai import OpenAIProvider
+    cfg = AgentConfig(provider="openai", model="gpt-4o")
+    provider = OpenAIProvider(api_key="test-key", config=cfg)
+
+    perm_exc = openai.PermissionDeniedError(
+        message="You do not have access to this model",
+        response=MagicMock(status_code=403),
+        body={"error": {"message": "You do not have access to this model", "type": "access_denied"}},
+    )
+
+    with patch.object(provider._client.chat.completions, "create", side_effect=perm_exc):
+        with pytest.raises(openai.PermissionDeniedError):
+            await provider.complete(messages=[Message(role="user", content="hi")])
+
+
 def _make_cfg(provider: str, model: str) -> "Config":
     from synthadoc.config import Config, AgentsConfig, AgentConfig
     return Config(agents=AgentsConfig(default=AgentConfig(provider=provider, model=model)))
@@ -982,6 +1028,21 @@ def test_classify_llm_error_returns_503_for_internal_server_error():
     assert result is not None
     assert result.status_code == 503
     assert "503" in result.detail
+
+
+def test_classify_llm_error_returns_403_for_permission_error():
+    """PermissionDeniedError (403) must return a clean HTTPException, not fall through to 502 with a stack trace."""
+    import openai
+    from synthadoc.integration.http_server import _classify_llm_error
+    exc = openai.PermissionDeniedError(
+        message="The free quota has been exhausted.",
+        response=MagicMock(status_code=403),
+        body={"error": {"message": "The free quota has been exhausted.", "type": "AllocationQuota.FreeTierOnly"}},
+    )
+    result = _classify_llm_error(exc)
+    assert result is not None
+    assert result.status_code == 403
+    assert "403" in result.detail
 
 
 def test_classify_llm_error_returns_401_for_auth_error():


### PR DESCRIPTION
… limit exhaustion

Three targeted fixes for issue #215:

1. openai.py: catch PermissionDeniedError (403) in _call_with_retry — if the body contains AllocationQuota (Qwen's free-tier exhaustion code), convert to DailyQuotaExhaustedException so the error surfaces as a clean log line with no traceback. Genuine 403s (model access denied) re-raise unchanged.

2. coding_tool.py: add "session limit" to ClaudeCodeProvider._is_quota_exhausted so "You've hit your session limit" is recognised and raises CodingToolQuotaExhaustedException instead of a bare RuntimeError.

3. http_server.py: add a 403 handler to _classify_llm_error as a catch-all safety net — any 403 that reaches the HTTP layer returns a clean error message rather than falling through to logger.exception().

Tests: 3 new provider tests + 1 updated coding-tool test covering all paths.