### PR TITLE
fix: session skill: no warning in the log when detect_format is unknown; the parser fallbacks to Codex with no warning  

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -35,7 +35,7 @@
       "source": "axoviq-ai/synthadoc",
       "sourceType": "github",
       "skillPath": "synthadoc/skills/session/SKILL.md",
-      "computedHash": "46d944339c39e8758f99bd5106c87745e9d61a12eb25b9a1d4e1e6a9ba953fe6"
+      "computedHash": "134cff0c31614ebb6860ed59134807d6745cebd43eaccaa0ddc5b385fa22cafe"
     },
     "url": {
       "source": "axoviq-ai/synthadoc",

--- a/synthadoc/skills/session/SKILL.md
+++ b/synthadoc/skills/session/SKILL.md
@@ -72,11 +72,15 @@ modification time and the first substantive user message:
 session-2026-07-15-how-do-i-implement-a-sliding
 ```
 
+## Large sessions — chunking
+
+Sessions longer than 30 substantive turns are split into 30-turn chunks.
+Each chunk is labelled with a `## Part N of M` header so the downstream LLM
+can process sections independently. The `metadata` dict includes `chunk_total`
+when chunking occurs; single-chunk sessions (≤ 30 turns) are unchanged.
+
 ## Limitations
 
-- **No chunking in v1.1** — very long sessions are truncated at the
-  `max_source_chars` limit (default 400 000 chars). Multi-session archives
-  should be split into individual `.jsonl` files before ingesting.
 - **Tool output excluded** — tool result blocks (shell output, file reads, etc.)
   are stripped. This is intentional: it avoids leaking file contents and
   credentials into the wiki.

--- a/synthadoc/skills/session/scripts/main.py
+++ b/synthadoc/skills/session/scripts/main.py
@@ -174,6 +174,8 @@ class SessionSkill(BaseSkill):
             return ExtractedContent(text="", source_path=source, metadata={"empty": True})
 
         fmt = _detect_format(lines)
+        if fmt == "unknown":
+            logger.info("session: unrecognised format in %s — falling back to Codex parser", path.name)
         raw_turns = _parse_claude_code(lines) if fmt == "claude_code" else _parse_codex(lines)
 
         turns = [(role, text) for role, text in raw_turns if _is_substantive(role, text)]

--- a/synthadoc/skills/session/scripts/main.py
+++ b/synthadoc/skills/session/scripts/main.py
@@ -14,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 _MIN_ASSISTANT_WORDS = 20
 _MIN_USER_WORDS = 3
+_CHUNK_SIZE = 30
 _SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
 
 _CLAUDE_CODE_TYPES = frozenset(
@@ -119,6 +120,13 @@ def _parse_codex(lines: list[str]) -> list[tuple[str, str]]:
     return turns
 
 
+def _chunk_turns(
+    turns: list[tuple[str, str]], size: int
+) -> list[list[tuple[str, str]]]:
+    """Split turns into successive slices of at most *size* elements."""
+    return [turns[i : i + size] for i in range(0, len(turns), size)]
+
+
 def _make_slug(path: Path, turns: list[tuple[str, str]]) -> str:
     """Generate a suggested slug: session-YYYY-MM-DD-<topic-from-first-user-turn>."""
     try:
@@ -178,18 +186,37 @@ class SessionSkill(BaseSkill):
                 metadata={"format": fmt, "empty": True},
             )
 
-        blocks = []
-        for role, text in turns:
-            label = "[USER]" if role in ("user", "human") else "[ASSISTANT]"
-            blocks.append(f"{label}\n{text}")
-        output = "\n\n---\n\n".join(blocks)
+        chunks = _chunk_turns(turns, _CHUNK_SIZE)
+        total = len(chunks)
+
+        def _render_chunk(chunk: list[tuple[str, str]]) -> str:
+            blocks = []
+            for role, text in chunk:
+                label = "[USER]" if role in ("user", "human") else "[ASSISTANT]"
+                blocks.append(f"{label}\n{text}")
+            return "\n\n---\n\n".join(blocks)
+
+        if total == 1:
+            output = _render_chunk(chunks[0])
+            metadata: dict = {
+                "format": fmt,
+                "turn_count": len(turns),
+                "suggested_slug": _make_slug(path, turns),
+            }
+        else:
+            parts = []
+            for i, chunk in enumerate(chunks, 1):
+                parts.append(f"## Part {i} of {total}\n\n{_render_chunk(chunk)}")
+            output = "\n\n---\n\n".join(parts)
+            metadata = {
+                "format": fmt,
+                "turn_count": len(turns),
+                "chunk_total": total,
+                "suggested_slug": _make_slug(path, turns),
+            }
 
         return ExtractedContent(
             text=output,
             source_path=source,
-            metadata={
-                "format": fmt,
-                "turn_count": len(turns),
-                "suggested_slug": _make_slug(path, turns),
-            },
+            metadata=metadata,
         )

--- a/tests/skills/test_session_skill.py
+++ b/tests/skills/test_session_skill.py
@@ -536,6 +536,128 @@ async def test_extract_unknown_format_falls_back_to_codex(tmp_path):
     assert result.text != ""
 
 
+# ── Chunking ─────────────────────────────────────────────────────────────────
+
+def _make_turns(n: int) -> list[tuple[str, str]]:
+    """Generate n alternating substantive (user, assistant) turns.
+
+    Unique zero-padded markers (USR-00000, AST-00001) ensure no marker is a
+    substring of another, which makes the no-duplication assertion reliable.
+    Assistant turns use 25 filler words to stay well above _MIN_ASSISTANT_WORDS=20.
+    """
+    turns = []
+    for i in range(n):
+        if i % 2 == 0:
+            turns.append(("user", f"USR-{i:05d} user question about this specific feature"))
+        else:
+            turns.append(("assistant", f"AST-{i:05d} " + " ".join(["word"] * 25)))
+    return turns
+
+
+def _write_turns_jsonl(tmp_path: Path, turns: list[tuple[str, str]], fmt: str = "codex") -> Path:
+    """Write pre-built turns to a JSONL file."""
+    lines = []
+    for role, text in turns:
+        if fmt == "codex":
+            lines.append(_codex_line(role, text))
+        else:
+            if role == "user":
+                lines.append(_cc_user(text))
+            else:
+                lines.append(_cc_assistant([_cc_text_block(text)]))
+    return _write_jsonl(tmp_path, lines)
+
+
+def test_chunk_turns_single_chunk_when_at_limit():
+    from synthadoc.skills.session.scripts.main import _chunk_turns
+    turns = _make_turns(30)
+    chunks = _chunk_turns(turns, 30)
+    assert len(chunks) == 1
+    assert chunks[0] == turns
+
+
+def test_chunk_turns_splits_at_boundary():
+    from synthadoc.skills.session.scripts.main import _chunk_turns
+    turns = _make_turns(31)
+    chunks = _chunk_turns(turns, 30)
+    assert len(chunks) == 2
+    assert len(chunks[0]) == 30
+    assert len(chunks[1]) == 1
+
+
+def test_chunk_turns_three_even_chunks():
+    from synthadoc.skills.session.scripts.main import _chunk_turns
+    turns = _make_turns(90)
+    chunks = _chunk_turns(turns, 30)
+    assert len(chunks) == 3
+    assert all(len(c) == 30 for c in chunks)
+
+
+def test_chunk_turns_uneven_last_chunk():
+    from synthadoc.skills.session.scripts.main import _chunk_turns
+    turns = _make_turns(65)
+    chunks = _chunk_turns(turns, 30)
+    assert len(chunks) == 3
+    assert len(chunks[0]) == 30
+    assert len(chunks[1]) == 30
+    assert len(chunks[2]) == 5
+
+
+def test_chunk_turns_preserves_all_turns():
+    from synthadoc.skills.session.scripts.main import _chunk_turns
+    turns = _make_turns(75)
+    chunks = _chunk_turns(turns, 30)
+    flat = [t for chunk in chunks for t in chunk]
+    assert flat == turns
+
+
+@pytest.mark.asyncio
+async def test_extract_small_session_has_no_part_headers(tmp_path):
+    skill = _load_skill()
+    f = _write_turns_jsonl(tmp_path, _make_turns(10))
+    result = await skill.extract(str(f))
+    assert "Part" not in result.text
+    assert result.metadata.get("chunk_total", 1) == 1
+
+
+@pytest.mark.asyncio
+async def test_extract_large_session_has_part_headers(tmp_path):
+    skill = _load_skill()
+    f = _write_turns_jsonl(tmp_path, _make_turns(31))
+    result = await skill.extract(str(f))
+    assert "Part 1 of 2" in result.text
+    assert "Part 2 of 2" in result.text
+
+
+@pytest.mark.asyncio
+async def test_extract_large_session_chunk_total_in_metadata(tmp_path):
+    skill = _load_skill()
+    f = _write_turns_jsonl(tmp_path, _make_turns(61))
+    result = await skill.extract(str(f))
+    assert result.metadata["chunk_total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_extract_large_session_no_turns_dropped(tmp_path):
+    skill = _load_skill()
+    turns = _make_turns(60)
+    f = _write_turns_jsonl(tmp_path, turns)
+    result = await skill.extract(str(f))
+    for _, text in turns:
+        assert text in result.text, f"Turn missing from output: {text[:40]}"
+
+
+@pytest.mark.asyncio
+async def test_extract_large_session_no_turns_duplicated(tmp_path):
+    skill = _load_skill()
+    f = _write_turns_jsonl(tmp_path, _make_turns(40))
+    result = await skill.extract(str(f))
+    # Each unique turn marker (USR-00000, USR-00002 …) appears exactly once
+    for i in range(0, 40, 2):
+        marker = f"USR-{i:05d}"
+        assert result.text.count(marker) == 1, f"Turn {i} appears more than once"
+
+
 # ── Skill registration ────────────────────────────────────────────────────────
 
 def test_skill_detected_for_jsonl_extension():

--- a/tests/skills/test_session_skill.py
+++ b/tests/skills/test_session_skill.py
@@ -536,6 +536,24 @@ async def test_extract_unknown_format_falls_back_to_codex(tmp_path):
     assert result.text != ""
 
 
+@pytest.mark.asyncio
+async def test_extract_unknown_format_logs_info(tmp_path, caplog):
+    import logging
+    import json as _json
+    skill = _load_skill()
+    # {"speaker"/"utterance"} matches neither claude_code nor codex detection rules
+    lines = [_json.dumps({"speaker": "user", "utterance": "hello world question here"})]
+    f = _write_jsonl(tmp_path, lines)
+    with caplog.at_level(logging.INFO):
+        await skill.extract(str(f))
+    # Must be an INFO record explicitly about the unknown format — not the WARNING
+    # that mentions the file path (which happens to contain "unknown" from the test name).
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+    assert any("format" in r.message.lower() for r in info_records), (
+        f"Expected an INFO log about unknown format; got INFO records: {[r.message for r in info_records]}"
+    )
+
+
 # ── Chunking ─────────────────────────────────────────────────────────────────
 
 def _make_turns(n: int) -> list[tuple[str, str]]:


### PR DESCRIPTION
issue: https://github.com/axoviq-ai/synthadoc/issues/260