### PR TITLE
fix(perf-tests): force SelectorEventLoop on Windows to prevent aiosql…

### DIFF
--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 William Johnason / axoviq.com
+import asyncio
+import platform
+import warnings
+
+# ProactorEventLoop (IOCP) deadlocks when aiosqlite's background thread
+# signals completion while asyncio is inside selectors._select on Windows CI
+# runners — the async test hangs until pytest-timeout kills it.
+# SelectorEventLoop avoids this; it is the same fix already applied in
+# _new_sync_loop() for the benchmark variants in test_query_cache_perf.py.
+#
+# WindowsSelectorEventLoopPolicy and set_event_loop_policy are deprecated in
+# Python 3.14 (removal in 3.16). Suppress the warnings until we migrate to a
+# loop_factory approach in a future release.
+if platform.system() == "Windows":
+    warnings.filterwarnings("ignore", ".*WindowsSelectorEventLoopPolicy.*", DeprecationWarning)
+    warnings.filterwarnings("ignore", ".*set_event_loop_policy.*", DeprecationWarning)
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
…ite hang

ProactorEventLoop (IOCP) deadlocks when aiosqlite signals its background thread while the asyncio event loop is inside selectors._select — the test hangs until pytest-timeout kills it with exit code 1 on Windows CI.

Add tests/performance/conftest.py that applies WindowsSelectorEventLoopPolicy on Windows, consistent with the _new_sync_loop() fix already present in the benchmark variants. Suppress the Python 3.14 deprecation warnings for the policy APIs (removal in 3.16; migration deferred until then).