### PR TITLE
fix(scheduler): write schedules.json atomically via .tmp + rename (BU…

### DIFF
--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -82,7 +82,9 @@ class Scheduler:
 
     def _save_raw(self, entries: list[dict]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        tmp.replace(self._path)
 
     def _fetch_last_runs(self) -> dict[str, dict]:
         from synthadoc.storage.log import AuditDB

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -97,3 +97,19 @@ async def test_run_scheduled_job_nonzero_exit(tmp_path):
     call = audit_db.record_scheduled_run_finish.call_args
     assert call.args[1] == "failed"
     assert "exit code 2" in call.args[3]
+
+
+def test_save_raw_is_atomic(tmp_path):
+    """_save_raw writes via a .tmp sibling then renames — no partial file on failure."""
+    sched = Scheduler(wiki="test", wiki_root=str(tmp_path))
+    sched.add("ingest", "0 2 * * *")
+
+    # The .tmp file must not be left behind after a successful write
+    tmp_file = sched._path.with_suffix(".tmp")
+    assert not tmp_file.exists()
+
+    # The target file must be valid JSON and contain the entry
+    import json
+    data = json.loads(sched._path.read_text())
+    assert len(data) == 1
+    assert data[0]["op"] == "ingest"


### PR DESCRIPTION
…G-17)

Prevents silent schedule loss if the process is killed mid-write.

issue: https://github.com/axoviq-ai/synthadoc/issues/243