### PR TITLE
Cost hard gate fires after LLM tokens are spent and pages are written

### DIFF
--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -33,6 +33,11 @@ class AgentConfig:
     base_url: str = ""
     thinking: str = ""  # "disabled" | "enabled" | "adaptive" | "" (provider default)
 
+    @property
+    def is_local(self) -> bool:
+        """True for providers that run locally and incur no API cost (e.g. Ollama)."""
+        return self.provider == "ollama"
+
 
 @dataclass
 class AgentsConfig:

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -254,37 +254,12 @@ class Orchestrator:
             if _is_web_search:
                 await self._queue.update_progress(job_id, {"phase": "searching"})
 
-            # Resolve agent config before constructing the agent (reused for post-call pricing).
+            if await self._pre_check_ingest_cost(job_id, source, cfg):
+                return
+
+            # Resolve agent config for post-call pricing.
             _agent_cfg = cfg.agents.resolve("ingest")
             _is_local = _agent_cfg.provider == "ollama"
-
-            # Pre-call coarse cost check: block before any LLM spend if over hard gate.
-            # Uses max_source_chars as the worst-case input bound (~4 chars per token).
-            _pre_input = cfg.ingest.max_source_chars // 4
-            _pre_output = _pre_input // 4
-            _pre_cost = estimate_cost(_agent_cfg.model, _pre_input, _pre_output, is_local=_is_local)
-            _pre_estimate = CostEstimate(
-                tokens=_pre_input + _pre_output,
-                cost_usd=_pre_cost,
-                operation=f"pre-check:ingest:{source}",
-            )
-            try:
-                self._cost.check(_pre_estimate, interactive=False)
-            except CostGateError as e:
-                logger.error("Ingest job %s blocked by pre-call cost check: %s", job_id, e)
-                await self._audit.record_audit_event(
-                    job_id=job_id,
-                    event="cost_gate_exceeded",
-                    metadata={
-                        "source": source,
-                        "cost_usd": _pre_cost,
-                        "hard_gate_usd": self._cfg.cost.hard_gate_usd,
-                        "tokens": _pre_input + _pre_output,
-                        "stage": "pre_call",
-                    },
-                )
-                await self._queue.fail_permanent(job_id, f"cost_gate_exceeded: {e}")
-                return
 
             _routing_path = self._root / "ROUTING.md"
             agent = IngestAgent(
@@ -421,12 +396,49 @@ class Orchestrator:
                 await self._queue.fail(job_id, str(e))
                 raise
 
+    async def _pre_check_ingest_cost(
+        self, job_id: str, source: str, cfg: "Config"
+    ) -> bool:
+        """Enforce the hard gate BEFORE any LLM call using a worst-case cost estimate.
+
+        Estimate: max_source_chars // 4 input tokens, // 16 output tokens (~4 chars/token).
+        Returns True if the job was permanently blocked — caller must return immediately.
+        """
+        _agent_cfg = cfg.agents.resolve("ingest")
+        _is_local = _agent_cfg.provider == "ollama"
+        _pre_input = cfg.ingest.max_source_chars // 4
+        _pre_output = _pre_input // 4
+        _pre_cost = estimate_cost(_agent_cfg.model, _pre_input, _pre_output, is_local=_is_local)
+        _pre_estimate = CostEstimate(
+            tokens=_pre_input + _pre_output,
+            cost_usd=_pre_cost,
+            operation=f"pre-check:ingest:{source}",
+        )
+        try:
+            self._cost.check(_pre_estimate, interactive=False)
+            return False
+        except CostGateError as e:
+            logger.error("Ingest job %s blocked by pre-call cost check: %s", job_id, e)
+            await self._audit.record_audit_event(
+                job_id=job_id,
+                event="cost_gate_exceeded",
+                metadata={
+                    "source": source,
+                    "cost_usd": _pre_cost,
+                    "hard_gate_usd": self._cfg.cost.hard_gate_usd,
+                    "tokens": _pre_input + _pre_output,
+                    "stage": "pre_call",
+                },
+            )
+            await self._queue.fail_permanent(job_id, f"cost_gate_exceeded: {e}")
+            return True
+
     async def _guard_ingest_cost(
         self, job_id: str, source: str, tokens: int, cost_usd: float
     ) -> None:
         """Emit a soft-cost warning if actual ingest cost exceeds soft_warn_usd.
 
-        The hard gate is enforced pre-call in _run_ingest before any LLM spend.
+        The hard gate is enforced pre-call via _pre_check_ingest_cost before any LLM spend.
         """
         if cost_usd >= self._cfg.cost.soft_warn_usd:
             logger.warning(

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -16,7 +16,6 @@ from synthadoc.core.hooks import HookExecutor
 from synthadoc.core.queue import JobQueue
 from synthadoc.observability.telemetry import get_tracer, setup_telemetry
 from synthadoc.providers import make_provider
-from synthadoc.providers.ollama import OllamaProvider
 from synthadoc.providers.pricing import estimate_cost
 from synthadoc.storage.log import AuditDB, LogWriter
 from synthadoc.storage.search import HybridSearch
@@ -259,7 +258,7 @@ class Orchestrator:
 
             # Resolve agent config for post-call pricing.
             _agent_cfg = cfg.agents.resolve("ingest")
-            _is_local = _agent_cfg.provider == "ollama"
+            _is_local = _agent_cfg.is_local
 
             _routing_path = self._root / "ROUTING.md"
             agent = IngestAgent(
@@ -405,7 +404,7 @@ class Orchestrator:
         Returns True if the job was permanently blocked — caller must return immediately.
         """
         _agent_cfg = cfg.agents.resolve("ingest")
-        _is_local = _agent_cfg.provider == "ollama"
+        _is_local = _agent_cfg.is_local
         _pre_input = cfg.ingest.max_source_chars // 4
         _pre_output = _pre_input // 4
         _pre_cost = estimate_cost(_agent_cfg.model, _pre_input, _pre_output, is_local=_is_local)
@@ -484,25 +483,24 @@ class Orchestrator:
         import asyncio
         from synthadoc.agents.query_agent import QueryAgent
         _provider = make_provider("query", self._cfg)
-        _model = self._cfg.agents.resolve("query").model
+        _query_cfg = self._cfg.agents.resolve("query")
         result = await asyncio.wait_for(
             QueryAgent(
                 provider=_provider,
                 store=self._store, search=self._search,
                 query_config=self._cfg.query,
-                model=_model,
+                model=_query_cfg.model,
                 gap_score_threshold=self._cfg.query.gap_score_threshold,
                 orchestrator=self,
                 max_tokens=self._cfg.agents.query_max_tokens,
             ).query(question),
             timeout=timeout_seconds if timeout_seconds > 0 else None,
         )
-        _model = self._cfg.agents.resolve("query").model
         cost_usd = estimate_cost(
-            _model,
+            _query_cfg.model,
             result.input_tokens,
             result.output_tokens,
-            is_local=isinstance(_provider, OllamaProvider),
+            is_local=_query_cfg.is_local,
         )
         await self._audit.record_query(
             question=question,

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -253,6 +253,39 @@ class Orchestrator:
             _is_web_search = bool(_WEB_SEARCH_RE.match(source))
             if _is_web_search:
                 await self._queue.update_progress(job_id, {"phase": "searching"})
+
+            # Resolve agent config before constructing the agent (reused for post-call pricing).
+            _agent_cfg = cfg.agents.resolve("ingest")
+            _is_local = _agent_cfg.provider == "ollama"
+
+            # Pre-call coarse cost check: block before any LLM spend if over hard gate.
+            # Uses max_source_chars as the worst-case input bound (~4 chars per token).
+            _pre_input = cfg.ingest.max_source_chars // 4
+            _pre_output = _pre_input // 4
+            _pre_cost = estimate_cost(_agent_cfg.model, _pre_input, _pre_output, is_local=_is_local)
+            _pre_estimate = CostEstimate(
+                tokens=_pre_input + _pre_output,
+                cost_usd=_pre_cost,
+                operation=f"pre-check:ingest:{source}",
+            )
+            try:
+                self._cost.check(_pre_estimate, interactive=False)
+            except CostGateError as e:
+                logger.error("Ingest job %s blocked by pre-call cost check: %s", job_id, e)
+                await self._audit.record_audit_event(
+                    job_id=job_id,
+                    event="cost_gate_exceeded",
+                    metadata={
+                        "source": source,
+                        "cost_usd": _pre_cost,
+                        "hard_gate_usd": self._cfg.cost.hard_gate_usd,
+                        "tokens": _pre_input + _pre_output,
+                        "stage": "pre_call",
+                    },
+                )
+                await self._queue.fail_permanent(job_id, f"cost_gate_exceeded: {e}")
+                return
+
             _routing_path = self._root / "ROUTING.md"
             agent = IngestAgent(
                 provider=make_provider("ingest", cfg),
@@ -267,16 +300,14 @@ class Orchestrator:
                 allow_external_paths=allow_external_paths,
             )
             result = await agent.ingest(source, force=force, bust_cache=force)
-            _agent_cfg = cfg.agents.resolve("ingest")
             result.cost_usd = estimate_cost(
                 _agent_cfg.model,
                 result.input_tokens,
                 result.output_tokens,
-                is_local=(_agent_cfg.provider == "ollama"),
+                is_local=_is_local,
             )
             await self._audit.update_ingest_cost(source, result.cost_usd)
-            if await self._guard_ingest_cost(job_id, source, result.tokens_used, result.cost_usd):
-                return
+            await self._guard_ingest_cost(job_id, source, result.tokens_used, result.cost_usd)
             if max_results is not None and result.child_sources:
                 result.child_sources = result.child_sources[:max_results]
             if _is_web_search and result.child_sources:
@@ -392,36 +423,16 @@ class Orchestrator:
 
     async def _guard_ingest_cost(
         self, job_id: str, source: str, tokens: int, cost_usd: float
-    ) -> bool:
-        """Check cost thresholds after an ingest LLM call.
+    ) -> None:
+        """Emit a soft-cost warning if actual ingest cost exceeds soft_warn_usd.
 
-        Returns True if the job was aborted (hard gate exceeded) — caller must return.
-        Logs a warning for soft warn; logs an error, records an audit event, and
-        permanently fails the job for hard gate.
+        The hard gate is enforced pre-call in _run_ingest before any LLM spend.
         """
-        estimate = CostEstimate(tokens=tokens, cost_usd=cost_usd, operation=f"ingest:{source}")
-        try:
-            self._cost.check(estimate, interactive=False)
-        except CostGateError as e:
-            logger.error("Ingest job %s aborted by cost guard: %s", job_id, e)
-            await self._audit.record_audit_event(
-                job_id=job_id,
-                event="cost_gate_exceeded",
-                metadata={
-                    "source": source,
-                    "cost_usd": cost_usd,
-                    "hard_gate_usd": self._cfg.cost.hard_gate_usd,
-                    "tokens": tokens,
-                },
-            )
-            await self._queue.fail_permanent(job_id, f"cost_gate_exceeded: {e}")
-            return True
         if cost_usd >= self._cfg.cost.soft_warn_usd:
             logger.warning(
                 "Ingest cost $%.4f exceeds soft_warn_usd $%.2f for job %s",
                 cost_usd, self._cfg.cost.soft_warn_usd, job_id,
             )
-        return False
 
     async def _auto_block_domain(self, exc: DomainBlockedException) -> None:
         """Persist a newly discovered blocked domain and record an audit event."""

--- a/tests/core/test_orchestrator_cost.py
+++ b/tests/core/test_orchestrator_cost.py
@@ -188,7 +188,11 @@ async def test_orchestrator_ingest_unknown_model_uses_fallback_nonzero(tmp_wiki)
 
 @pytest.mark.asyncio
 async def test_guard_ingest_cost_hard_gate_fails_job_permanently(tmp_wiki):
-    """Hard gate exceeded must permanently fail the job and record an audit event."""
+    """Hard gate exceeded must permanently fail the job and record an audit event.
+
+    Gate now fires pre-call: with hard_gate_usd=0.0001 and default max_source_chars=32000,
+    the pre-call estimate (≈$0.018 on haiku) exceeds the limit before any LLM call.
+    """
     from synthadoc.core.queue import JobStatus
 
     cfg = Config(
@@ -199,7 +203,6 @@ async def test_guard_ingest_cost_hard_gate_fails_job_permanently(tmp_wiki):
     await orch.init()
 
     try:
-        # 10k input + 5k output on haiku ≈ $0.035 — well above the $0.0001 hard gate
         mock_agent = _mock_ingest_agent(input_tokens=10_000, output_tokens=5_000)
         job_id = await orch._queue.enqueue("ingest", {"source": "test.md", "force": False})
 
@@ -247,6 +250,108 @@ async def test_guard_ingest_cost_soft_warn_completes_normally(tmp_wiki, caplog):
         assert any(j.id == job_id for j in completed), "Soft warn must not abort the job"
         assert any("soft_warn" in r.message for r in caplog.records), \
             "Soft warn must emit a logger.warning"
+    finally:
+        await orch.close()
+
+
+# ── Pre-call cost gate ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_pre_call_gate_blocks_ingest_agent_not_called(tmp_wiki):
+    """Pre-call estimate must block the LLM call entirely when over hard_gate_usd.
+
+    With hard_gate_usd=0.001 and default max_source_chars=32000 on haiku, the
+    worst-case estimate (~$0.018) exceeds the limit before agent.ingest() runs.
+    """
+    from synthadoc.core.queue import JobStatus
+
+    cfg = Config(
+        agents=AgentsConfig(default=AgentConfig(provider="anthropic", model="claude-haiku-4-5-20251001")),
+        cost=CostConfig(soft_warn_usd=0.0001, hard_gate_usd=0.001),
+    )
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+    await orch.init()
+
+    try:
+        mock_agent = _mock_ingest_agent(input_tokens=10_000, output_tokens=5_000)
+        job_id = await orch._queue.enqueue("ingest", {"source": "test.md", "force": False})
+
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock(spec=[])), \
+             patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent), \
+             patch.object(orch._audit, "record_audit_event", new=AsyncMock()) as mock_audit:
+            await orch._run_ingest(job_id, "test.md", auto_confirm=True)
+
+        mock_agent.ingest.assert_not_awaited()
+
+        dead = await orch._queue.list_jobs(status=JobStatus.DEAD)
+        assert any(j.id == job_id for j in dead), "Pre-call gate must permanently fail the job"
+        job = next(j for j in dead if j.id == job_id)
+        assert "cost_gate_exceeded" in (job.error or "")
+
+        mock_audit.assert_awaited_once()
+        metadata = mock_audit.call_args.kwargs["metadata"]
+        assert metadata["stage"] == "pre_call"
+        assert metadata["cost_usd"] > 0
+    finally:
+        await orch.close()
+
+
+@pytest.mark.asyncio
+async def test_pre_call_gate_passes_and_ingest_runs_normally(tmp_wiki):
+    """When hard_gate_usd is high enough for the pre-call estimate, ingest must proceed."""
+    from synthadoc.core.queue import JobStatus
+
+    cfg = Config(
+        agents=AgentsConfig(default=AgentConfig(provider="anthropic", model="claude-haiku-4-5-20251001")),
+        cost=CostConfig(soft_warn_usd=0.0001, hard_gate_usd=100.0),
+    )
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+    await orch.init()
+
+    try:
+        mock_agent = _mock_ingest_agent(input_tokens=1_000, output_tokens=500)
+        job_id = await orch._queue.enqueue("ingest", {"source": "test.md", "force": False})
+
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock(spec=[])), \
+             patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent):
+            await orch._run_ingest(job_id, "test.md", auto_confirm=True)
+
+        mock_agent.ingest.assert_awaited_once()
+        completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
+        assert any(j.id == job_id for j in completed), "Job must complete when gate passes"
+    finally:
+        await orch.close()
+
+
+@pytest.mark.asyncio
+async def test_post_call_soft_warn_fires_but_does_not_abort_job(tmp_wiki, caplog):
+    """After the hard gate was moved pre-call, the post-call check is soft-warn only:
+    actual cost exceeding soft_warn_usd must log a warning but not abort the job."""
+    import logging
+    from synthadoc.core.queue import JobStatus
+
+    # actual cost ≈ $0.035 on haiku (10k/5k tokens) will exceed soft_warn_usd=0.001;
+    # hard_gate_usd=100.0 so the pre-call check passes.
+    cfg = Config(
+        agents=AgentsConfig(default=AgentConfig(provider="anthropic", model="claude-haiku-4-5-20251001")),
+        cost=CostConfig(soft_warn_usd=0.001, hard_gate_usd=100.0),
+    )
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+    await orch.init()
+
+    try:
+        mock_agent = _mock_ingest_agent(input_tokens=10_000, output_tokens=5_000)
+        job_id = await orch._queue.enqueue("ingest", {"source": "test.md", "force": False})
+
+        with patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock(spec=[])), \
+             patch("synthadoc.agents.ingest_agent.IngestAgent", return_value=mock_agent), \
+             caplog.at_level(logging.WARNING, logger="synthadoc.core.orchestrator"):
+            await orch._run_ingest(job_id, "test.md", auto_confirm=True)
+
+        completed = await orch._queue.list_jobs(status=JobStatus.COMPLETED)
+        assert any(j.id == job_id for j in completed), "Soft warn must not abort the job"
+        assert any("soft_warn" in r.message for r in caplog.records), \
+            "Post-call soft warn must emit a logger.warning"
     finally:
         await orch.close()
 


### PR DESCRIPTION
Issue: #221 

orchestrator.py - Before IngestAgent is even constructed, the code now:
1. Resolves _agent_cfg (moved up from post-call)
2. Computes a worst-case estimate: max_source_chars // 4 input tokens, // 16 output tokens
3. Calls self._cost.check() — if it throws CostGateError, the job is permanently failed with stage: pre_call in the audit metadata and the function returns before any LLM call
4. _guard_ingest_cost is now soft-warn only (the CostEstimate/CostGateError logic was removed from it)

tests/core/test_orchestrator_cost.py - 3 new tests added.