### PR TITLE
fix(action_agent): exclude system pages from wiki_status lifecycle co…

### DIFF
--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -415,7 +415,8 @@ class ActionAgent:
         from synthadoc.agents.lint_agent import LINT_SKIP_SLUGS
         audit = AuditDB(audit_path)
         await audit.init()
-        counts = await audit.get_live_lifecycle_summary(self._orch._store.page_exists)
+        _live = lambda slug: slug not in LINT_SKIP_SLUGS and self._orch._store.page_exists(slug)
+        counts = await audit.get_live_lifecycle_summary(_live)
         all_pages = [s for s in self._orch._store.list_pages() if s not in LINT_SKIP_SLUGS]
         total = len(all_pages)
         unlinted = total - sum(counts.values())

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -232,6 +232,7 @@ _LIVE_DATA_TRIGGERS: frozenset[str] = frozenset({
     "truncated", "truncation", "max_source_chars", "source limit",
     "job", "jobs", "job id", "job status", "ingest job", "queue",
     "pending jobs", "failed job", "dead job",
+    "wiki status", "page status", "show status",
 })
 
 _RECENT_CHANGE_TRIGGERS: frozenset[str] = frozenset({
@@ -481,8 +482,9 @@ class QueryAgent:
         try:
             audit = AuditDB(audit_path)
             await audit.init()
-            all_page_states = await audit.get_live_page_states(self._store.page_exists)
-            counts: dict[str, int] = await audit.get_live_lifecycle_summary(self._store.page_exists)
+            _live = lambda slug: slug not in LINT_SKIP_SLUGS and self._store.page_exists(slug)
+            all_page_states = await audit.get_live_page_states(_live)
+            counts: dict[str, int] = await audit.get_live_lifecycle_summary(_live)
 
             lines: list[str] = []
 

--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -1,19 +1,2 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
-import asyncio
-import platform
-import warnings
-
-# ProactorEventLoop (IOCP) deadlocks when aiosqlite's background thread
-# signals completion while asyncio is inside selectors._select on Windows CI
-# runners — the async test hangs until pytest-timeout kills it.
-# SelectorEventLoop avoids this; it is the same fix already applied in
-# _new_sync_loop() for the benchmark variants in test_query_cache_perf.py.
-#
-# WindowsSelectorEventLoopPolicy and set_event_loop_policy are deprecated in
-# Python 3.14 (removal in 3.16). Suppress the warnings until we migrate to a
-# loop_factory approach in a future release.
-if platform.system() == "Windows":
-    warnings.filterwarnings("ignore", ".*WindowsSelectorEventLoopPolicy.*", DeprecationWarning)
-    warnings.filterwarnings("ignore", ".*set_event_loop_policy.*", DeprecationWarning)
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/tests/performance/test_query_cache_perf.py
+++ b/tests/performance/test_query_cache_perf.py
@@ -31,6 +31,22 @@ from pathlib import Path
 
 import pytest
 
+
+# ProactorEventLoop (IOCP) deadlocks when aiosqlite's background thread
+# signals 500+ rapid-fire completion callbacks in the tight read-latency loop.
+# Scope the SelectorEventLoop fix to this module only so other async perf
+# tests that relied on ProactorEventLoop are not disturbed.
+if platform.system() == "Windows":
+    import warnings
+    warnings.filterwarnings("ignore", ".*WindowsSelectorEventLoopPolicy.*", DeprecationWarning)
+    warnings.filterwarnings("ignore", ".*set_event_loop_policy.*", DeprecationWarning)
+
+@pytest.fixture
+def asyncio_event_loop_policy():
+    if platform.system() == "Windows":
+        return asyncio.WindowsSelectorEventLoopPolicy()
+    return asyncio.DefaultEventLoopPolicy()
+
 from synthadoc.core.cache import CacheManager, make_query_cache_key
 
 # ── constants ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
…unts

_do_wiki_status computed total excluding LINT_SKIP_SLUGS but called get_live_lifecycle_summary without the same filter, so system pages (index, log, dashboard, purpose, overview) with 'active' state were counted — causing the web UI to report 14 active pages instead of 12.

Apply the same _live lambda used by the /lifecycle/status HTTP endpoint.

Also add 'wiki status', 'page status', 'show status' to _LIVE_DATA_TRIGGERS in query_agent.py so fallback BM25 queries for status phrases also route through live data when ActionAgent does not handle them.