### PR TITLE
fix: /provenance/citations fetches up to 100 000 rows to compute total 

### DIFF
--- a/synthadoc/integration/http_server.py
+++ b/synthadoc/integration/http_server.py
@@ -1573,9 +1573,13 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
     ):
         audit = app.state.orch._audit
         if broken:
-            all_failures = await audit.list_citation_failures(limit=100_000, offset=0)
+            total = await audit.count_citation_failures(page_slug=page or None)
             rows = await audit.list_citation_failures(limit=limit, offset=offset)
-            return {"total": len(all_failures), "citations": rows}
+            return {"total": total, "citations": rows}
+        total = await audit.count_citations(
+            page_slug=page or None,
+            source_file=source or None,
+        )
         rows = await audit.list_citations(
             page_slug=page or None,
             source_file=source or None,
@@ -1584,14 +1588,7 @@ def create_app(wiki_root: Path, max_body_bytes: int = _MAX_BODY_BYTES, enable_mc
             sort=sort,
             order=order,
         )
-        # Total count without limit
-        all_rows = await audit.list_citations(
-            page_slug=page or None,
-            source_file=source or None,
-            limit=100_000,
-            offset=0,
-        )
-        return {"total": len(all_rows), "citations": rows}
+        return {"total": total, "citations": rows}
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -216,6 +216,17 @@ class AuditDB:
                     await db.commit()
                 except Exception:
                     pass  # column already exists
+            # One-time data cleanup: remove duplicate claim_citations rows that
+            # accumulated before record_claim_citations gained DELETE-before-INSERT.
+            # Keeps the highest id (most recent insert) per unique citation key.
+            await db.execute("""
+                DELETE FROM claim_citations
+                WHERE id NOT IN (
+                    SELECT MAX(id)
+                    FROM claim_citations
+                    GROUP BY page_slug, source_file, line_start, line_end
+                )
+            """)
             await db.execute(f"PRAGMA user_version = {DB_SCHEMA_VERSION}")
             await db.commit()
 

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -94,6 +94,43 @@ class AuditDB:
         self._path = Path(db_path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    async def _run_migrations(db) -> None:
+        """Apply schema and data migrations to an open db connection.
+
+        Schema migrations (ALTER TABLE) are silently skipped when the column
+        already exists.  Data migrations are written as idempotent SQL so they
+        are safe to re-run on every startup.
+        """
+        # Schema migrations — ignored if the column already exists
+        for sql in (
+            "ALTER TABLE scheduled_runs ADD COLUMN entry_id TEXT NOT NULL DEFAULT ''",
+            "ALTER TABLE scheduled_runs ADD COLUMN output TEXT DEFAULT ''",
+            "ALTER TABLE chat_sessions ADD COLUMN history_summary TEXT DEFAULT NULL",
+            "ALTER TABLE chat_sessions ADD COLUMN summary_turn_count INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE chat_messages ADD COLUMN citations TEXT DEFAULT NULL",
+            "ALTER TABLE chat_messages ADD COLUMN gap_suggestions TEXT DEFAULT NULL",
+            "ALTER TABLE graph_edges ADD COLUMN edge_type TEXT NOT NULL DEFAULT 'mixed'",
+            "ALTER TABLE lifecycle_events ADD COLUMN content_snapshot TEXT DEFAULT NULL",
+        ):
+            try:
+                await db.execute(sql)
+                await db.commit()
+            except Exception:
+                pass  # column already exists
+
+        # Data migrations — idempotent by SQL semantics
+        # Remove duplicate claim_citations rows accumulated before
+        # record_claim_citations gained its DELETE-before-INSERT guard.
+        await db.execute("""
+            DELETE FROM claim_citations
+            WHERE id NOT IN (
+                SELECT MAX(id)
+                FROM claim_citations
+                GROUP BY page_slug, source_file, line_start, line_end
+            )
+        """)
+
     async def init(self) -> None:
         # WAL mode is not enabled here. Each public method opens its own
         # aiosqlite connection, so concurrent callers serialize on SQLite's
@@ -200,33 +237,7 @@ class AuditDB:
                     edge_type   TEXT NOT NULL DEFAULT 'mixed',
                     PRIMARY KEY (from_slug, to_slug)
                 )""")
-            # Migrations for existing installs
-            for migration in (
-                "ALTER TABLE scheduled_runs ADD COLUMN entry_id TEXT NOT NULL DEFAULT ''",
-                "ALTER TABLE scheduled_runs ADD COLUMN output TEXT DEFAULT ''",
-                "ALTER TABLE chat_sessions ADD COLUMN history_summary TEXT DEFAULT NULL",
-                "ALTER TABLE chat_sessions ADD COLUMN summary_turn_count INTEGER NOT NULL DEFAULT 0",
-                "ALTER TABLE chat_messages ADD COLUMN citations TEXT DEFAULT NULL",
-                "ALTER TABLE chat_messages ADD COLUMN gap_suggestions TEXT DEFAULT NULL",
-                "ALTER TABLE graph_edges ADD COLUMN edge_type TEXT NOT NULL DEFAULT 'mixed'",
-                "ALTER TABLE lifecycle_events ADD COLUMN content_snapshot TEXT DEFAULT NULL",
-            ):
-                try:
-                    await db.execute(migration)
-                    await db.commit()
-                except Exception:
-                    pass  # column already exists
-            # One-time data cleanup: remove duplicate claim_citations rows that
-            # accumulated before record_claim_citations gained DELETE-before-INSERT.
-            # Keeps the highest id (most recent insert) per unique citation key.
-            await db.execute("""
-                DELETE FROM claim_citations
-                WHERE id NOT IN (
-                    SELECT MAX(id)
-                    FROM claim_citations
-                    GROUP BY page_slug, source_file, line_start, line_end
-                )
-            """)
+            await self._run_migrations(db)
             await db.execute(f"PRAGMA user_version = {DB_SCHEMA_VERSION}")
             await db.commit()
 

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -473,6 +473,37 @@ class AuditDB:
             })
         return result
 
+    async def count_citations(
+        self,
+        page_slug: str | None = None,
+        source_file: str | None = None,
+    ) -> int:
+        """Return the total number of claim_citations rows matching the filters."""
+        wheres, params = [], []
+        if page_slug:
+            wheres.append("page_slug=?")
+            params.append(page_slug)
+        if source_file:
+            wheres.append("source_file=?")
+            params.append(source_file)
+        where = ("WHERE " + " AND ".join(wheres)) if wheres else ""
+        async with aiosqlite.connect(self._path) as db:
+            async with db.execute(
+                f"SELECT COUNT(*) FROM claim_citations {where}", params
+            ) as cur:
+                return (await cur.fetchone())[0]
+
+    async def count_citation_failures(self, page_slug: str | None = None) -> int:
+        """Return the total number of citation_validation_failed audit events."""
+        slug_filter, params = _audit_slug_filter(page_slug)
+        async with aiosqlite.connect(self._path) as db:
+            async with db.execute(
+                f"SELECT COUNT(*) FROM audit_events "
+                f"WHERE event='citation_validation_failed' {slug_filter}",
+                params,
+            ) as cur:
+                return (await cur.fetchone())[0]
+
     async def write_event(self, event: str, job_id: str = "",
                           metadata: dict | None = None) -> None:
         """Write a single audit event."""

--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -384,11 +384,18 @@ class AuditDB:
     async def record_claim_citations(
         self, page_slug: str, citations: list[dict]
     ) -> None:
-        """Record claim-level citations produced by Pass 4."""
+        """Record claim-level citations produced by Pass 4.
+
+        Replaces any previously stored citations for this slug so that
+        re-ingesting a page never accumulates duplicate rows.
+        """
         if not citations:
             return
         ts = datetime.now(timezone.utc).isoformat()
         async with aiosqlite.connect(self._path) as db:
+            await db.execute(
+                "DELETE FROM claim_citations WHERE page_slug=?", (page_slug,)
+            )
             await db.executemany(
                 "INSERT INTO claim_citations "
                 "(page_slug,source_file,line_start,line_end,claim_excerpt,ingested_at) "

--- a/tests/cli/test_audit_cli.py
+++ b/tests/cli/test_audit_cli.py
@@ -269,11 +269,11 @@ async def test_list_citations_filter_by_page(db):
 
 
 async def test_list_citations_filter_by_source(db):
+    # Both source files belong to the same page — pass them in a single call
+    # so the replace-on-reingest logic does not discard the first entry.
     await db.record_claim_citations("alan-turing", [
-        {"source_file": "bio.txt", "line_start": 1, "line_end": 5, "claim_excerpt": "x"}
-    ])
-    await db.record_claim_citations("alan-turing", [
-        {"source_file": "other.txt", "line_start": 1, "line_end": 5, "claim_excerpt": "y"}
+        {"source_file": "bio.txt",   "line_start": 1, "line_end": 5, "claim_excerpt": "x"},
+        {"source_file": "other.txt", "line_start": 1, "line_end": 5, "claim_excerpt": "y"},
     ])
     rows = await db.list_citations(source_file="bio.txt")
     assert len(rows) == 1

--- a/tests/storage/test_log.py
+++ b/tests/storage/test_log.py
@@ -410,3 +410,89 @@ async def test_delete_graph_node_no_op_when_slug_absent(tmp_path):
 
     graph = await db.read_graph()
     assert len(graph["nodes"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# count_citations / count_citation_failures
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_count_citations_empty(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    assert await db.count_citations() == 0
+
+
+@pytest.mark.asyncio
+async def test_count_citations_matches_inserted(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_claim_citations("turing", [
+        {"source_file": "bio.txt", "line_start": 1, "line_end": 5, "claim_excerpt": "c1"},
+        {"source_file": "bio.txt", "line_start": 6, "line_end": 10, "claim_excerpt": "c2"},
+    ])
+    await db.record_claim_citations("hopper", [
+        {"source_file": "hist.txt", "line_start": 1, "line_end": 3, "claim_excerpt": "c3"},
+    ])
+    assert await db.count_citations() == 3
+
+
+@pytest.mark.asyncio
+async def test_count_citations_filter_by_page_slug(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_claim_citations("turing", [
+        {"source_file": "a.txt", "line_start": 1, "line_end": 2, "claim_excerpt": "x"},
+        {"source_file": "a.txt", "line_start": 3, "line_end": 4, "claim_excerpt": "y"},
+    ])
+    await db.record_claim_citations("hopper", [
+        {"source_file": "b.txt", "line_start": 1, "line_end": 2, "claim_excerpt": "z"},
+    ])
+    assert await db.count_citations(page_slug="turing") == 2
+    assert await db.count_citations(page_slug="hopper") == 1
+    assert await db.count_citations(page_slug="nobody") == 0
+
+
+@pytest.mark.asyncio
+async def test_count_citations_filter_by_source_file(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.record_claim_citations("turing", [
+        {"source_file": "bio.txt", "line_start": 1, "line_end": 2, "claim_excerpt": "x"},
+        {"source_file": "paper.txt", "line_start": 3, "line_end": 4, "claim_excerpt": "y"},
+    ])
+    assert await db.count_citations(source_file="bio.txt") == 1
+    assert await db.count_citations(source_file="paper.txt") == 1
+
+
+@pytest.mark.asyncio
+async def test_count_citation_failures_empty(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    assert await db.count_citation_failures() == 0
+
+
+@pytest.mark.asyncio
+async def test_count_citation_failures_matches_events(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.write_event("citation_validation_failed",
+                         metadata={"slug": "p1", "citation": "^[x]", "reason": "broken"})
+    await db.write_event("citation_validation_failed",
+                         metadata={"slug": "p1", "citation": "^[y]", "reason": "broken"})
+    await db.write_event("ingest_complete",
+                         metadata={"slug": "p1"})  # different event, must not be counted
+    assert await db.count_citation_failures() == 2
+
+
+@pytest.mark.asyncio
+async def test_count_citation_failures_filter_by_page_slug(tmp_path):
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+    await db.write_event("citation_validation_failed",
+                         metadata={"page_slug": "turing", "citation": "^[a]", "reason": "r"})
+    await db.write_event("citation_validation_failed",
+                         metadata={"page_slug": "hopper", "citation": "^[b]", "reason": "r"})
+    assert await db.count_citation_failures(page_slug="turing") == 1
+    assert await db.count_citation_failures(page_slug="hopper") == 1
+    assert await db.count_citation_failures(page_slug="nobody") == 0

--- a/tests/storage/test_log.py
+++ b/tests/storage/test_log.py
@@ -417,6 +417,31 @@ async def test_delete_graph_node_no_op_when_slug_absent(tmp_path):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
+async def test_record_claim_citations_replaces_on_reingest(tmp_path):
+    """Re-ingesting a page must replace its citations, not accumulate duplicates."""
+    db = AuditDB(tmp_path / "audit.db")
+    await db.init()
+
+    citations_v1 = [
+        {"source_file": "src.txt", "line_start": 1, "line_end": 1, "claim_excerpt": "c1"},
+        {"source_file": "src.txt", "line_start": 2, "line_end": 2, "claim_excerpt": "c2"},
+    ]
+    citations_v2 = [
+        {"source_file": "src.txt", "line_start": 1, "line_end": 1, "claim_excerpt": "c1-updated"},
+    ]
+
+    await db.record_claim_citations("edsac", citations_v1)
+    assert await db.count_citations(page_slug="edsac") == 2
+
+    # Re-ingest: must replace, not append
+    await db.record_claim_citations("edsac", citations_v2)
+    assert await db.count_citations(page_slug="edsac") == 1
+
+    rows = await db.list_citations(page_slug="edsac")
+    assert rows[0]["claim_excerpt"] == "c1-updated"
+
+
+@pytest.mark.asyncio
 async def test_count_citations_empty(tmp_path):
     db = AuditDB(tmp_path / "audit.db")
     await db.init()


### PR DESCRIPTION
site: https://github.com/axoviq-ai/synthadoc/issues/285

In addition: 
- eccf4f4 - dedup migration runs at init() time, cleaning up your live DB on next server start
- ddce50c - _run_migrations() static method: schema ALTERs in one section, data migrations in another; adding future migrations is a one-line change in the right section