### PR TITLE
refactor: consolidate system slug lists to SYSTEM_PAGE_SLUGS

### DIFF
--- a/synthadoc/agents/scaffold_agent.py
+++ b/synthadoc/agents/scaffold_agent.py
@@ -11,12 +11,13 @@ from typing import Optional
 
 from synthadoc.providers.base import LLMProvider, Message
 from synthadoc.cli._init import _AGENT_INSTRUCTION_BODY
+from synthadoc.storage.wiki import SYSTEM_PAGE_SLUGS
 
 logger = logging.getLogger(__name__)
 
 SCAFFOLD_MARKER = "<!-- synthadoc:scaffold -->"
 _SCAFFOLD_RETRY_LIMIT = 3
-_META_SLUGS = frozenset({"index", "overview", "purpose", "dashboard", "log"})
+_META_SLUGS = SYSTEM_PAGE_SLUGS
 
 _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
 _FM_STRIP_RE = re.compile(r"^---\s*\n.*?\n---\s*\n+", re.DOTALL)

--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException, Request, Response
 from synthadoc.core.queue import JobStatus
+from synthadoc.storage.wiki import SYSTEM_PAGE_SLUGS
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator, model_validator
 from typing import Optional
@@ -583,8 +584,7 @@ _graph_task: "asyncio.Task[None] | None" = None  # retained reference prevents G
 # (index, dashboard, overview, purpose, log) never appear in the
 # Current States, Audit Log, or Content Snapshots tabs — regardless of
 # what historical records the audit DB contains.
-_SCAFFOLD_SLUG_LOWER: frozenset[str] = frozenset({
-    "index", "log", "dashboard", "purpose", "overview",  # wiki/ scaffold (LINT_SKIP_SLUGS)
+_SCAFFOLD_SLUG_LOWER: frozenset[str] = SYSTEM_PAGE_SLUGS | frozenset({
     "agents", "claude", "gemini", "routing", "readme",   # vault-root config files
 })
 


### PR DESCRIPTION
scaffold_agent.py had an independent _META_SLUGS copy; http_server.py had the same five slugs hardcoded inside _SCAFFOLD_SLUG_LOWER. Both now derive from the canonical SYSTEM_PAGE_SLUGS in storage/wiki.py so any future slug addition only needs one edit.