### PR TITLE
fix: Transient-failure jobs are re-queued with no backoff — retry budget exhausted in seconds

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1228,7 +1228,7 @@ skill   = { model = "claude-haiku-4-5-20251001" }
 [queue]
 max_parallel_ingest  = 4
 max_retries          = 3
-backoff_base_seconds = 5
+backoff_base_seconds = 30
 
 [cost]
 soft_warn_usd                     = 0.50
@@ -1310,7 +1310,7 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 | `query.context_token_budget` | int | `4000` | Token budget for context pack assembly. Increase for richer context on complex queries; decrease if hitting prompt size limits. |
 | `queue.max_parallel_ingest` | int | `4` | Max concurrent ingest agents |
 | `queue.max_retries` | int | `3` | Retries before job → dead |
-| `queue.backoff_base_seconds` | int | `5` | Exponential backoff base (±20% jitter) |
+| `queue.backoff_base_seconds` | int | `30` | Exponential backoff base; delays are `min(base × 2^(attempt−1), 300)` seconds |
 | `cache.version` | str | `"4"` | Bump to invalidate all cached LLM responses without touching source code |
 | `cost.soft_warn_usd` | float | `0.50` | Emit `logger.warning` in server log when per-job ingest cost exceeds this threshold; job continues normally |
 | `cost.hard_gate_usd` | float | `2.00` | Permanently fail the ingest job (DEAD) and record a `cost_gate_exceeded` audit event when per-job cost exceeds this threshold |
@@ -1581,8 +1581,8 @@ in_progress → skipped      (system-initiated skip; e.g. auto-blocked domain)
 | `skipped` | System-initiated permanent skip (e.g. domain auto-blocked after repeated 403s) | No action needed; remove domain from blocked list to re-enable |
 | `cancelled` | Pending job cancelled by user via `synthadoc jobs cancel` | Re-enqueue manually if cancelled in error |
 
-**Backoff formula:** `backoff_base_seconds × 2^(retry_count) × jitter`  
-where `jitter ∈ [0.8, 1.2]` (±20% random). Applied only to retryable errors (LLM API timeouts, 5xx responses).
+**Backoff formula:** `min(backoff_base_seconds × 2^(attempt − 1), 300)`  
+With the default base of 30 s: attempt 1 waits 30 s, attempt 2 waits 60 s, attempt 3 waits 120 s (all capped at 300 s). The `retry_after` timestamp is stored in the jobs table; `dequeue()` skips any job whose `retry_after` is still in the future. Applied only to transient errors (network timeouts, connection failures, 5xx responses).
 
 **Persistence:** Jobs survive server restarts. `in_progress` jobs at shutdown are reset to `pending` on startup.
 

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -131,7 +131,7 @@ class QueueConfig:
     # throughput support is a design goal.
     max_parallel_ingest: int = 4
     max_retries: int = 3
-    backoff_base_seconds: int = 5
+    backoff_base_seconds: int = 30
 
 
 @dataclass

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -374,8 +374,9 @@ class Orchestrator:
                 await self._auto_block_domain(e)
                 await self._queue.skip(job_id, str(e))
             elif isinstance(e, (httpx.ReadTimeout, httpx.ConnectTimeout, httpx.PoolTimeout,
-                                   httpx.ConnectError, httpx.ReadError)):
-                # Transient network error (timeout, connection refused, dropped) — retry with backoff.
+                                   httpx.ConnectError, httpx.ReadError,
+                                   httpx.RemoteProtocolError)):
+                # Transient network error (timeout, connection refused, dropped, protocol) — retry with backoff.
                 logging.getLogger(__name__).warning(
                     "URL fetch failed for job %s (%s: %s) — will retry", job_id, source,
                     type(e).__name__

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -377,9 +377,12 @@ class Orchestrator:
                                    httpx.ConnectError, httpx.ReadError,
                                    httpx.RemoteProtocolError)):
                 # Transient network error (timeout, connection refused, dropped, protocol) — retry with backoff.
+                _job = await self._queue.get_job(job_id)
+                _retries_so_far = (_job.retries if _job else 0) + 1
+                _outcome = "dead — retry budget exhausted" if _retries_so_far >= self._queue._max_retries else f"will retry (attempt {_retries_so_far}/{self._queue._max_retries})"
                 logging.getLogger(__name__).warning(
-                    "URL fetch failed for job %s (%s: %s) — will retry", job_id, source,
-                    type(e).__name__
+                    "URL fetch failed for job %s (%s: %s) — %s", job_id, source,
+                    type(e).__name__, _outcome,
                 )
                 await self._queue.fail(job_id, f"{type(e).__name__}: {source}")
             elif isinstance(e, httpx.HTTPStatusError):

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -90,7 +90,9 @@ class Orchestrator:
         sd.mkdir(parents=True, exist_ok=True)
         (sd / "logs").mkdir(exist_ok=True)
 
-        self._queue  = JobQueue(sd / "jobs.db", max_retries=self._cfg.queue.max_retries)
+        self._queue  = JobQueue(sd / "jobs.db",
+                                max_retries=self._cfg.queue.max_retries,
+                                backoff_base_seconds=self._cfg.queue.backoff_base_seconds)
         self.queue   = self._queue
         self._audit  = AuditDB(sd / "audit.db")
         self._cache  = CacheManager(sd / "cache.db")

--- a/synthadoc/core/queue.py
+++ b/synthadoc/core/queue.py
@@ -32,14 +32,30 @@ class Job:
     created_at: Optional[str] = None
     result: Optional[dict] = None
     progress: Optional[dict] = None
+    retry_after: Optional[str] = None
+
+
+_MAX_BACKOFF_SECONDS: int = 300
 
 
 class JobQueue:
-    def __init__(self, db_path: Path, max_retries: int = 3) -> None:
+    def __init__(self, db_path: Path, max_retries: int = 3,
+                 backoff_base_seconds: int = 30) -> None:
         self._path = Path(db_path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._max_retries = max_retries
+        self._backoff_base_seconds = backoff_base_seconds
         self._lock = asyncio.Lock()
+
+    def _backoff_delay(self, new_retries: int) -> int:
+        """Exponential backoff delay in seconds for the given retry count.
+
+        Returns 0 when backoff_base_seconds is 0 (disabled, used in tests).
+        """
+        if self._backoff_base_seconds <= 0:
+            return 0
+        return min(self._backoff_base_seconds * (2 ** (new_retries - 1)),
+                   _MAX_BACKOFF_SECONDS)
 
     _DEFAULT_JOB_TIMEOUT_SECONDS: int = 600  # matches [server] job_timeout_seconds default
 
@@ -66,6 +82,11 @@ class JobQueue:
             # Migrate existing DBs that predate the progress column
             try:
                 await db.execute("ALTER TABLE jobs ADD COLUMN progress TEXT")
+            except Exception:
+                pass  # column already exists
+            # Migrate existing DBs that predate the retry_after column
+            try:
+                await db.execute("ALTER TABLE jobs ADD COLUMN retry_after TEXT")
             except Exception:
                 pass  # column already exists
             # Jobs left in_progress from a crashed session can never complete —
@@ -110,7 +131,9 @@ class JobQueue:
             async with aiosqlite.connect(self._path) as db:
                 db.row_factory = aiosqlite.Row
                 async with db.execute(
-                    "SELECT * FROM jobs WHERE status='pending' ORDER BY created_at LIMIT 1"
+                    "SELECT * FROM jobs WHERE status='pending' "
+                    "AND (retry_after IS NULL OR retry_after <= datetime('now')) "
+                    "ORDER BY created_at LIMIT 1"
                 ) as cur:
                     row = await cur.fetchone()
                 if not row:
@@ -123,7 +146,8 @@ class JobQueue:
                            retries=row["retries"], error=row["error"],
                            created_at=row["created_at"],
                            result=json.loads(row["result"]) if row["result"] else None,
-                           progress=json.loads(row["progress"]) if row["progress"] else None)
+                           progress=json.loads(row["progress"]) if row["progress"] else None,
+                           retry_after=row["retry_after"])
 
     async def complete(self, job_id: str, result: Optional[dict] = None) -> None:
         async with aiosqlite.connect(self._path) as db:
@@ -148,10 +172,24 @@ class JobQueue:
                 row = await cur.fetchone()
             retries = (row["retries"] + 1) if row else 1
             new_status = JobStatus.DEAD if retries >= self._max_retries else JobStatus.PENDING
-            await db.execute(
-                "UPDATE jobs SET status=?,retries=?,error=? WHERE id=?",
-                (new_status, retries, error, job_id),
-            )
+            if new_status == JobStatus.PENDING:
+                delay = self._backoff_delay(retries)
+                if delay > 0:
+                    await db.execute(
+                        "UPDATE jobs SET status=?,retries=?,error=?,"
+                        "retry_after=datetime('now',?) WHERE id=?",
+                        (new_status, retries, error, f"+{delay} seconds", job_id),
+                    )
+                else:
+                    await db.execute(
+                        "UPDATE jobs SET status=?,retries=?,error=?,retry_after=NULL WHERE id=?",
+                        (new_status, retries, error, job_id),
+                    )
+            else:
+                await db.execute(
+                    "UPDATE jobs SET status=?,retries=?,error=?,retry_after=NULL WHERE id=?",
+                    (new_status, retries, error, job_id),
+                )
             await db.commit()
 
     async def requeue(self, job_id: str, error: str = "") -> None:
@@ -195,7 +233,8 @@ class JobQueue:
     async def retry(self, job_id: str) -> None:
         async with aiosqlite.connect(self._path) as db:
             await db.execute(
-                "UPDATE jobs SET status='pending',retries=0,error=NULL WHERE id=?", (job_id,)
+                "UPDATE jobs SET status='pending',retries=0,error=NULL,retry_after=NULL WHERE id=?",
+                (job_id,),
             )
             await db.commit()
 
@@ -257,6 +296,7 @@ class JobQueue:
                         created_at=r["created_at"],
                         result=json.loads(r["result"]) if r["result"] else None,
                         progress=json.loads(r["progress"]) if r["progress"] else None,
+                        retry_after=r["retry_after"],
                         ) for r in rows]
 
     async def get_job(self, job_id: str) -> Optional[Job]:
@@ -275,4 +315,5 @@ class JobQueue:
             created_at=row["created_at"],
             result=json.loads(row["result"]) if row["result"] else None,
             progress=json.loads(row["progress"]) if row["progress"] else None,
+            retry_after=row["retry_after"],
         )

--- a/tests/core/test_queue.py
+++ b/tests/core/test_queue.py
@@ -30,7 +30,7 @@ async def test_complete_job(tmp_wiki):
 
 @pytest.mark.asyncio
 async def test_fail_retries_then_dies(tmp_wiki):
-    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=2)
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=2, backoff_base_seconds=0)
     await q.init()
     await q.enqueue("ingest", {"source": "x.pdf"})
     job = await q.dequeue()
@@ -74,7 +74,7 @@ async def test_queue_handles_overflow(tmp_wiki):
 @pytest.mark.asyncio
 async def test_fail_exactly_at_max_retries_becomes_dead(tmp_wiki):
     """Job must become dead on the Nth failure where N == max_retries."""
-    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=3)
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=3, backoff_base_seconds=0)
     await q.init()
     await q.enqueue("ingest", {"source": "x.pdf"})
     for _ in range(3):
@@ -189,7 +189,7 @@ async def test_enqueue_many_all_pending(tmp_wiki):
 @pytest.mark.asyncio
 async def test_retry_resets_retries_counter(tmp_wiki):
     """retry() must reset the retries counter to 0 so the job gets a full retry budget."""
-    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=2)
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=2, backoff_base_seconds=0)
     await q.init()
     job_id = await q.enqueue("ingest", {"source": "x.pdf"})
     # Exhaust retries → dead
@@ -500,3 +500,69 @@ async def test_list_jobs_invalid_sort_column_falls_back_to_created_at(tmp_wiki):
     await q.enqueue("ingest", {"source": "x.pdf"})
     jobs = await q.list_jobs(sort_by="__injected__; DROP TABLE jobs--", order="asc")
     assert len(jobs) == 1
+
+
+# ── Exponential backoff ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_fail_sets_retry_after_backoff(tmp_wiki):
+    """fail() on a retryable job must set retry_after to a future timestamp."""
+    import aiosqlite
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=3, backoff_base_seconds=30)
+    await q.init()
+    job_id = await q.enqueue("ingest", {"source": "x.pdf"})
+    job = await q.dequeue()
+    assert job is not None
+    await q.fail(job_id, "transient error")
+    async with aiosqlite.connect(q._path) as db:
+        async with db.execute("SELECT retry_after FROM jobs WHERE id=?", (job_id,)) as cur:
+            row = await cur.fetchone()
+    assert row is not None
+    assert row[0] is not None, "retry_after must be set after a transient failure"
+
+
+@pytest.mark.asyncio
+async def test_dequeue_skips_jobs_in_backoff(tmp_wiki):
+    """dequeue() must not return a job whose retry_after is in the future."""
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=3, backoff_base_seconds=30)
+    await q.init()
+    job_id = await q.enqueue("ingest", {"source": "x.pdf"})
+    job = await q.dequeue()
+    assert job is not None
+    await q.fail(job_id, "transient error")
+    # retry_after is ~30 s in the future — dequeue must not return the job yet
+    result = await q.dequeue()
+    assert result is None, "dequeue must skip jobs still in backoff"
+
+
+@pytest.mark.asyncio
+async def test_fail_dead_clears_retry_after(tmp_wiki):
+    """The final failure (status=dead) must not leave retry_after set."""
+    import aiosqlite
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=1, backoff_base_seconds=30)
+    await q.init()
+    job_id = await q.enqueue("ingest", {"source": "x.pdf"})
+    job = await q.dequeue()
+    assert job is not None
+    await q.fail(job_id, "fatal error")
+    async with aiosqlite.connect(q._path) as db:
+        async with db.execute("SELECT status, retry_after FROM jobs WHERE id=?", (job_id,)) as cur:
+            row = await cur.fetchone()
+    assert row[0] == "dead"
+    assert row[1] is None, "dead jobs must not have retry_after set"
+
+
+@pytest.mark.asyncio
+async def test_retry_clears_retry_after(tmp_wiki):
+    """Manual retry() must clear retry_after so the job is immediately dequeued."""
+    q = JobQueue(tmp_wiki / ".synthadoc" / "jobs.db", max_retries=3, backoff_base_seconds=30)
+    await q.init()
+    job_id = await q.enqueue("ingest", {"source": "x.pdf"})
+    job = await q.dequeue()
+    assert job is not None
+    await q.fail(job_id, "transient error")
+    # retry_after is set — manual retry must clear it
+    await q.retry(job_id)
+    result = await q.dequeue()
+    assert result is not None, "after retry(), job must be immediately dequeued"
+    assert result.id == job_id

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -44,12 +44,15 @@ No mocks.  This script is run manually, not by CI.
              context build, lint report, schedule, audit lifecycle purge,
              plugin upgrade, backup/restore
   Tier 2 — Live.  Runs when server responds at SYNTHADOC_URL; calls LLM.
-             [13]–[23] — status, ingest, query, scaffold, export, jobs,
-             lint run, schedule run, lifecycle, cascade link cleanup, cache clear, audit
+             [13]–[25] — status, ingest, query, scaffold, export, jobs,
+             lint run, schedule run, lifecycle, cascade link cleanup, cache clear,
+             job backoff, audit, logging
 
 ────────────────────────────────────────────────────────────────────────────────
  SIDE EFFECTS & ROLLBACK
 ────────────────────────────────────────────────────────────────────────────────
+  • job backoff: one ingest job is enqueued to a URL that returns 503; it runs
+                through all 3 retries (~3 min total) and is deleted on completion.
   • backup:     zip written to a temp dir, deleted after tests.
   • restore:    two wikis registered under '_live-test-restore' and
                 '_live-test-restore-dflt'; directories deleted and registry
@@ -734,8 +737,101 @@ def run_live_tests(wiki_root: pathlib.Path) -> None:
     check("audit events",    ["audit", "events"]     + w)
     check("audit citations", ["audit", "citations"]  + w)
 
+    # ── job backoff (transient-failure retry) ────────────────────────────────
+    print("\n[24] job backoff")
+
+    _BACKOFF_URL  = "https://httpstat.us/503"
+    _backoff_base = SYNTHADOC_URL.rstrip("/")
+    _backoff_jid  = ""
+
+    try:
+        _req = urllib.request.Request(
+            f"{_backoff_base}/jobs/ingest",
+            data=json.dumps({"source": _BACKOFF_URL}).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(_req, timeout=10) as _r:
+            _backoff_jid = json.loads(_r.read().decode()).get("job_id", "")
+        info(f"Enqueued job {_backoff_jid} — waiting for first failure (~30-40s)…")
+    except Exception as _e:
+        fail("job backoff — enqueue", str(_e))
+
+    if _backoff_jid:
+        # Poll the DB until the job enters its first backoff window:
+        # status=pending, retry_after IS NOT NULL
+        _db_path       = wiki_root / ".synthadoc" / "jobs.db"
+        _bo_deadline   = time.monotonic() + 90
+        _bo_row        = None
+        while time.monotonic() < _bo_deadline:
+            time.sleep(3)
+            try:
+                _c = sqlite3.connect(str(_db_path))
+                _bo_row = _c.execute(
+                    "SELECT status, retries, retry_after FROM jobs WHERE id=?",
+                    (_backoff_jid,)
+                ).fetchone()
+                _c.close()
+                if _bo_row and _bo_row[0] == "pending" and _bo_row[2] is not None:
+                    break
+                _bo_row = None
+            except Exception:
+                pass
+
+        if _bo_row:
+            ok("job backoff — retry_after set after first failure",
+               f"retries={_bo_row[1]}, retry_after={_bo_row[2]}")
+
+            # retry_after must be a future UTC timestamp
+            import datetime as _dt
+            try:
+                _ra  = _dt.datetime.fromisoformat(_bo_row[2])
+                _now = _dt.datetime.utcnow()
+                if _ra > _now:
+                    ok("job backoff — retry_after is a future timestamp",
+                       f"{int((_ra - _now).total_seconds())}s remaining")
+                else:
+                    fail("job backoff — retry_after is a future timestamp",
+                         f"retry_after {_bo_row[2]} is already in the past")
+            except ValueError as _e:
+                fail("job backoff — retry_after is a future timestamp",
+                     f"could not parse retry_after: {_e}")
+
+            # Log must contain WARN "will retry", not an ERROR+stacktrace
+            _log_path = wiki_root / ".synthadoc" / "logs" / "synthadoc.log"
+            if _log_path.exists():
+                _log_lines = _log_path.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+                _job_lines  = [l for l in _log_lines if _backoff_jid in l]
+                _has_error  = any('"level": "ERROR"' in l for l in _job_lines)
+                _has_warn   = any("will retry" in l for l in _job_lines)
+                if not _has_error:
+                    ok("job backoff — no ERROR log entry (no stacktrace)")
+                else:
+                    fail("job backoff — no ERROR log entry",
+                         f"ERROR entry found for job {_backoff_jid}")
+                if _has_warn:
+                    _wmsg = next(l for l in _job_lines if "will retry" in l)
+                    try:
+                        _wmsg = json.loads(_wmsg).get("msg", _wmsg)
+                    except Exception:
+                        pass
+                    ok("job backoff — WARN log present", str(_wmsg)[:120])
+                else:
+                    warn("job backoff — WARN log present",
+                         "no 'will retry' warning found in log yet")
+        else:
+            fail("job backoff — retry_after set after first failure",
+                 "job did not enter backoff state within 90s")
+
+        # Wait for all retries to exhaust then delete the job
+        _wait_job_terminal(_backoff_jid, "job backoff — wait for dead", max_wait=360)
+        run(["jobs", "delete", _backoff_jid] + w)
+        ok("job backoff — cleanup", f"job {_backoff_jid} deleted")
+
     # ── logging ───────────────────────────────────────────────────────────────
-    print("\n[24] logging")
+    print("\n[25] logging")
     import json as _json
     log_path = wiki_root / ".synthadoc" / "logs" / "synthadoc.log"
     if not log_path.exists():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -77,7 +77,7 @@ def test_queue_defaults():
     cfg = load_config()
     assert cfg.queue.max_parallel_ingest == 4
     assert cfg.queue.max_retries == 3
-    assert cfg.queue.backoff_base_seconds == 5
+    assert cfg.queue.backoff_base_seconds == 30
 
 
 def test_unlimited_wikis(tmp_path):


### PR DESCRIPTION
Issue: https://github.com/axoviq-ai/synthadoc/issues/238
