### PR TITLE
fix: ModuleNotFoundError: No module named 'mcp.server.fastmcp' from some forked env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
       - run: pip install -e ".[dev]"
-      - run: pip install "mcp>=1.0"
+      - run: pip install "mcp>=1.0,<2.0"
       - run: python scripts/update_badges.py --check
       - run: pytest --cov=synthadoc --cov-report=term-missing -v
 
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/prepare_pypi_readme.py
       - run: pip install -e ".[dev]"
-      - run: pip install "mcp>=1.0"
+      - run: pip install "mcp>=1.0,<2.0"
       - run: pytest --cov=synthadoc --cov-report=json -q
       - run: python scripts/update_badges.py --coverage-json coverage.json
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             exit 1
           fi
       - run: pip install -e ".[dev]"
+      - run: pip install "mcp>=1.0"
       - run: python scripts/update_badges.py --check
       - run: pytest --cov=synthadoc --cov-report=term-missing -v
 
@@ -49,6 +50,7 @@ jobs:
           python-version: "3.12"
       - run: python scripts/prepare_pypi_readme.py
       - run: pip install -e ".[dev]"
+      - run: pip install "mcp>=1.0"
       - run: pytest --cov=synthadoc --cov-report=json -q
       - run: python scripts/update_badges.py --coverage-json coverage.json
       - run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "croniter>=2.0",
     "networkx>=3.0",
     "python-louvain>=0.16",
-    "mcp>=1.0",
+    "mcp>=1.0,<2.0",
 ]
 
 [project.urls]
@@ -72,7 +72,7 @@ dev = [
     "pytest-benchmark>=4.0",
     "respx>=0.21",
     "matplotlib>=3.8",
-    "mcp>=1.0",
+    "mcp>=1.0,<2.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     "pytest-benchmark>=4.0",
     "respx>=0.21",
     "matplotlib>=3.8",
+    "mcp>=1.0",
 ]
 
 [project.scripts]

--- a/scripts/update_badges.py
+++ b/scripts/update_badges.py
@@ -56,12 +56,11 @@ def count_obsidian_commands() -> int:
 
 
 def count_mcp_tools() -> int:
-    """Count MCP tools registered in create_mcp_server()."""
-    sys.path.insert(0, str(ROOT))
-    from unittest.mock import MagicMock
-    from synthadoc.integration.mcp_server import create_mcp_server
-    mcp = create_mcp_server(MagicMock())
-    return len(mcp._tool_manager.list_tools())
+    """Count MCP tools registered in mcp_server.py by counting @mcp.tool() decorators."""
+    mcp_server_py = ROOT / "synthadoc" / "integration" / "mcp_server.py"
+    if not mcp_server_py.exists():
+        return 0
+    return mcp_server_py.read_text(encoding="utf-8").count("@mcp.tool()")
 
 
 def count_skills() -> int:

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -611,9 +611,12 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
     )
 
     if enable_mcp:
-        from synthadoc.integration.mcp_server import create_mcp_server
-        _mcp = create_mcp_server(orchestrator=orch)
-        app.mount("/mcp", _mcp.sse_app())
+        try:
+            from synthadoc.integration.mcp_server import create_mcp_server
+            _mcp = create_mcp_server(orchestrator=orch)
+            app.mount("/mcp", _mcp.sse_app())
+        except ImportError:
+            pass
 
     @app.get("/", response_class=Response)
     async def index():

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -611,12 +611,9 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
     )
 
     if enable_mcp:
-        try:
-            from synthadoc.integration.mcp_server import create_mcp_server
-            _mcp = create_mcp_server(orchestrator=orch)
-            app.mount("/mcp", _mcp.sse_app())
-        except ImportError:
-            pass
+        from synthadoc.integration.mcp_server import create_mcp_server
+        _mcp = create_mcp_server(orchestrator=orch)
+        app.mount("/mcp", _mcp.sse_app())
 
     @app.get("/", response_class=Response)
     async def index():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,16 @@ import sqlite3
 import pytest
 from pathlib import Path
 
+# Detect whether the MCP package is properly installed.  Forks whose
+# pyproject.toml pre-dates the mcp dependency may have no mcp package, or an
+# old one that lacks mcp.server.fastmcp.  We detect this once at import time
+# so the autouse fixture below is zero-cost when mcp is present.
+try:
+    from mcp.server.fastmcp import FastMCP as _FastMCP  # noqa: F401
+    _MCP_AVAILABLE = True
+except ImportError:
+    _MCP_AVAILABLE = False
+
 # ProactorEventLoop (Windows IOCP) deadlocks with aiosqlite's worker thread
 # under load — observed in test_cache_read_latency_p99 and concurrent-reader
 # tests.  Force SelectorEventLoop for all async tests on Windows.
@@ -16,6 +26,25 @@ if platform.system() == "Windows":
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+@pytest.fixture(autouse=True)
+def _disable_mcp_when_unavailable(monkeypatch):
+    """Force enable_mcp=False in create_app when mcp.server.fastmcp is absent.
+
+    Non-MCP tests (HTTP API, routing, SSE, …) don't exercise the MCP mount
+    and must not fail just because the mcp package is missing or stale.
+    MCP-specific tests guard themselves with pytest.importorskip.
+    """
+    if _MCP_AVAILABLE:
+        return
+    import synthadoc.integration.http_server as _hs
+    _orig = _hs.create_app
+
+    def _patched(wiki_root, *, enable_mcp=True, **kwargs):
+        return _orig(wiki_root, enable_mcp=False, **kwargs)
+
+    monkeypatch.setattr(_hs, "create_app", _patched)
 
 
 @pytest.fixture

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-pytest.importorskip("mcp", reason="mcp package not installed")
+pytest.importorskip("mcp.server.fastmcp", reason="mcp>=1.0 (modelcontextprotocol) not installed")
 
 
 # ── Fixture ──────────────────────────────────────────────────────────────────

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -3,6 +3,8 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+pytest.importorskip("mcp", reason="mcp package not installed")
+
 
 # ── Fixture ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
issue: https://github.com/axoviq-ai/synthadoc/issues/256