### PR TITLE
fix: Config staging_policy and staging_confidence_min accept invalid values silently

### DIFF
--- a/synthadoc/agents/scaffold_agent.py
+++ b/synthadoc/agents/scaffold_agent.py
@@ -137,7 +137,7 @@ Return ONLY valid JSON:
     }},
     ...
   ],
-  "agents_guidelines": "3 domain-specific ingest and query guidelines, one per line — write each guideline as a plain sentence on its own line with no bullet or dash symbol (the renderer adds the bullet)",
+  "agents_guidelines": ["domain-specific guideline one", "domain-specific guideline two", "domain-specific guideline three"],
   "purpose_overview": "2-3 sentences describing the domain, its importance, and what this wiki is for",
   "purpose_include": "3-5 items listing the types of topics, concepts, and artefacts that belong in this wiki, one per line, no bullet symbols",
   "purpose_exclude": "3-5 items listing what is explicitly out of scope, one per line, no bullet symbols",
@@ -146,6 +146,7 @@ Return ONLY valid JSON:
   "dashboard_intro": "one sentence describing what this wiki tracks"
 }}
 
+Write exactly 3 "agents_guidelines" items — each a plain sentence with no bullet or dash prefix (the renderer adds bullets).
 The "slugs" array must contain the kebab-case page slugs that belong in each category.
 {slugs_instruction}If a category has no known pages yet, use an empty array.
 Never include system/meta pages in any "slugs" array: index, overview, purpose, dashboard, log.
@@ -479,8 +480,12 @@ class ScaffoldAgent:
     ) -> tuple[str, str, str]:
         """Return (agents_md, claude_md, gemini_md) from LLM scaffold data."""
         raw_guidelines = data.get("agents_guidelines", "Summarize key claims.")
+        if isinstance(raw_guidelines, list):
+            lines = [str(g) for g in raw_guidelines]
+        else:
+            lines = raw_guidelines.splitlines()
         bullets = []
-        for line in raw_guidelines.splitlines():
+        for line in lines:
             line = line.strip().lstrip("-•* ")
             if line:
                 bullets.append(f"- {line}")

--- a/synthadoc/cli/candidates.py
+++ b/synthadoc/cli/candidates.py
@@ -14,6 +14,7 @@ import yaml
 from synthadoc.cli._wiki import resolve_wiki
 from synthadoc.cli._wiki import resolve_wiki_path
 from synthadoc.cli.main import app
+from synthadoc.config import STAGING_POLICIES, STAGING_CONFIDENCE_LEVELS
 
 staging_app = typer.Typer(name="staging", help="Manage staging policy for new wiki pages.")
 candidates_app = typer.Typer(name="candidates", help="Review, promote, or discard candidate pages.")
@@ -116,8 +117,11 @@ def staging_policy_cmd(
             typer.echo(f"Minimum confidence for auto-promote: {min_c}")
         return
 
-    if policy not in ("off", "all", "threshold"):
-        typer.echo("Policy must be one of: off, all, threshold")
+    if policy not in STAGING_POLICIES:
+        typer.echo(f"Policy must be one of: {', '.join(sorted(STAGING_POLICIES))}")
+        raise typer.Exit(1)
+    if min_confidence and min_confidence not in STAGING_CONFIDENCE_LEVELS:
+        typer.echo(f"min-confidence must be one of: {', '.join(sorted(STAGING_CONFIDENCE_LEVELS))}")
         raise typer.Exit(1)
 
     updates = {"staging_policy": policy}

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -20,6 +20,9 @@ from typing import Optional
 KNOWN_PROVIDERS = {"anthropic", "openai", "ollama", "gemini", "groq", "minimax", "deepseek",
                    "qwen", "claude-code", "opencode"}
 
+STAGING_POLICIES: frozenset[str] = frozenset({"off", "all", "threshold"})
+STAGING_CONFIDENCE_LEVELS: frozenset[str] = frozenset({"high", "medium", "low"})
+
 
 # ---------------------------------------------------------------------------
 # Leaf dataclasses
@@ -254,6 +257,19 @@ def _validate_provider(agent: AgentConfig) -> None:
         )
 
 
+def _validate_ingest_staging(policy: str, confidence_min: str) -> None:
+    if policy not in STAGING_POLICIES:
+        raise ValueError(
+            f"Unknown staging_policy '{policy}'. "
+            f"Must be one of: {', '.join(sorted(STAGING_POLICIES))}"
+        )
+    if confidence_min not in STAGING_CONFIDENCE_LEVELS:
+        raise ValueError(
+            f"Unknown staging_confidence_min '{confidence_min}'. "
+            f"Must be one of: {', '.join(sorted(STAGING_CONFIDENCE_LEVELS))}"
+        )
+
+
 def _build_default_agents_config() -> AgentsConfig:
     """Return a sentinel AgentsConfig with no real default (used as base before merging)."""
     # We use a placeholder that will be replaced during _merge if the user
@@ -347,6 +363,7 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
         citation_source_lines=int(ig.get("citation_source_lines", 400)),
         citation_max_tokens=int(ig.get("citation_max_tokens", 8192)),
     )
+    _validate_ingest_staging(ingest.staging_policy, ingest.staging_confidence_min)
 
     # --- query ---
     q_section = raw.get("query", {})

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -546,7 +546,7 @@ _graph_computing = False  # module-level flag prevents duplicate background task
 def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mcp: bool = True) -> FastAPI:
     import os
     import synthadoc
-    from synthadoc.config import load_config
+    from synthadoc.config import load_config, STAGING_POLICIES, STAGING_CONFIDENCE_LEVELS
     from synthadoc.core.orchestrator import Orchestrator
     from synthadoc.storage.log import AuditDB as _AuditDB
     from synthadoc.storage.wiki import LifecycleState, TriggerSource
@@ -1405,10 +1405,10 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
     async def staging_policy_set(req: StagingPolicyRequest):
         import tomllib as _tomllib
         from synthadoc.cli.candidates import _patch_toml as _cand_patch_toml
-        if req.policy not in ("off", "all", "threshold"):
-            raise HTTPException(400, "policy must be off, all, or threshold")
-        if req.confidence_min and req.confidence_min not in ("high", "medium", "low"):
-            raise HTTPException(400, "confidence_min must be high, medium, or low")
+        if req.policy not in STAGING_POLICIES:
+            raise HTTPException(400, f"policy must be one of: {', '.join(sorted(STAGING_POLICIES))}")
+        if req.confidence_min and req.confidence_min not in STAGING_CONFIDENCE_LEVELS:
+            raise HTTPException(400, f"confidence_min must be one of: {', '.join(sorted(STAGING_CONFIDENCE_LEVELS))}")
         cfg_path = _staging_cfg_path()
         cfg_path.parent.mkdir(parents=True, exist_ok=True)
         updates: dict = {"staging_policy": req.policy}

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -56,6 +56,24 @@ class LogWriter:
         )
 
 
+def _audit_slug_filter(page_slug: str | None) -> tuple[str, list]:
+    """Return (SQL WHERE fragment, bound params) for filtering audit_events by slug.
+
+    Metadata may store the slug under 'page_slug' (preferred) or legacy 'slug'.
+    Expressing the filter in SQL ensures LIMIT/OFFSET operate on the
+    already-filtered set rather than on all rows (BUG-11).
+    """
+    if page_slug is None:
+        return "", []
+    return (
+        "AND COALESCE("
+        "JSON_EXTRACT(metadata, '$.page_slug'), "
+        "JSON_EXTRACT(metadata, '$.slug')"
+        ") = ? ",
+        [page_slug],
+    )
+
+
 class AuditDB:
     def __init__(self, db_path: Path) -> None:
         self._path = Path(db_path)
@@ -403,13 +421,15 @@ class AuditDB:
         Each returned dict has keys: page_slug, source_file, citation, reason,
         event_time.
         """
+        slug_filter, params = _audit_slug_filter(page_slug)
+        params.extend([limit, offset])
         async with aiosqlite.connect(self._path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
                 "SELECT timestamp, metadata FROM audit_events "
-                "WHERE event='citation_validation_failed' "
+                f"WHERE event='citation_validation_failed' {slug_filter}"
                 "ORDER BY id DESC LIMIT ? OFFSET ?",
-                (limit, offset),
+                params,
             ) as cur:
                 rows = await cur.fetchall()
         result = []
@@ -418,16 +438,13 @@ class AuditDB:
                 m = json.loads(r["metadata"] or "{}")
             except Exception:
                 m = {}
-            entry = {
+            result.append({
                 "page_slug": m.get("page_slug") or m.get("slug"),
                 "source_file": m.get("source_file"),
                 "citation": m.get("citation"),
                 "reason": m.get("reason"),
                 "event_time": r["timestamp"],
-            }
-            if page_slug is not None and entry["page_slug"] != page_slug:
-                continue
-            result.append(entry)
+            })
         return result
 
     async def write_event(self, event: str, job_id: str = "",

--- a/tests/cli/test_audit_cli.py
+++ b/tests/cli/test_audit_cli.py
@@ -317,6 +317,40 @@ async def test_list_citation_failures_multiple_events(db):
     assert all(r["reason"] == "broken" for r in rows)
 
 
+async def test_list_citation_failures_slug_filter_applies_before_limit(db):
+    """BUG-11 regression: page_slug filter must be in SQL, not Python.
+
+    If the filter ran in Python after LIMIT, a page whose rows appear after the
+    first LIMIT rows would never be found even though matching rows exist.
+    """
+    # Write 5 failures for "other-page" followed by 1 for "target-page".
+    # With LIMIT=3 and Python-side filtering, "target-page" would never appear.
+    for i in range(5):
+        await db.write_event(
+            "citation_validation_failed",
+            metadata={"slug": "other-page", "citation": f"^[f{i}.txt:1]", "reason": "broken"},
+        )
+    await db.write_event(
+        "citation_validation_failed",
+        metadata={"slug": "target-page", "citation": "^[target.txt:1]", "reason": "missing"},
+    )
+    rows = await db.list_citation_failures(page_slug="target-page", limit=3, offset=0)
+    assert len(rows) == 1
+    assert rows[0]["page_slug"] == "target-page"
+    assert rows[0]["reason"] == "missing"
+
+
+async def test_list_citation_failures_page_slug_key_also_matched(db):
+    """Metadata stored with 'page_slug' key (not legacy 'slug') must also be returned."""
+    await db.write_event(
+        "citation_validation_failed",
+        metadata={"page_slug": "modern-page", "citation": "^[a.txt:1]", "reason": "broken_ref"},
+    )
+    rows = await db.list_citation_failures(page_slug="modern-page")
+    assert len(rows) == 1
+    assert rows[0]["page_slug"] == "modern-page"
+
+
 async def test_write_event_stores_event(db):
     await db.write_event("citation_pass4_skipped",
                          metadata={"slug": "p", "error": "timeout"})

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -75,6 +75,7 @@ no Obsidian runtime needed.  Organized by the 14 plugin commands + ribbon icon.
   [v1.0-f] context budget       : GET /query/stream, citations non-empty and status count consistent
   [v1.0-g] streaming token audit: GET /query/stream done event tokens_used > 0,
                                    GET /audit/queries shows non-zero tokens and cost_usd
+  [v1.1-a] citation pagination  : GET /provenance/citations?broken=true structure + pagination (BUG-11)
 
 ────────────────────────────────────────────────────────────────────────────────
  SIDE EFFECTS & ROLLBACK
@@ -720,6 +721,47 @@ def _test_streaming_query_audit() -> None:
         f"Audit row tokens={latest.get('tokens')} — streaming token count not persisted"
     )
     assert latest.get("cost_usd", 0.0) >= 0.0  # 0.0 is valid for Ollama (local)
+
+
+def _test_citation_failures_pagination() -> None:
+    """GET /provenance/citations?broken=true must return correct structure and honour pagination.
+
+    BUG-11 regression: the page_slug filter was applied in Python after LIMIT,
+    so rows for a specific slug could be invisible if other slugs filled the page.
+    The fix pushes filtering into SQL. This live test verifies:
+      1. The endpoint returns 200 with 'total' and 'citations' keys.
+      2. Pagination (limit=1, offset=0) returns at most 1 row.
+      3. total >= len(citations) (no off-by-one from the SQL fix).
+      4. /provenance/citations?page=<slug> (non-broken, page filter in SQL) works.
+    """
+    code, body = GET("/provenance/citations?broken=true")
+    assert code == 200, f"GET /provenance/citations?broken=true returned HTTP {code}: {body}"
+    assert isinstance(body, dict), f"Expected dict, got {type(body).__name__}: {body}"
+    assert "total" in body, f"Response missing 'total' key: {list(body.keys())}"
+    assert "citations" in body, f"Response missing 'citations' key: {list(body.keys())}"
+    total = body["total"]
+    all_citations = body["citations"]
+    assert isinstance(all_citations, list), f"'citations' must be a list, got {type(all_citations).__name__}"
+    assert total >= len(all_citations), (
+        f"total={total} < len(citations)={len(all_citations)} — SQL LIMIT/OFFSET mis-applied"
+    )
+
+    # Pagination: limit=1 must return at most 1 row
+    code2, body2 = GET("/provenance/citations?broken=true&limit=1&offset=0")
+    assert code2 == 200, f"pagination call returned HTTP {code2}"
+    paged = body2.get("citations", [])
+    assert len(paged) <= 1, f"limit=1 returned {len(paged)} rows — LIMIT not respected"
+
+    # Non-broken path with page filter (exercises the list_citations SQL path)
+    code3, lc_body = GET("/lifecycle/pages")
+    if code3 == 200:
+        lc_pages = lc_body if isinstance(lc_body, list) else lc_body.get("pages", [])
+        if lc_pages:
+            slug = (lc_pages[0].get("slug") if isinstance(lc_pages[0], dict) else lc_pages[0])
+            if slug:
+                code4, body4 = GET(f"/provenance/citations?page={urllib.parse.quote(slug)}&limit=10")
+                assert code4 == 200, f"page-filtered citations returned HTTP {code4}"
+                assert "citations" in body4, f"Missing 'citations' key in page-filtered response"
 
 
 def _test_blocked_domain_filter() -> None:
@@ -1385,6 +1427,12 @@ def main() -> None:
         ok("GET /graph (lazy hydration)", "repeated poll resolved to ready")
     except AssertionError as e:
         fail("GET /graph (lazy hydration)", str(e))
+
+    try:
+        _test_citation_failures_pagination()
+        ok("GET /provenance/citations (BUG-11 pagination)", "structure valid, total >= len(citations), limit respected")
+    except AssertionError as e:
+        fail("GET /provenance/citations (BUG-11 pagination)", str(e))
 
     try:
         _test_sanitizer_and_truncation_flag()

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -221,18 +221,55 @@ def _cleanup_job_pages(job_id: str) -> list[str]:
 
 
 def _cleanup_test_ingest(job_id: str, src_file: pathlib.Path) -> None:
-    """Remove wiki pages and extracted sidecars written by a live test ingest job.
+    """Remove all artifacts written by a live test ingest job.
 
-    Deletes pages newly created by the job (not pre-existing pages that were
-    updated), plus any .synthadoc/extracted/<basename> sidecar and companion
-    pagemap JSON, so test runs leave no artifacts behind.
+    Three cleanup passes run regardless of job outcome (completed / dead):
+      1. Job-result pass: delete pages listed in pages_created.
+      2. Source-scan pass: delete any wiki / candidate page whose frontmatter
+         sources[] references src_file.name — catches pages_updated entries and
+         pages created by dead jobs whose result is empty.
+      3. DB pass: delete claim_citations rows for src_file.name so the Page
+         Provenance modal no longer shows stale rows pointing at a deleted file.
+    Also removes the .synthadoc/extracted sidecar and pagemap JSON.
     """
     _cleanup_job_pages(job_id)
     wiki_root = _discover_wiki_root()
     if not wiki_root:
         return
+
+    # Pass 2: scan all markdown files for references to the test source
+    src_name = src_file.name
+    wiki_dir = wiki_root / "wiki"
+    candidates_dir = wiki_dir / "candidates"
+    for md_file in list(wiki_dir.glob("*.md")) + list(candidates_dir.glob("*.md")):
+        try:
+            fm = _read_frontmatter(md_file)
+            if any(
+                isinstance(s, dict) and src_name in (s.get("file") or "")
+                for s in fm.get("sources", [])
+            ):
+                md_file.unlink(missing_ok=True)
+        except Exception:
+            pass
+
+    # Pass 3: purge claim_citations and related audit_events for this source
+    db_path = wiki_root / ".synthadoc" / "audit.db"
+    if db_path.exists():
+        import sqlite3 as _sqlite3
+        with _sqlite3.connect(db_path) as _db:
+            _db.execute(
+                "DELETE FROM claim_citations WHERE source_file = ?", (src_name,)
+            )
+            _db.execute(
+                "DELETE FROM audit_events "
+                "WHERE event = 'citation_validation_failed' "
+                "AND JSON_EXTRACT(metadata, '$.source_file') = ?",
+                (src_name,),
+            )
+            _db.commit()
+
     # Remove extracted sidecar for the test source file
-    extracted = wiki_root / ".synthadoc" / "extracted" / src_file.name
+    extracted = wiki_root / ".synthadoc" / "extracted" / src_name
     if extracted.exists():
         extracted.unlink()
     # Remove a companion pagemap JSON if present (PDF sources)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -278,6 +278,20 @@ def test_chat_config_defaults_via_load_config(tmp_path):
     assert cfg.chat.session_retention_days == 30
 
 
+def test_invalid_staging_policy_raises(tmp_path):
+    toml_file = tmp_path / "config.toml"
+    toml_file.write_text('[ingest]\nstaging_policy = "bogus"\n')
+    with pytest.raises(ValueError, match="Unknown staging_policy"):
+        load_config(project_config=toml_file)
+
+
+def test_invalid_staging_confidence_min_raises(tmp_path):
+    toml_file = tmp_path / "config.toml"
+    toml_file.write_text('[ingest]\nstaging_confidence_min = "extreme"\n')
+    with pytest.raises(ValueError, match="Unknown staging_confidence_min"):
+        load_config(project_config=toml_file)
+
+
 def test_ingest_config_max_source_chars_default():
     from synthadoc.config import IngestConfig
     cfg = IngestConfig()


### PR DESCRIPTION
Issue: https://github.com/axoviq-ai/synthadoc/issues/241

- config.py: STAGING_POLICIES and STAGING_CONFIDENCE_LEVELS constants added, _validate_ingest_staging() helper validates on config load, raises ValueError with clear message
- http_server.py: replaced two hardcoded tuples with the imported constants
- cli/candidates.py: replaced hardcoded tuple, added missing min_confidence validation
- Two new tests confirm invalid values raise ValueError