### PR TITLE
fix(file-io): make WikiStorage.write_page atomic via shared atomic_wr…

### DIFF
--- a/synthadoc/core/orchestrator.py
+++ b/synthadoc/core/orchestrator.py
@@ -9,6 +9,7 @@ from typing import Optional
 import logging
 
 from synthadoc.config import Config, load_config
+from synthadoc.utils import atomic_write_text
 from synthadoc.errors import DomainBlockedException
 from synthadoc.core.cache import CacheManager
 from synthadoc.core.cost_guard import CostGuard, CostEstimate, CostGateError
@@ -468,11 +469,7 @@ class Orchestrator:
                     if blocked_path.exists() else []
                 if exc.domain not in existing:
                     existing.append(exc.domain)
-                    # Atomic write: write to .tmp then replace to avoid a partial
-                    # file being visible to concurrent readers on failure.
-                    tmp_path = blocked_path.with_suffix(".tmp")
-                    tmp_path.write_text(json.dumps(existing, indent=2), encoding="utf-8", newline="\n")
-                    tmp_path.replace(blocked_path)
+                    atomic_write_text(blocked_path, json.dumps(existing, indent=2))
             except Exception as write_err:
                 logging.getLogger(__name__).warning(
                     "Could not persist blocked domain %s: %s", exc.domain, write_err

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -14,6 +14,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from synthadoc.utils import atomic_write_text
+
 if TYPE_CHECKING:
     from synthadoc.storage.log import AuditDB
 
@@ -82,9 +84,7 @@ class Scheduler:
 
     def _save_raw(self, entries: list[dict]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8", newline="\n")
-        tmp.replace(self._path)
+        atomic_write_text(self._path, json.dumps(entries, indent=2))
 
     def _fetch_last_runs(self) -> dict[str, dict]:
         from synthadoc.storage.log import AuditDB

--- a/synthadoc/storage/wiki.py
+++ b/synthadoc/storage/wiki.py
@@ -11,6 +11,8 @@ from typing import Optional
 import yaml
 from filelock import FileLock
 
+from synthadoc.utils import atomic_write_text
+
 _FRONTMATTER_FIELDS = ("title", "tags", "status", "confidence", "created", "updated", "sources", "orphan",
                        "categories", "aliases", "contradiction_note", "unresolved_note", "lint_warnings",
                        "type", "resource")
@@ -200,7 +202,7 @@ class WikiStorage:
         yaml_str = yaml.dump(fm, default_flow_style=False, allow_unicode=True)
         text = f"---\n{yaml_str}---\n\n{body}"
         target = self._page_path(slug)
-        target.write_text(text, encoding="utf-8", newline="\n")
+        atomic_write_text(target, text)
 
     def read_page(self, slug: str) -> Optional[WikiPage]:
         target = self._page_path(slug)

--- a/synthadoc/utils.py
+++ b/synthadoc/utils.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Paul Chen / axoviq.com
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def atomic_write_text(
+    path: Path,
+    text: str,
+    encoding: str = "utf-8",
+    newline: str = "\n",
+) -> None:
+    """Write *text* to *path* atomically via a .tmp sibling then os.replace().
+
+    os.replace() is atomic on POSIX and on Windows (Vista+/Python 3.3+), so
+    readers never see a partial file. The .tmp sibling lives in the same
+    directory as the target, guaranteeing the rename stays on one filesystem.
+    """
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(text, encoding=encoding, newline=newline)
+    os.replace(tmp, path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Paul Chen / axoviq.com
+"""Tests for synthadoc.utils shared utilities."""
+import pathlib
+from unittest.mock import patch
+
+from synthadoc.utils import atomic_write_text
+
+
+def test_atomic_write_text_creates_file(tmp_path):
+    target = tmp_path / "out.txt"
+    atomic_write_text(target, "hello\nworld\n")
+    assert target.read_text(encoding="utf-8") == "hello\nworld\n"
+
+
+def test_atomic_write_text_no_crlf(tmp_path):
+    target = tmp_path / "out.md"
+    atomic_write_text(target, "line one\nline two\n")
+    assert b"\r\n" not in target.read_bytes()
+
+
+def test_atomic_write_text_no_tmp_left_behind(tmp_path):
+    target = tmp_path / "out.json"
+    atomic_write_text(target, "{}")
+    assert not (tmp_path / "out.tmp").exists()
+
+
+def test_atomic_write_text_overwrites_existing(tmp_path):
+    target = tmp_path / "page.md"
+    target.write_text("old content", encoding="utf-8")
+    atomic_write_text(target, "new content")
+    assert target.read_text(encoding="utf-8") == "new content"
+
+
+def test_atomic_write_text_uses_unix_line_endings_via_spy(tmp_path):
+    """Spy confirms newline='\\n' is passed even on platforms where it matters."""
+    target = tmp_path / "page.md"
+    real_write_text = pathlib.Path.write_text
+    calls: list = []
+
+    def spy(self, data, *args, **kwargs):
+        calls.append(kwargs)
+        return real_write_text(self, data, *args, **kwargs)
+
+    with patch.object(pathlib.Path, "write_text", spy):
+        atomic_write_text(target, "body\n")
+
+    assert calls
+    for kwargs in calls:
+        assert kwargs.get("newline") == "\n"
+
+
+# ---------------------------------------------------------------------------
+# BUG-24 — WikiStorage.write_page must be atomic
+# ---------------------------------------------------------------------------
+
+def test_write_page_is_atomic(tmp_wiki):
+    """BUG-24: write_page must write via a .tmp sibling then os.replace().
+
+    No .tmp file should remain, and the target must never be partially written.
+    We verify atomicity by confirming the .tmp file is absent after the call
+    and that the on-disk content matches exactly what was written.
+    """
+    from synthadoc.storage.wiki import WikiStorage, WikiPage
+
+    wiki_dir = tmp_wiki / "wiki"
+    wiki_dir.mkdir(parents=True, exist_ok=True)
+    store = WikiStorage(wiki_dir)
+    page = WikiPage(title="Atomic", tags=[], content="body text",
+                    status="draft", confidence="medium", sources=[])
+
+    store.write_page("atomic-page", page)
+
+    target = wiki_dir / "atomic-page.md"
+    tmp = wiki_dir / "atomic-page.tmp"
+
+    assert target.exists(), "page file must exist after write"
+    assert not tmp.exists(), ".tmp file must not be left behind"
+    assert "body text" in target.read_text(encoding="utf-8")
+    assert b"\r\n" not in target.read_bytes()


### PR DESCRIPTION
…ite_text 

Introduce synthadoc/utils.py with atomic_write_text(path, text) which writes to a .tmp sibling then calls os.replace() — atomic on POSIX and Windows Vista+. Migrate all three existing atomic-write sites to use it:
- WikiStorage.write_page (storage/wiki.py) — the BUG fix
- Scheduler._save_raw (core/scheduler.py) — was already doing .tmp+replace inline
- Orchestrator._auto_block_domain (core/orchestrator.py) — same pattern inline

Removes the duplicated .tmp/replace boilerplate in scheduler and orchestrator and ensures all future callers get newline="\n" and os.replace() consistency for free.


issue: https://github.com/axoviq-ai/synthadoc/issues/279