### PR TITLE
fix(server): prune _session_state to prevent unbounded memory growth

### DIFF
--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -386,7 +386,22 @@ def _assert_job_retryable(job: "Job") -> "str | None":
     raise HTTPException(status_code=409, detail=detail)
 
 
-async def _worker_loop(orch) -> None:
+async def _prune_stale_session_state(audit, session_state: dict) -> int:
+    """Remove in-memory session state entries that no longer exist in the audit DB.
+
+    Called from the hourly purge block so _session_state mirrors the DB lifetime:
+    once a session is deleted from chat_sessions, its RAM entry is evicted too.
+    Returns the number of entries removed.
+    """
+    active_ids = await audit.list_all_session_ids()
+    # Build the stale list first to avoid mutating the dict while iterating over it
+    stale_keys = [k for k in session_state if k not in active_ids]
+    for k in stale_keys:
+        del session_state[k]
+    return len(stale_keys)
+
+
+async def _worker_loop(orch, session_state: dict) -> None:
     """Background task: poll jobs.db and execute pending jobs."""
     sleep_secs = _WORKER_POLL_SECONDS
     _last_purge_time: float = 0.0
@@ -461,6 +476,11 @@ async def _worker_loop(orch) -> None:
                     _purged = await orch._audit.purge_old_sessions(_retention)
                     if _purged:
                         logger.info("Purged %d stale sessions.", _purged)
+                # Prune in-memory session state to match DB — removes entries for
+                # sessions that have been deleted from the DB (or were never persisted).
+                _pruned = await _prune_stale_session_state(orch._audit, session_state)
+                if _pruned:
+                    logger.debug("Pruned %d stale session_state entries.", _pruned)
                 _last_purge_time = time.monotonic()
             except Exception as _pe:
                 logger.error("Session purge failed: %s", _pe)
@@ -497,7 +517,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
         app.state.orch = orch
         from synthadoc.agents.hint_engine import HintEngine as _HE
         _HE.configure(wiki_root / "hints.json")
-        worker = asyncio.create_task(_worker_loop(orch))
+        worker = asyncio.create_task(_worker_loop(orch, _session_state))
 
         from synthadoc.core.scheduler import run_scheduler_loop
         # orch.init() already created all tables in audit.db via self._audit.init();

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -784,6 +784,13 @@ class AuditDB:
             })
         return result
 
+    async def list_all_session_ids(self) -> set[str]:
+        """Return the set of all session IDs currently in the DB."""
+        async with aiosqlite.connect(self._path) as db:
+            async with db.execute("SELECT session_id FROM chat_sessions") as cur:
+                rows = await cur.fetchall()
+        return {r[0] for r in rows}
+
     async def purge_old_sessions(self, retention_days: int) -> int:
         """Delete sessions inactive for more than retention_days. Returns count deleted."""
         cutoff = (datetime.now(timezone.utc) - timedelta(days=retention_days)).isoformat()

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -513,16 +513,24 @@ def test_get_graph_computing_returns_no_store_header(tmp_wiki, reset_graph_flag)
 
 
 def test_session_purge_does_not_reference_session_state(tmp_wiki):
-    """_worker_loop session purge must not raise NameError for _session_state.
+    """_worker_loop must not directly reference the closure variable _session_state.
 
     Regression test: _session_state is defined inside create_app() and is not
-    accessible from the module-level _worker_loop.  The purge branch must not
-    call _session_state.clear() (or any other reference to that name).
+    accessible from the module-level _worker_loop.  The purge branch must receive
+    it as the session_state parameter, not reference _session_state by name.
+
+    The check uses a word-boundary regex so that helper function names that
+    contain the substring (e.g. _prune_stale_session_state) do not falsely trip
+    the assertion — only a standalone identifier _session_state would match.
     """
+    import re
     import inspect
     from synthadoc.integration import http_server
 
     src = inspect.getsource(http_server._worker_loop)
-    assert "_session_state" not in src, (
-        "_worker_loop must not reference _session_state (it is out of scope)"
+    # Match _session_state only when it is NOT preceded by another word character
+    # (which would mean it is part of a longer identifier like _prune_stale_session_state).
+    assert not re.search(r"(?<!\w)_session_state", src), (
+        "_worker_loop must not reference _session_state directly (it is out of scope); "
+        "pass it as the session_state parameter instead"
     )

--- a/tests/storage/test_log.py
+++ b/tests/storage/test_log.py
@@ -353,6 +353,49 @@ async def test_delete_graph_node_removes_node_and_edges(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_list_all_session_ids_returns_all_ids(tmp_path):
+    """list_all_session_ids() must return every session currently in the DB."""
+    from synthadoc.storage.log import AuditDB
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+
+    assert await db.list_all_session_ids() == set()
+
+    await db.create_session("s1", "POWER_USER")
+    await db.create_session("s2", "EXPLORER")
+    await db.create_session("s3", "NEW_WIKI")
+
+    ids = await db.list_all_session_ids()
+    assert ids == {"s1", "s2", "s3"}
+
+
+@pytest.mark.asyncio
+async def test_list_all_session_ids_after_purge_excludes_deleted(tmp_path):
+    """list_all_session_ids() must not return sessions that were purged from the DB."""
+    import aiosqlite
+    from synthadoc.storage.log import AuditDB
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+
+    await db.create_session("old", "POWER_USER")
+    await db.create_session("recent", "POWER_USER")
+
+    # Back-date the old session so purge_old_sessions removes it
+    async with aiosqlite.connect(tmp_path / "audit.db") as conn:
+        await conn.execute(
+            "UPDATE chat_sessions SET last_active=? WHERE session_id=?",
+            ("2020-01-01T00:00:00", "old"),
+        )
+        await conn.commit()
+
+    await db.purge_old_sessions(retention_days=30)
+
+    ids = await db.list_all_session_ids()
+    assert "old" not in ids
+    assert "recent" in ids
+
+
+@pytest.mark.asyncio
 async def test_delete_graph_node_no_op_when_slug_absent(tmp_path):
     from synthadoc.storage.log import AuditDB
     db = AuditDB(tmp_path / "audit.db")

--- a/tests/test_http_sessions.py
+++ b/tests/test_http_sessions.py
@@ -127,3 +127,40 @@ def test_get_hints_defaults_to_power_user(client_and_db):
     resp = client.get("/hints")
     assert resp.status_code == 200
     assert "hints" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_session_state_pruned_to_match_db(tmp_path):
+    """_prune_stale_session_state() must evict entries absent from the DB.
+
+    Simulates the hourly purge path: POST /sessions populates _session_state,
+    purge_old_sessions deletes the row from the DB, then _prune_stale_session_state
+    removes the orphaned in-memory entry.
+    """
+    from synthadoc.integration.http_server import _prune_stale_session_state
+
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+
+    # Simulate three sessions added to in-memory state (as POST /sessions would do)
+    session_state: dict[str, dict] = {
+        "alive-1": {"mode": "POWER_USER", "cursor": 0, "last_hints": []},
+        "alive-2": {"mode": "EXPLORER",   "cursor": 2, "last_hints": ["hint-a"]},
+        # gone-1 is in RAM but absent from the DB (purged or never persisted)
+        "gone-1":  {"mode": "POWER_USER", "cursor": 0, "last_hints": []},
+    }
+
+    # Only alive-1 and alive-2 exist in the DB
+    await db.create_session("alive-1", "POWER_USER")
+    await db.create_session("alive-2", "EXPLORER")
+
+    pruned = await _prune_stale_session_state(db, session_state)
+
+    # gone-1 must be evicted; the return count must reflect it
+    assert pruned == 1
+    assert "gone-1" not in session_state
+    # Alive entries must be preserved intact
+    assert "alive-1" in session_state
+    assert "alive-2" in session_state
+    assert session_state["alive-2"]["cursor"] == 2
+    assert session_state["alive-2"]["last_hints"] == ["hint-a"]


### PR DESCRIPTION
Issue: https://github.com/axoviq-ai/synthadoc/issues/228

_session_state (mode, hint cursor, last_hints per session) grew forever because purge_old_sessions only cleaned the audit DB, never RAM.

Fix:
- AuditDB.list_all_session_ids() — lightweight SELECT id FROM chat_sessions
- _prune_stale_session_state(audit, session_state) — module-level helper that evicts entries whose session ID is no longer in the DB; returns count removed for logging
- _worker_loop now accepts session_state as an explicit parameter (fixes a latent NameError: _session_state is a create_app() closure variable, inaccessible from the module-level worker loop)
- Hourly purge block calls _prune_stale_session_state after DB purge so RAM always mirrors the DB within one purge interval
- Regression test updated to use word-boundary regex so the helper function name _prune_stale_session_state does not falsely trip the "must not reference _session_state directly" assertion

Tests added:
- test_list_all_session_ids_returns_all_ids
- test_list_all_session_ids_after_purge_excludes_deleted
- test_session_state_pruned_to_match_db