### PR TITLE
fix(scheduler): use shlex.split(op) instead of op.split() for subproc…

### DIFF
--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -126,7 +127,7 @@ def run_cmd(
     typer.echo(f"[schedule] {run_id}  {op}  starting")
     t0 = time.monotonic()
     try:
-        cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + op.split()
+        cmd = [sys.executable, "-m", "synthadoc", "-w", wiki_name] + shlex.split(op)
         sub_env = {**os.environ, "PYTHONIOENCODING": "utf-8"}
         result = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True,
                                 encoding="utf-8", env=sub_env)

--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+import shlex
 import sys
 import time
 import uuid
@@ -159,7 +160,7 @@ async def _run_scheduled_job(
     try:
         proc = await asyncio.create_subprocess_exec(
             sys.executable, "-m", "synthadoc", "-w", wiki,
-            *op.split(),
+            *shlex.split(op),
             cwd=str(wiki_root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -131,6 +131,28 @@ async def test_run_scheduled_job_cancelled_records_finish_and_reraises(tmp_path)
     assert task.cancelled()
 
 
+async def test_run_scheduled_job_op_with_spaces_in_path(tmp_path):
+    """shlex.split preserves quoted paths with spaces — regression for op.split() bug."""
+    audit_db = AsyncMock()
+    captured_args = []
+
+    async def _fake_exec(*args, **kwargs):
+        captured_args.extend(args)
+        mock = MagicMock()
+        mock.returncode = 0
+        mock.communicate = AsyncMock(return_value=(b"", b""))
+        return mock
+
+    entry = {"id": "sched-spaces", "op": 'ingest "raw sources/my report.pdf"'}
+
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        await _run_scheduled_job(entry, "test-wiki", tmp_path, audit_db, job_timeout_seconds=30)
+
+    # The path with spaces must arrive as a single argument, not split into two
+    assert "raw sources/my report.pdf" in captured_args
+    assert "report.pdf" not in [a for a in captured_args if a != "raw sources/my report.pdf"]
+
+
 def test_save_raw_is_atomic(tmp_path):
     """_save_raw writes via a .tmp sibling then renames — no partial file on failure."""
     sched = Scheduler(wiki="test", wiki_root=str(tmp_path))


### PR DESCRIPTION
…ess args

op.split() breaks scheduled operations with spaces in paths (e.g. 'ingest "raw sources/my report.pdf"' splits into three args instead of two). shlex.split() correctly handles quoted tokens on all platforms.

issue: https://github.com/axoviq-ai/synthadoc/issues/239