### PR TITLE
fix: duplicate lifecycle content snapshot entries triggered from Claudecode tool through MCP integration

### DIFF
--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -1778,12 +1778,15 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
         current_content = page.content
         current_state = page.status
 
-        # Record the pre-rollback state as a new snapshot (makes rollback undoable)
+        # Record the pre-rollback state as a new snapshot (makes rollback undoable).
+        # force=True: the undo checkpoint must always be stored, even if content
+        # matches the last snapshot (e.g. rolling back to the activation snapshot).
         await audit.record_lifecycle_event(
             slug, current_state, current_state,
             f"rollback:{req.index}:{req.reason}",
             TriggerSource.USER,
             content_snapshot=current_content,
+            force=True,
         )
         rollback_event_index = 1  # always 1: newest id → index 1 (ORDER BY id DESC)
 

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -523,10 +523,11 @@ class AuditDB:
         self, slug: str, from_state: Optional[str], to_state: str,
         reason: str, triggered_by: str,
         content_snapshot: Optional[str] = None,
+        force: bool = False,
     ) -> None:
         if content_snapshot is not None:
             content_snapshot = strip_frontmatter(content_snapshot)
-            if await self._last_content_snapshot(slug) == content_snapshot:
+            if not force and await self._last_content_snapshot(slug) == content_snapshot:
                 content_snapshot = None  # suppress: same content already stored
         ts = datetime.now(timezone.utc).isoformat()
         async with aiosqlite.connect(self._path) as db:

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -509,8 +509,21 @@ class AuditDB:
     async def record_lifecycle_event(
         self, slug: str, from_state: Optional[str], to_state: str,
         reason: str, triggered_by: str,
-        content_snapshot: Optional[str] = None,   # ← new
+        content_snapshot: Optional[str] = None,
     ) -> None:
+        if content_snapshot is not None:
+            content_snapshot = strip_frontmatter(content_snapshot)
+            async with aiosqlite.connect(self._path) as db:
+                db.row_factory = aiosqlite.Row
+                async with db.execute(
+                    "SELECT content_snapshot FROM lifecycle_events"
+                    " WHERE slug = ? AND content_snapshot IS NOT NULL"
+                    " ORDER BY id DESC LIMIT 1",
+                    (slug,),
+                ) as cur:
+                    row = await cur.fetchone()
+            if row and dict(row)["content_snapshot"] == content_snapshot:
+                content_snapshot = None  # suppress: same content already stored
         ts = datetime.now(timezone.utc).isoformat()
         async with aiosqlite.connect(self._path) as db:
             await db.execute(

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -506,6 +506,19 @@ class AuditDB:
                 row = await cur.fetchone()
         return dict(row) if row else None
 
+    async def _last_content_snapshot(self, slug: str) -> Optional[str]:
+        """Return the body of the most recent content_snapshot for *slug*, or None."""
+        async with aiosqlite.connect(self._path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT content_snapshot FROM lifecycle_events"
+                " WHERE slug = ? AND content_snapshot IS NOT NULL"
+                " ORDER BY id DESC LIMIT 1",
+                (slug,),
+            ) as cur:
+                row = await cur.fetchone()
+        return dict(row)["content_snapshot"] if row else None
+
     async def record_lifecycle_event(
         self, slug: str, from_state: Optional[str], to_state: str,
         reason: str, triggered_by: str,
@@ -513,16 +526,7 @@ class AuditDB:
     ) -> None:
         if content_snapshot is not None:
             content_snapshot = strip_frontmatter(content_snapshot)
-            async with aiosqlite.connect(self._path) as db:
-                db.row_factory = aiosqlite.Row
-                async with db.execute(
-                    "SELECT content_snapshot FROM lifecycle_events"
-                    " WHERE slug = ? AND content_snapshot IS NOT NULL"
-                    " ORDER BY id DESC LIMIT 1",
-                    (slug,),
-                ) as cur:
-                    row = await cur.fetchone()
-            if row and dict(row)["content_snapshot"] == content_snapshot:
+            if await self._last_content_snapshot(slug) == content_snapshot:
                 content_snapshot = None  # suppress: same content already stored
         ts = datetime.now(timezone.utc).isoformat()
         async with aiosqlite.connect(self._path) as db:
@@ -649,17 +653,7 @@ class AuditDB:
         need to normalise it themselves.
         """
         content = strip_frontmatter(content)
-        async with aiosqlite.connect(self._path) as db:
-            db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT content_snapshot FROM lifecycle_events"
-                " WHERE slug = ? AND content_snapshot IS NOT NULL"
-                " ORDER BY id DESC LIMIT 1",
-                (slug,),
-            ) as cur:
-                row = await cur.fetchone()
-        last = dict(row)["content_snapshot"] if row else None
-        if last == content:
+        if await self._last_content_snapshot(slug) == content:
             return False
         state_row = await self.get_page_state(slug)
         current_state = state_row["state"] if state_row else "draft"

--- a/tests/integration/test_lifecycle_snapshots.py
+++ b/tests/integration/test_lifecycle_snapshots.py
@@ -835,6 +835,31 @@ async def test_record_lifecycle_event_stores_different_content(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_record_lifecycle_event_force_bypasses_dedup(tmp_path: Path):
+    """force=True always stores content_snapshot even when content equals the last snapshot.
+
+    The rollback endpoint uses this to guarantee the pre-rollback undo checkpoint is
+    recorded even when the current page content matches the most recent snapshot.
+    """
+    audit = AuditDB(tmp_path / "audit.db")
+    await audit.init()
+
+    body = "Content that would normally be deduplicated."
+    await audit.record_lifecycle_event(
+        "p", "draft", "active", "activate", "user", content_snapshot=body
+    )
+    # Second call with the same content but force=True — must NOT be suppressed
+    await audit.record_lifecycle_event(
+        "p", "active", "active", "rollback:1:undo", "user",
+        content_snapshot=body, force=True,
+    )
+
+    snaps = await audit.list_page_snapshots("p")
+    assert len(snaps) == 2, "force=True must bypass dedup and record the snapshot"
+    assert snaps[0]["content_length"] > 0
+
+
+@pytest.mark.asyncio
 async def test_record_lifecycle_event_dedup_strips_frontmatter(tmp_path: Path):
     """Dedup compares body-only; passing raw .md content does not bypass it."""
     audit = AuditDB(tmp_path / "audit.db")

--- a/tests/integration/test_lifecycle_snapshots.py
+++ b/tests/integration/test_lifecycle_snapshots.py
@@ -779,6 +779,83 @@ def test_snapshot_endpoint_rejects_system_page_slugs(tmp_wiki):
         assert data["recorded"] is False, f"Expected recorded=false for slug={system_slug!r}"
 
 
+# ── record_lifecycle_event dedup tests ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_record_lifecycle_event_suppresses_duplicate_content_snapshot(tmp_path: Path):
+    """When content_snapshot is identical to the last stored snapshot, the second
+    record_lifecycle_event call stores the lifecycle metadata but NULL for content.
+
+    This prevents lifecycle transitions (e.g., state changes) from duplicating
+    content that was already captured by snapshot_if_changed or a prior call.
+    """
+    audit = AuditDB(tmp_path / "audit.db")
+    await audit.init()
+
+    body = "Content that must not be duplicated."
+    await audit.record_lifecycle_event(
+        "p", "draft", "active", "first write", "mcp", content_snapshot=body
+    )
+    await audit.record_lifecycle_event(
+        "p", "active", "active", "lifecycle transition with same content", "mcp",
+        content_snapshot=body,
+    )
+
+    # Only one content snapshot — second call should have stored NULL
+    snaps = await audit.list_page_snapshots("p")
+    assert len(snaps) == 1
+
+    # Both lifecycle events ARE in the audit log (event is still recorded)
+    async with aiosqlite.connect(tmp_path / "audit.db") as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute("SELECT id, content_snapshot FROM lifecycle_events WHERE slug='p'") as cur:
+            rows = await cur.fetchall()
+    assert len(rows) == 2
+    assert rows[0]["content_snapshot"] == body
+    assert rows[1]["content_snapshot"] is None
+
+
+@pytest.mark.asyncio
+async def test_record_lifecycle_event_stores_different_content(tmp_path: Path):
+    """record_lifecycle_event stores content_snapshot when content has changed."""
+    audit = AuditDB(tmp_path / "audit.db")
+    await audit.init()
+
+    await audit.record_lifecycle_event(
+        "p", "draft", "active", "v1", "user", content_snapshot="body v1"
+    )
+    await audit.record_lifecycle_event(
+        "p", "active", "stale", "v2", "user", content_snapshot="body v2"
+    )
+
+    snaps = await audit.list_page_snapshots("p")
+    assert len(snaps) == 2
+    assert snaps[0]["to_state"] == "stale"   # newest first
+    assert snaps[1]["to_state"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_record_lifecycle_event_dedup_strips_frontmatter(tmp_path: Path):
+    """Dedup compares body-only; passing raw .md content does not bypass it."""
+    audit = AuditDB(tmp_path / "audit.db")
+    await audit.init()
+
+    body = "The real body content."
+    raw = f"---\ntitle: T\nstatus: active\n---\n\n{body}"
+
+    # First call: store body-only
+    await audit.record_lifecycle_event(
+        "p", "draft", "active", "r1", "user", content_snapshot=body
+    )
+    # Second call: same body wrapped in frontmatter — should be suppressed
+    await audit.record_lifecycle_event(
+        "p", "active", "active", "r2", "mcp", content_snapshot=raw
+    )
+
+    snaps = await audit.list_page_snapshots("p")
+    assert len(snaps) == 1, "raw .md wrapper must not bypass content dedup"
+
+
 # ── Lint snapshot tests ──────────────────────────────────────────────────────
 
 def test_lint_transition_captures_snapshot(tmp_wiki):

--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -121,12 +121,51 @@ async def run_tests():
             # ── 1. synthadoc_status ─────────────────────────────────────────
             print("\n[1] synthadoc_status")
             r = await call(session, "synthadoc_status")
-            if "pages" in r and "wiki" in r:
-                ok("synthadoc_status", f"wiki={r['wiki']!r}  pages={r['pages']}")
-                wiki_pages = r["pages"]
-            else:
-                fail("synthadoc_status", f"unexpected response: {r}")
+            required_keys = {"wiki", "pages", "jobs_pending", "jobs_total", "lifecycle"}
+            missing_keys = required_keys - set(r.keys())
+            if missing_keys:
+                fail("synthadoc_status", f"missing keys: {missing_keys}  got: {list(r.keys())}")
                 wiki_pages = 0
+            else:
+                lc = r["lifecycle"]
+                lc_keys = {"active", "draft", "stale", "contradicted", "archived"}
+                missing_lc = lc_keys - set(lc.keys())
+                lc_sum = sum(lc.get(s, 0) for s in lc_keys) + lc.get("unlinted", 0)
+                ok("synthadoc_status",
+                   f"wiki={r['wiki']!r}  pages={r['pages']}  "
+                   f"jobs_pending={r['jobs_pending']}  jobs_total={r['jobs_total']}  "
+                   f"lifecycle={lc}")
+                wiki_pages = r["pages"]
+                if missing_lc:
+                    fail("synthadoc_status(lifecycle keys)", f"missing lifecycle keys: {missing_lc}")
+                else:
+                    ok("synthadoc_status(lifecycle keys)", "all 5 lifecycle states present")
+                if lc_sum != wiki_pages:
+                    fail("synthadoc_status(lifecycle sum)",
+                         f"lifecycle counts sum to {lc_sum} but pages={wiki_pages} "
+                         f"(diff={wiki_pages - lc_sum})")
+                else:
+                    ok("synthadoc_status(lifecycle sum)", f"counts sum correctly to {wiki_pages}")
+                # Cross-check against HTTP /status endpoint
+                try:
+                    with urllib.request.urlopen(f"{_HTTP_BASE}/status", timeout=5) as resp:
+                        http_status = json.loads(resp.read().decode())
+                    http_pages = http_status.get("pages")
+                    if http_pages == wiki_pages:
+                        ok("synthadoc_status(page count vs HTTP /status)",
+                           f"MCP and HTTP agree: {wiki_pages} pages")
+                    else:
+                        fail("synthadoc_status(page count vs HTTP /status)",
+                             f"MCP says {wiki_pages} but HTTP /status says {http_pages}")
+                    http_pending = http_status.get("jobs_pending")
+                    if http_pending == r["jobs_pending"]:
+                        ok("synthadoc_status(jobs_pending vs HTTP /status)",
+                           f"MCP and HTTP agree: {r['jobs_pending']} pending")
+                    else:
+                        fail("synthadoc_status(jobs_pending vs HTTP /status)",
+                             f"MCP={r['jobs_pending']} vs HTTP={http_pending}")
+                except Exception as exc:
+                    warn("synthadoc_status(HTTP cross-check)", f"could not reach HTTP /status: {exc}")
 
             # ── 2. synthadoc_list_pages (all) ───────────────────────────────
             print("\n[2] synthadoc_list_pages — all")
@@ -310,19 +349,30 @@ async def run_tests():
                 # write modified content
                 test_content = original_content + "\n\n<!-- MCP live test marker -->"
                 r = await call(session, "synthadoc_write_page",
-                               {"slug": first_slug, "content": test_content})
+                               {"slug": first_slug, "content": test_content,
+                                "reason": "MCP live test — adding marker"})
                 if r.get("slug") == first_slug and "status" in r:
                     ok("synthadoc_write_page(update content)", f"slug={first_slug!r}  status={r['status']!r}")
+                    # snapshot_recorded must be present and True (content changed)
+                    if r.get("snapshot_recorded") is True:
+                        ok("synthadoc_write_page(snapshot_recorded)", "snapshot recorded for content change")
+                    elif r.get("snapshot_recorded") is False:
+                        warn("synthadoc_write_page(snapshot_recorded)",
+                             "snapshot_recorded=False — content may be identical to last snapshot")
+                    else:
+                        fail("synthadoc_write_page(snapshot_recorded)",
+                             f"snapshot_recorded field missing or unexpected: {r.get('snapshot_recorded')!r}")
                     # verify the write took effect
                     verify = await call(session, "synthadoc_read_page", {"slug": first_slug})
                     if "<!-- MCP live test marker -->" in verify.get("content", ""):
                         ok("synthadoc_write_page(verify read-back)", "content change confirmed by read_page")
                     else:
                         fail("synthadoc_write_page(verify read-back)", "content not updated in storage")
-                    # restore original
-                    await call(session, "synthadoc_write_page",
-                               {"slug": first_slug, "content": original_content, "title": original_title})
-                    info(f"Restored {first_slug!r} to original content")
+                    # restore original — snapshot_recorded should be True again
+                    restore_r = await call(session, "synthadoc_write_page",
+                               {"slug": first_slug, "content": original_content, "title": original_title,
+                                "reason": "MCP live test — restore original"})
+                    info(f"Restored {first_slug!r} to original content  snapshot_recorded={restore_r.get('snapshot_recorded')}")
                 else:
                     fail("synthadoc_write_page(update content)", str(r))
 

--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -23,6 +23,7 @@ MCP_URL defaults to http://127.0.0.1:7070/mcp/sse if the env var is not set.
 import asyncio
 import json
 import os
+import shutil
 import sys
 import time
 import urllib.error
@@ -472,11 +473,17 @@ async def run_tests():
             else:
                 fail("synthadoc_export(json inline)", f"unexpected: {r}")
 
-            # okf — writes to disk (default path)
+            # okf — writes to disk (default path); cleaned up afterwards
             r = await call(session, "synthadoc_export",
                            {"format": "okf", "status_filter": "active"})
             if r.get("format") == "okf" and "output_path" in r and "files_written" in r:
-                ok("synthadoc_export(okf to disk)", f"files_written={r['files_written']}  path={r['output_path']!r}")
+                okf_path = r["output_path"]
+                ok("synthadoc_export(okf to disk)", f"files_written={r['files_written']}  path={okf_path!r}")
+                try:
+                    shutil.rmtree(okf_path)
+                    info(f"Cleaned up OKF export directory: {okf_path!r}")
+                except Exception as exc:
+                    warn("synthadoc_export(okf cleanup)", f"could not remove {okf_path!r}: {exc}")
             elif "error" in r:
                 fail("synthadoc_export(okf to disk)", r["error"])
             else:
@@ -555,6 +562,9 @@ async def run_tests():
 
             # ── 14. synthadoc_ingest ─────────────────────────────────────────
             print("\n[14] synthadoc_ingest")
+            # Snapshot slug set before ingest so we can diff and archive new pages.
+            _pre_ingest = {p["slug"] for p in (await call(session, "synthadoc_list_pages", {"status": "all"})).get("pages", [])}
+
             # ingest a direct, stable Wikipedia URL — avoids third-party timeouts
             # that plagued the old "search for: Harvard Mark I" search-intent form
             # (search results returned unreliable domains like devx.com that timed out)
@@ -566,6 +576,20 @@ async def run_tests():
                 _done = await _wait_all_terminal(r["job_id"])
                 if _done:
                     info("Ingest job reached terminal state")
+                    # Archive any pages that didn't exist before the ingest.
+                    _post_ingest = {p["slug"] for p in (await call(session, "synthadoc_list_pages", {"status": "all"})).get("pages", [])}
+                    new_slugs = _post_ingest - _pre_ingest
+                    if new_slugs:
+                        for ns in new_slugs:
+                            arc = await call(session, "synthadoc_lifecycle",
+                                             {"slug": ns, "to_state": "archived",
+                                              "reason": "live test cleanup"})
+                            if arc.get("to_state") == "archived" or "already in state" in arc.get("error", ""):
+                                info(f"Archived ingest test page {ns!r}")
+                            else:
+                                warn("synthadoc_ingest(cleanup)", f"could not archive {ns!r}: {arc}")
+                    else:
+                        info("Ingest updated an existing page — no new slug to archive")
                 else:
                     warn("synthadoc_ingest(url)",
                          "Job still running after 3 min — check the Jobs panel")

--- a/tests/live/live_mcp_test.py
+++ b/tests/live/live_mcp_test.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
 """
-Live MCP integration test — exercises all 12 MCP tools against a running server.
+Live MCP integration test — exercises all MCP tools against a running server.
 
 Prerequisites:
     synthadoc serve -w history-of-computing   # starts HTTP + MCP on port 7070
@@ -489,8 +489,72 @@ async def run_tests():
             else:
                 fail("synthadoc_export(invalid format)", f"expected 'unknown format' error, got: {r}")
 
-            # ── 13. synthadoc_ingest ─────────────────────────────────────────
-            print("\n[13] synthadoc_ingest")
+            # ── 13. duplicate-snapshot dedup ────────────────────────────────
+            # Validates the fix for: synthadoc_lifecycle after synthadoc_write_page
+            # must NOT create a second content snapshot for the same content.
+            # snapshot count for active_slug via HTTP /pages/{slug}/history
+            print("\n[13] duplicate-snapshot dedup: write_page then lifecycle")
+            if active_slug:
+                def _snap_count(slug: str) -> int | None:
+                    try:
+                        url = f"{_HTTP_BASE}/pages/{slug}/history"
+                        with urllib.request.urlopen(url, timeout=5) as resp:
+                            return len(json.loads(resp.read().decode()).get("snapshots", []))
+                    except Exception:
+                        return None
+
+                before = _snap_count(active_slug)
+                if before is None:
+                    warn("dedup(snapshot count before)", "could not reach HTTP /pages/.../history — skipping")
+                else:
+                    # Read the current page so we can restore it afterwards
+                    orig_page = await call(session, "synthadoc_read_page", {"slug": active_slug})
+                    orig_content = orig_page.get("content", "")
+                    orig_title   = orig_page.get("title", "")
+
+                    # 1. Write new content — should produce exactly 1 new snapshot
+                    new_content = orig_content + "\n\n<!-- dedup-test-marker -->"
+                    wr = await call(session, "synthadoc_write_page",
+                                    {"slug": active_slug, "content": new_content,
+                                     "reason": "dedup test — write step"})
+                    if wr.get("snapshot_recorded") is not True:
+                        fail("dedup(write_page snapshot)", f"expected snapshot_recorded=True, got {wr}")
+                    else:
+                        ok("dedup(write_page snapshot)", "write_page recorded snapshot as expected")
+
+                    # 2. Lifecycle transition with the SAME content — must NOT add a second snapshot
+                    lc = await call(session, "synthadoc_lifecycle",
+                                    {"slug": active_slug, "to_state": "stale",
+                                     "reason": "dedup test — lifecycle after write"})
+                    if "to_state" not in lc or lc.get("to_state") != "stale":
+                        fail("dedup(lifecycle transition)", f"lifecycle call failed: {lc}")
+                    else:
+                        ok("dedup(lifecycle transition)", "active→stale succeeded")
+
+                    # 3. Verify snapshot count increased by exactly 1
+                    after = _snap_count(active_slug)
+                    if after is None:
+                        warn("dedup(snapshot count after)", "could not reach HTTP /pages/.../history")
+                    elif after == before + 1:
+                        ok("dedup(no duplicate)", f"snapshot count before={before} after={after} — exactly 1 new snapshot, no duplicate")
+                    elif after == before + 2:
+                        fail("dedup(no duplicate)", f"snapshot count before={before} after={after} — DUPLICATE: both write_page and lifecycle created a snapshot")
+                    else:
+                        warn("dedup(no duplicate)", f"snapshot count before={before} after={after} — unexpected delta={after - before}")
+
+                    # 4. Restore: transition back to active, then restore original content
+                    await call(session, "synthadoc_lifecycle",
+                               {"slug": active_slug, "to_state": "active",
+                                "reason": "dedup test — restore state"})
+                    await call(session, "synthadoc_write_page",
+                               {"slug": active_slug, "content": orig_content, "title": orig_title,
+                                "reason": "dedup test — restore content"})
+                    info(f"Restored {active_slug!r} to original content and state")
+            else:
+                warn("dedup", "skipped — no active page available")
+
+            # ── 14. synthadoc_ingest ─────────────────────────────────────────
+            print("\n[14] synthadoc_ingest")
             # ingest a direct, stable Wikipedia URL — avoids third-party timeouts
             # that plagued the old "search for: Harvard Mark I" search-intent form
             # (search results returned unreliable domains like devx.com that timed out)


### PR DESCRIPTION
Record_lifecycle_event always stored content_snapshot=page.content without any dedup check. When Claude Code called synthadoc_write_page (→ snapshot_if_changed → snapshot A) and then synthadoc_lifecycle (→ record_lifecycle_event(content_snapshot=same_content) → snapshot B), both appeared in the Content Snapshots tab with identical content and near-identical timestamps.

Fix (synthadoc/storage/log.py): Before inserting, record_lifecycle_event now strips frontmatter from the incoming content_snapshot and fetches the last stored snapshot for that slug. If the content is identical, it sets content_snapshot = None - the lifecycle event (from_state, to_state, reason, triggered_by) is still written to the audit log, but no duplicate content block is stored.

The Obsidian vault monitor was already handled correctly, it routes through snapshot_if_changed which has its own dedup check, and the session-based monitor waits for a leaf-change or 10-minute idle before sending (well after any MCP write has committed).