### PR TITLE
fix(file-io): add newline="\n" to all missed write_text calls

### DIFF
--- a/synthadoc/agents/ingest_agent.py
+++ b/synthadoc/agents/ingest_agent.py
@@ -538,10 +538,10 @@ class IngestAgent:
         extracted_dir = self._wiki_root / ".synthadoc" / "extracted"
         extracted_dir.mkdir(parents=True, exist_ok=True)
         name = Path(source_path).stem
-        (extracted_dir / f"{name}.txt").write_text(text, encoding="utf-8")
+        (extracted_dir / f"{name}.txt").write_text(text, encoding="utf-8", newline="\n")
         if pagemap:
             (extracted_dir / f"{name}.pdf.pagemap").write_text(
-                json.dumps(pagemap, indent=2), encoding="utf-8"
+                json.dumps(pagemap, indent=2), encoding="utf-8", newline="\n"
             )
 
     async def _annotate_citations(

--- a/synthadoc/cli/candidates.py
+++ b/synthadoc/cli/candidates.py
@@ -96,7 +96,7 @@ def _patch_toml(path: Path, section: str, updates: dict) -> None:
         for k, v in updates.items():
             result.append(f"{k} = {_toml_value(v)}")
 
-    path.write_text("\n".join(result) + "\n", encoding="utf-8")
+    path.write_text("\n".join(result) + "\n", encoding="utf-8", newline="\n")
 
 
 @staging_app.command("policy")
@@ -185,10 +185,10 @@ def _add_to_index(wiki_dir: Path, entries: list[tuple[str, str]]) -> None:
                 insert_at = i + 1
         for j, entry in enumerate(new_lines):
             lines.insert(insert_at + j, entry)
-        index_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        index_path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
     else:
         section = "\n\n## Recently Added\n" + "\n".join(new_lines) + "\n"
-        index_path.write_text(text.rstrip() + section, encoding="utf-8")
+        index_path.write_text(text.rstrip() + section, encoding="utf-8", newline="\n")
 
 
 @candidates_app.command("promote")

--- a/synthadoc/core/routing.py
+++ b/synthadoc/core/routing.py
@@ -97,4 +97,4 @@ class RoutingIndex:
             for slug in slugs:
                 lines.append(f"- [[{slug}]]")
             lines.append("")
-        path.write_text("\n".join(lines), encoding="utf-8")
+        path.write_text("\n".join(lines), encoding="utf-8", newline="\n")

--- a/synthadoc/storage/wiki.py
+++ b/synthadoc/storage/wiki.py
@@ -200,7 +200,7 @@ class WikiStorage:
         yaml_str = yaml.dump(fm, default_flow_style=False, allow_unicode=True)
         text = f"---\n{yaml_str}---\n\n{body}"
         target = self._page_path(slug)
-        target.write_text(text, encoding="utf-8")
+        target.write_text(text, encoding="utf-8", newline="\n")
 
     def read_page(self, slug: str) -> Optional[WikiPage]:
         target = self._page_path(slug)
@@ -276,7 +276,7 @@ class WikiStorage:
             raw = raw.rstrip() + f"\n{entry}\n"
         else:
             raw = raw.rstrip() + f"\n\n## Recently Added\n{entry}\n"
-        index_path.write_text(raw, encoding="utf-8")
+        index_path.write_text(raw, encoding="utf-8", newline="\n")
         # Stamp the page itself so it's queryable by category
         self._add_category(slug, "Recently Added")
 

--- a/tests/storage/test_wiki.py
+++ b/tests/storage/test_wiki.py
@@ -340,3 +340,60 @@ def test_read_page_with_malformed_yaml_frontmatter(tmp_wiki):
     assert loaded is not None
     assert isinstance(loaded, WikiPage)
     assert "some body" in loaded.content
+
+
+# ---------------------------------------------------------------------------
+# BUG-23 — write_page and append_to_index must use newline="\n" (no CRLF)
+# ---------------------------------------------------------------------------
+
+def test_write_page_uses_unix_line_endings(tmp_wiki):
+    """BUG-23: write_page must pass newline="\\n" so no CRLF on Windows."""
+    import pathlib
+    from unittest.mock import patch
+
+    store = WikiStorage(tmp_wiki / "wiki")
+    (tmp_wiki / "wiki").mkdir(parents=True, exist_ok=True)
+    page = WikiPage(title="T", tags=[], content="body", status="draft",
+                    confidence="medium", sources=[])
+
+    real_write_text = pathlib.Path.write_text
+    calls: list = []
+
+    def spy(self, data, *args, **kwargs):
+        calls.append(kwargs)
+        return real_write_text(self, data, *args, **kwargs)
+
+    with patch.object(pathlib.Path, "write_text", spy):
+        store.write_page("test-newline", page)
+
+    assert calls, "write_text was never called"
+    for kwargs in calls:
+        assert kwargs.get("newline") == "\n", "write_text called without newline='\\n'"
+    assert b"\r\n" not in (tmp_wiki / "wiki" / "test-newline.md").read_bytes()
+
+
+def test_append_to_index_uses_unix_line_endings(tmp_wiki):
+    """BUG-23: append_to_index must pass newline="\\n" so no CRLF on Windows."""
+    import pathlib
+    from unittest.mock import patch
+
+    wiki_dir = tmp_wiki / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    index = wiki_dir / "index.md"
+    index.write_text("# Index\n\n## Recently Added\n", encoding="utf-8")
+
+    store = WikiStorage(wiki_dir)
+    real_write_text = pathlib.Path.write_text
+    calls: list = []
+
+    def spy(self, data, *args, **kwargs):
+        calls.append(kwargs)
+        return real_write_text(self, data, *args, **kwargs)
+
+    with patch.object(pathlib.Path, "write_text", spy):
+        store.append_to_index("new-page", "New Page")
+
+    assert calls, "write_text was never called"
+    for kwargs in calls:
+        assert kwargs.get("newline") == "\n", "write_text called without newline='\\n'"
+    assert b"\r\n" not in index.read_bytes()


### PR DESCRIPTION
This bug fixed CRLF in JSON-writing modules but missed Markdown/TOML writers:
- WikiStorage.write_page (wiki.py:203)
- WikiStorage.append_to_index (wiki.py:279)
- candidates._patch_toml (candidates.py:99)
- candidates._add_to_index (candidates.py:188, 191)
- RoutingIndex.save (routing.py:100)
- ingest_agent extracted .txt and .pdf.pagemap (ingest_agent.py:541, 543)

On Windows, Python's default text mode translates \n to \r\n, corrupting YAML frontmatter and breaking YAML parsers. All seven sites now pass newline="\n".