### PR TITLE
fix(jobs): prevent retry of non-retryable job statuses (BUG-2, BUG-9)

### DIFF
--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -358,6 +358,34 @@ def _parse_retry_after(exc: Exception, default: float = 60.0) -> float:
     return default
 
 
+def _assert_job_retryable(job: "Job") -> "str | None":
+    """Return a warning string for SKIPPED jobs, or raise HTTPException for non-retryable statuses.
+
+    Retryable: FAILED, CANCELLED, SKIPPED (with a warning).
+    Non-retryable: COMPLETED, IN_PROGRESS, DEAD, PENDING.
+    """
+    from synthadoc.core.queue import JobStatus
+    _RETRYABLE = {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.SKIPPED}
+    if job.status in _RETRYABLE:
+        if job.status == JobStatus.SKIPPED:
+            return (
+                f"Job {job.id!r} was previously skipped (e.g. domain auto-blocked). "
+                "Resolve the underlying issue first or it will be skipped again."
+            )
+        return None
+    if job.status == JobStatus.COMPLETED:
+        detail = f"Job {job.id!r} already completed successfully — retrying would cause a duplicate ingest"
+    elif job.status == JobStatus.IN_PROGRESS:
+        detail = f"Job {job.id!r} is currently running — wait for it to finish before retrying"
+    elif job.status == JobStatus.DEAD:
+        detail = f"Job {job.id!r} is permanently dead and cannot be retried"
+    elif job.status == JobStatus.PENDING:
+        detail = f"Job {job.id!r} is already pending"
+    else:
+        detail = f"Job {job.id!r} has status '{job.status}' and cannot be retried"
+    raise HTTPException(status_code=409, detail=detail)
+
+
 async def _worker_loop(orch) -> None:
     """Background task: poll jobs.db and execute pending jobs."""
     sleep_secs = _WORKER_POLL_SECONDS
@@ -1169,14 +1197,12 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
 
     @app.post("/jobs/{job_id}/retry")
     async def retry_job(job_id: str):
-        jobs = await app.state.orch.queue.list_jobs()
-        job = next((j for j in jobs if j.id == job_id), None)
+        job = await app.state.orch.queue.get_job(job_id)
         if job is None:
             raise HTTPException(status_code=404, detail=f"Job {job_id!r} not found")
-        if job.status == JobStatus.DEAD:
-            raise HTTPException(status_code=409, detail=f"Job {job_id!r} is permanently dead and cannot be retried")
+        warning = _assert_job_retryable(job)
         await app.state.orch.queue.retry(job_id)
-        return {"retried": job_id}
+        return {"retried": job_id, **({"warning": warning} if warning else {})}
 
     @app.post("/jobs/cancel-pending")
     async def cancel_pending_jobs():

--- a/tests/integration/test_http_api.py
+++ b/tests/integration/test_http_api.py
@@ -108,35 +108,133 @@ def test_ingest_backslash_url_is_normalised_not_path_resolved(tmp_wiki):
     assert str(tmp_wiki) not in queued_source
 
 
+def _make_job(job_id: str, status, retries: int = 0, error: str = ""):
+    from synthadoc.core.queue import Job
+    return Job(id=job_id, operation="ingest", payload={},
+               status=status, retries=retries, error=error)
+
+
 def test_retry_job_endpoint(tmp_wiki):
-    """POST /jobs/{id}/retry resets the job to pending."""
+    """POST /jobs/{id}/retry on a FAILED job resets it to pending."""
     from synthadoc.integration.http_server import create_app
-    from synthadoc.core.queue import Job, JobStatus
-    fake_job = Job(id="fail-1", operation="ingest", payload={},
-                   status=JobStatus.FAILED, retries=0, error="server restarted")
-    with patch("synthadoc.core.queue.JobQueue.list_jobs",
-               new=AsyncMock(return_value=[fake_job])):
-        with patch("synthadoc.core.queue.JobQueue.retry",
-                   new=AsyncMock()) as mock_retry:
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("fail-1", JobStatus.FAILED, error="server restarted")
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
             with TestClient(create_app(wiki_root=tmp_wiki)) as client:
                 resp = client.post("/jobs/fail-1/retry")
     assert resp.status_code == 200
-    assert resp.json()["retried"] == "fail-1"
+    body = resp.json()
+    assert body["retried"] == "fail-1"
+    assert "warning" not in body
     mock_retry.assert_awaited_once_with("fail-1")
 
 
-def test_retry_dead_job_returns_409(tmp_wiki):
-    """POST /jobs/{id}/retry on a dead job must return 409 — dead jobs cannot be retried."""
+def test_retry_cancelled_job_returns_200(tmp_wiki):
+    """POST /jobs/{id}/retry on a CANCELLED job must succeed with no warning."""
     from synthadoc.integration.http_server import create_app
-    from synthadoc.core.queue import Job, JobStatus
-    fake_job = Job(id="dead-1", operation="ingest", payload={},
-                   status=JobStatus.DEAD, retries=3, error="timed out after 600s")
-    with patch("synthadoc.core.queue.JobQueue.list_jobs",
-               new=AsyncMock(return_value=[fake_job])):
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("cancel-1", JobStatus.CANCELLED)
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
+            with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+                resp = client.post("/jobs/cancel-1/retry")
+    assert resp.status_code == 200
+    assert "warning" not in resp.json()
+    mock_retry.assert_awaited_once_with("cancel-1")
+
+
+def test_retry_skipped_job_returns_200_with_warning(tmp_wiki):
+    """POST /jobs/{id}/retry on a SKIPPED job must succeed but include a warning."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("skip-1", JobStatus.SKIPPED)
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
+            with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+                resp = client.post("/jobs/skip-1/retry")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["retried"] == "skip-1"
+    assert "warning" in body
+    assert "skipped" in body["warning"].lower()
+    mock_retry.assert_awaited_once_with("skip-1")
+
+
+def test_retry_dead_job_returns_409(tmp_wiki):
+    """POST /jobs/{id}/retry on a DEAD job must return 409."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("dead-1", JobStatus.DEAD, retries=3, error="timed out after 600s")
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
         with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
             with TestClient(create_app(wiki_root=tmp_wiki)) as client:
                 resp = client.post("/jobs/dead-1/retry")
     assert resp.status_code == 409
+    mock_retry.assert_not_awaited()
+
+
+def test_retry_completed_job_returns_409(tmp_wiki):
+    """POST /jobs/{id}/retry on a COMPLETED job must return 409 — would cause duplicate ingest."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("done-1", JobStatus.COMPLETED)
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
+            with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+                resp = client.post("/jobs/done-1/retry")
+    assert resp.status_code == 409
+    assert "duplicate" in resp.json()["detail"].lower()
+    mock_retry.assert_not_awaited()
+
+
+def test_retry_in_progress_job_returns_409(tmp_wiki):
+    """POST /jobs/{id}/retry on an IN_PROGRESS job must return 409 — would cause concurrent double-execution."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("running-1", JobStatus.IN_PROGRESS)
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
+            with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+                resp = client.post("/jobs/running-1/retry")
+    assert resp.status_code == 409
+    assert "running" in resp.json()["detail"].lower()
+    mock_retry.assert_not_awaited()
+
+
+def test_retry_pending_job_returns_409(tmp_wiki):
+    """POST /jobs/{id}/retry on a PENDING job must return 409 — already queued."""
+    from synthadoc.integration.http_server import create_app
+    from synthadoc.core.queue import JobStatus
+    fake_job = _make_job("pend-1", JobStatus.PENDING)
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
+            with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+                resp = client.post("/jobs/pend-1/retry")
+    assert resp.status_code == 409
+    assert "pending" in resp.json()["detail"].lower()
+    mock_retry.assert_not_awaited()
+
+
+def test_retry_nonexistent_job_returns_404(tmp_wiki):
+    """POST /jobs/{id}/retry on an unknown job ID must return 404."""
+    from synthadoc.integration.http_server import create_app
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=None)):
+        with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+            resp = client.post("/jobs/ghost-1/retry")
+    assert resp.status_code == 404
+
+
+def test_retry_unknown_status_returns_409(tmp_wiki):
+    """_assert_job_retryable else branch: an unrecognised status produces a 409 with a generic message."""
+    from synthadoc.integration.http_server import create_app
+    fake_job = _make_job("weird-1", "future_unknown_status")
+    with patch("synthadoc.core.queue.JobQueue.get_job", new=AsyncMock(return_value=fake_job)):
+        with patch("synthadoc.core.queue.JobQueue.retry", new=AsyncMock()) as mock_retry:
+            with TestClient(create_app(wiki_root=tmp_wiki)) as client:
+                resp = client.post("/jobs/weird-1/retry")
+    assert resp.status_code == 409
+    assert "cannot be retried" in resp.json()["detail"].lower()
     mock_retry.assert_not_awaited()
 
 

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -28,6 +28,80 @@ async def test_anthropic_provider_complete():
     assert result.total_tokens == 15
 
 
+def test_anthropic_provider_init_with_timeout():
+    """AnthropicProvider with timeout > 0 must forward it to the SDK client."""
+    import anthropic as anthropic_lib
+    cfg = AgentConfig(provider="anthropic", model="claude-haiku-4-5-20251001")
+    provider = AnthropicProvider(api_key="test-key", config=cfg, timeout=60)
+    # The AsyncAnthropic client stores the timeout on its own httpx client; verify
+    # the object was constructed without error and exposes the expected attribute.
+    assert isinstance(provider._client, anthropic_lib.AsyncAnthropic)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_complete_passes_temperature_for_legacy_model():
+    """Legacy claude-3 models support temperature — it must appear in kwargs."""
+    cfg = AgentConfig(provider="anthropic", model="claude-3-opus-20240229")
+    provider = AnthropicProvider(api_key="test-key", config=cfg)
+    captured: dict = {}
+
+    async def capture(**kwargs):
+        captured.update(kwargs)
+        mock = MagicMock()
+        mock.content = [MagicMock(text="ok")]
+        mock.usage = MagicMock(input_tokens=5, output_tokens=2)
+        return mock
+
+    with patch.object(provider._client.messages, "create", side_effect=capture):
+        await provider.complete(
+            messages=[Message(role="user", content="hi")],
+            temperature=0.7,
+        )
+    assert "temperature" in captured
+    assert captured["temperature"] == 0.7
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_stream_passes_temperature_and_system_for_legacy_model():
+    """complete_stream on a legacy claude-3 model must include temperature and system kwargs."""
+    cfg = AgentConfig(provider="anthropic", model="claude-3-sonnet-20240229")
+    provider = AnthropicProvider(api_key="test-key", config=cfg)
+    captured: dict = {}
+
+    event = MagicMock()
+    event.type = "content_block_delta"
+    event.delta = MagicMock(text="hello")
+
+    class _FakeStream:
+        def __init__(self): self._done = False
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): pass
+        def __aiter__(self): return self
+        async def __anext__(self):
+            if self._done:
+                raise StopAsyncIteration
+            self._done = True
+            return event
+
+    def fake_stream(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream()
+
+    provider._client.messages.stream = fake_stream
+    tokens = []
+    async for tok in provider.complete_stream(
+        messages=[Message(role="user", content="hi")],
+        system="You are helpful.",
+        temperature=0.5,
+    ):
+        tokens.append(tok)
+
+    assert tokens == ["hello"]
+    assert "temperature" in captured
+    assert captured["temperature"] == 0.5
+    assert captured.get("system") == "You are helpful."
+
+
 @pytest.mark.asyncio
 async def test_anthropic_provider_propagates_rate_limit_immediately():
     """RateLimitError must not be retried — it should propagate on the first attempt."""


### PR DESCRIPTION
POST /jobs/{id}/retry now rejects COMPLETED, IN_PROGRESS, DEAD, and PENDING jobs with HTTP 409 (specific message per status). SKIPPED jobs are allowed but return a warning encouraging the user to resolve the underlying issue first. Guard logic extracted into _assert_job_retryable helper. Endpoint now uses get_job() direct lookup instead of a full table scan (BUG-9).