### PR TITLE
fix(json-writes): add newline="\n" to all JSON write_text calls (BUG-16)

### DIFF
--- a/synthadoc/cli/install.py
+++ b/synthadoc/cli/install.py
@@ -40,7 +40,7 @@ def resolve_wiki_path(wiki: str) -> Path:
 
 def _write_registry(data: dict) -> None:
     _REGISTRY.parent.mkdir(parents=True, exist_ok=True)
-    _REGISTRY.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    _REGISTRY.write_text(json.dumps(data, indent=2), encoding="utf-8", newline="\n")
 
 
 def _get_reserved_ports() -> set[int]:

--- a/synthadoc/cli/plugin.py
+++ b/synthadoc/cli/plugin.py
@@ -65,7 +65,7 @@ def _write_plugin_data(wiki_path: Path, plugin_dir: Path) -> None:
             pass
 
     existing["serverUrl"] = server_url
-    data_json.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+    data_json.write_text(json.dumps(existing, indent=2), encoding="utf-8", newline="\n")
 
 
 def _update_community_plugins(wiki_path: Path, *plugin_ids: str) -> None:
@@ -87,7 +87,7 @@ def _update_community_plugins(wiki_path: Path, *plugin_ids: str) -> None:
             enabled.append(pid)
             changed = True
     if changed:
-        cp_file.write_text(json.dumps(enabled, indent=2), encoding="utf-8")
+        cp_file.write_text(json.dumps(enabled, indent=2), encoding="utf-8", newline="\n")
 
 
 def _install_dataview(wiki_path: Path) -> str:
@@ -144,7 +144,7 @@ def _set_reading_view_default(wiki_path: Path) -> bool:
     config[_OBSIDIAN_APP_JSON_KEY] = _OBSIDIAN_READING_VIEW
     config["newFileLocation"] = _OBSIDIAN_NEW_FILE_LOCATION
     config["newFileFolderPath"] = _OBSIDIAN_NEW_FILE_FOLDER
-    app_json.write_text(json.dumps(config, indent=2), encoding="utf-8")
+    app_json.write_text(json.dumps(config, indent=2), encoding="utf-8", newline="\n")
     return True
 
 
@@ -190,7 +190,7 @@ def _patch_workspace_reading_view(wiki_path: Path) -> bool:
 
     _patch(workspace)
     if changed:
-        ws_json.write_text(json.dumps(workspace, indent=2), encoding="utf-8")
+        ws_json.write_text(json.dumps(workspace, indent=2), encoding="utf-8", newline="\n")
     return changed
 
 

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -62,7 +62,7 @@ def _sync_plugin_config(wiki_root: Path, host: str, port: int) -> None:
         if data.get("serverUrl") != expected_url:
             old_url = data.get("serverUrl", "(none)")
             data["serverUrl"] = expected_url
-            data_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            data_json.write_text(json.dumps(data, indent=2), encoding="utf-8", newline="\n")
             typer.echo(
                 f"Notice: plugin server URL updated {old_url!r} → {expected_url!r}.\n"
                 f"Reload Obsidian (Cmd+R / Ctrl+R) if it is already open."

--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -471,7 +471,7 @@ class Orchestrator:
                     # Atomic write: write to .tmp then replace to avoid a partial
                     # file being visible to concurrent readers on failure.
                     tmp_path = blocked_path.with_suffix(".tmp")
-                    tmp_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+                    tmp_path.write_text(json.dumps(existing, indent=2), encoding="utf-8", newline="\n")
                     tmp_path.replace(blocked_path)
             except Exception as write_err:
                 logging.getLogger(__name__).warning(

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -83,7 +83,7 @@ class Scheduler:
     def _save_raw(self, entries: list[dict]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8", newline="\n")
         tmp.replace(self._path)
 
     def _fetch_last_runs(self) -> dict[str, dict]:

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -551,15 +551,32 @@ async def test_run_scaffold_coding_tool_quota_fails_permanent(tmp_wiki):
 
 @pytest.mark.asyncio
 async def test_auto_block_domain_writes_unix_line_endings(tmp_wiki):
-    """blocked_domains.json must use LF-only line endings on all platforms (no CRLF)."""
+    """blocked_domains.json must pass newline="\\n" to write_text regardless of platform.
+
+    A binary-mode read catches the symptom on Windows; the write_text spy
+    catches a missing newline= argument on Linux/Mac where Python never
+    produces CRLF anyway (so the byte check alone would always pass there).
+    """
+    import pathlib
     from synthadoc.errors import DomainBlockedException
+
+    real_write_text = pathlib.Path.write_text
+    calls: list = []
+
+    def spy(self, data, *args, **kwargs):
+        calls.append((args, kwargs))
+        return real_write_text(self, data, *args, **kwargs)
 
     cfg = load_config()
     async with Orchestrator(wiki_root=tmp_wiki, config=cfg) as orch:
         exc = DomainBlockedException(domain="evil.com", url="https://evil.com/p", status_code=403)
-        await orch._auto_block_domain(exc)
+        with patch("pathlib.Path.write_text", spy):
+            await orch._auto_block_domain(exc)
 
     blocked_path = tmp_wiki / ".synthadoc" / "blocked_domains.json"
     assert blocked_path.exists()
-    raw = blocked_path.read_bytes()
-    assert b"\r\n" not in raw
+    # Verify newline="\n" was passed on every write_text call
+    for _, kwargs in calls:
+        assert kwargs.get("newline") == "\n", "write_text called without newline='\\n'"
+    # Also verify the on-disk bytes contain no CRLF
+    assert b"\r\n" not in blocked_path.read_bytes()

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -547,3 +547,19 @@ async def test_run_scaffold_coding_tool_quota_fails_permanent(tmp_wiki):
 
     mock_queue.fail_permanent.assert_awaited_once()
     mock_queue.fail.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_block_domain_writes_unix_line_endings(tmp_wiki):
+    """blocked_domains.json must use LF-only line endings on all platforms (no CRLF)."""
+    from synthadoc.errors import DomainBlockedException
+
+    cfg = load_config()
+    async with Orchestrator(wiki_root=tmp_wiki, config=cfg) as orch:
+        exc = DomainBlockedException(domain="evil.com", url="https://evil.com/p", status_code=403)
+        await orch._auto_block_domain(exc)
+
+    blocked_path = tmp_wiki / ".synthadoc" / "blocked_domains.json"
+    assert blocked_path.exists()
+    raw = blocked_path.read_bytes()
+    assert b"\r\n" not in raw

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -116,8 +116,28 @@ def test_save_raw_is_atomic(tmp_path):
 
 
 def test_save_raw_uses_unix_line_endings(tmp_path):
-    """schedules.json must use LF-only line endings on all platforms (no CRLF)."""
+    """_save_raw must pass newline="\\n" to write_text regardless of platform.
+
+    A binary-mode read catches the symptom on Windows; the write_text spy
+    catches a missing newline= argument on Linux/Mac where Python never
+    produces CRLF anyway (so the byte check alone would always pass there).
+    """
+    import pathlib
+    from unittest.mock import patch, call
+
+    real_write_text = pathlib.Path.write_text
+    calls: list = []
+
+    def spy(self, data, *args, **kwargs):
+        calls.append((args, kwargs))
+        return real_write_text(self, data, *args, **kwargs)
+
     sched = Scheduler(wiki="test", wiki_root=str(tmp_path))
-    sched.add("ingest", "0 2 * * *")
-    raw = sched._path.read_bytes()
-    assert b"\r\n" not in raw
+    with patch.object(pathlib.Path, "write_text", spy):
+        sched.add("ingest", "0 2 * * *")
+
+    # Verify newline="\n" was passed on every write_text call
+    for _, kwargs in calls:
+        assert kwargs.get("newline") == "\n", "write_text called without newline='\\n'"
+    # Also verify the on-disk bytes contain no CRLF
+    assert b"\r\n" not in sched._path.read_bytes()

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -113,3 +113,11 @@ def test_save_raw_is_atomic(tmp_path):
     data = json.loads(sched._path.read_text())
     assert len(data) == 1
     assert data[0]["op"] == "ingest"
+
+
+def test_save_raw_uses_unix_line_endings(tmp_path):
+    """schedules.json must use LF-only line endings on all platforms (no CRLF)."""
+    sched = Scheduler(wiki="test", wiki_root=str(tmp_path))
+    sched.add("ingest", "0 2 * * *")
+    raw = sched._path.read_bytes()
+    assert b"\r\n" not in raw


### PR DESCRIPTION
issue: https://github.com/axoviq-ai/synthadoc/issues/242

Prevents CRLF line endings in JSON files on Windows across orchestrator, scheduler, serve, plugin, and install modules.