### PR TITLE
fix: run scaffold retries on quota-exhausted errors may burning all retry budget

### DIFF
--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -632,8 +632,12 @@ class Orchestrator:
                 "routing_regenerated": routing_regenerated,
             })
         except Exception as e:
-            await self._queue.fail(job_id, str(e))
-            raise
+            from synthadoc.errors import DailyQuotaExhaustedException, CodingToolQuotaExhaustedException
+            if isinstance(e, (DailyQuotaExhaustedException, CodingToolQuotaExhaustedException)):
+                await self._queue.fail_permanent(job_id, str(e))
+            else:
+                await self._queue.fail(job_id, str(e))
+                raise
 
     async def _run_lint(self, job_id: str, scope: str = "all", auto_resolve: bool = False,
                         adversarial: bool = True, lifecycle: bool = True,

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -632,12 +632,26 @@ class Orchestrator:
                 "routing_regenerated": routing_regenerated,
             })
         except Exception as e:
-            from synthadoc.errors import DailyQuotaExhaustedException, CodingToolQuotaExhaustedException
-            if isinstance(e, (DailyQuotaExhaustedException, CodingToolQuotaExhaustedException)):
-                await self._queue.fail_permanent(job_id, str(e))
-            else:
-                await self._queue.fail(job_id, str(e))
+            if not await self._fail_or_permanent(job_id, e):
                 raise
+
+    async def _fail_or_permanent(self, job_id: str, exc: Exception) -> bool:
+        """Permanently fail the job for quota errors; mark retryable for everything else.
+
+        Returns True when the job was permanently failed (quota exhausted — caller must
+        NOT re-raise). Returns False when the job was marked retryable — caller must
+        re-raise so the worker loop records the original traceback.
+
+        Bare ``raise`` in the caller's except block preserves the original traceback;
+        ``raise exc`` inside this helper would truncate it, which is why we use a bool
+        return instead of raising here.
+        """
+        from synthadoc.errors import DailyQuotaExhaustedException, CodingToolQuotaExhaustedException
+        if isinstance(exc, (DailyQuotaExhaustedException, CodingToolQuotaExhaustedException)):
+            await self._queue.fail_permanent(job_id, str(exc))
+            return True
+        await self._queue.fail(job_id, str(exc))
+        return False
 
     async def _run_lint(self, job_id: str, scope: str = "all", auto_resolve: bool = False,
                         adversarial: bool = True, lifecycle: bool = True,
@@ -686,9 +700,5 @@ class Orchestrator:
                 "orphans": report.orphan_slugs,
             })
         except Exception as e:
-            from synthadoc.errors import DailyQuotaExhaustedException, CodingToolQuotaExhaustedException
-            if isinstance(e, (DailyQuotaExhaustedException, CodingToolQuotaExhaustedException)):
-                await self._queue.fail_permanent(job_id, str(e))
-            else:
-                await self._queue.fail(job_id, str(e))
+            if not await self._fail_or_permanent(job_id, e):
                 raise

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -505,3 +505,45 @@ async def test_run_scaffold_excludes_meta_slugs_from_protected(tmp_wiki):
             f"Meta slug '{meta}' must be filtered out of protected_slugs passed to scaffold"
         )
     assert "real-topic" in captured_slugs
+
+
+@pytest.mark.asyncio
+async def test_run_scaffold_daily_quota_exhausted_fails_permanent(tmp_wiki):
+    """DailyQuotaExhaustedException in _run_scaffold must permanently fail the job (no retry)."""
+    from synthadoc.errors import DailyQuotaExhaustedException
+
+    cfg = load_config()
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+
+    exc = DailyQuotaExhaustedException(provider="anthropic")
+
+    with patch("synthadoc.agents.scaffold_agent.ScaffoldAgent.scaffold", new=AsyncMock(side_effect=exc)), \
+         patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch.object(orch, "_queue") as mock_queue:
+        mock_queue.fail_permanent = AsyncMock()
+        mock_queue.fail = AsyncMock()
+        await orch._run_scaffold("job-quota-daily", "TestDomain")
+
+    mock_queue.fail_permanent.assert_awaited_once()
+    mock_queue.fail.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_scaffold_coding_tool_quota_fails_permanent(tmp_wiki):
+    """CodingToolQuotaExhaustedException in _run_scaffold must permanently fail the job (no retry)."""
+    from synthadoc.errors import CodingToolQuotaExhaustedException
+
+    cfg = load_config()
+    orch = Orchestrator(wiki_root=tmp_wiki, config=cfg)
+
+    exc = CodingToolQuotaExhaustedException("claude-code")
+
+    with patch("synthadoc.agents.scaffold_agent.ScaffoldAgent.scaffold", new=AsyncMock(side_effect=exc)), \
+         patch("synthadoc.core.orchestrator.make_provider", return_value=MagicMock()), \
+         patch.object(orch, "_queue") as mock_queue:
+        mock_queue.fail_permanent = AsyncMock()
+        mock_queue.fail = AsyncMock()
+        await orch._run_scaffold("job-quota-coding", "TestDomain")
+
+    mock_queue.fail_permanent.assert_awaited_once()
+    mock_queue.fail.assert_not_awaited()


### PR DESCRIPTION
issue: https://github.com/axoviq-ai/synthadoc/issues/226

The fix mirrors _run_lint exactly: check isinstance(e, (DailyQuotaExhaustedException, CodingToolQuotaExhaustedException)) first and call fail_permanent(), otherwise fall through to the retryable fail() + re-raise path.

Make it a common function, the same function can be reused by _run_lint as well. 
