### PR TITLE
feat: add get_page_states step to agentic reingest workflow

### DIFF
--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -253,6 +253,31 @@ async def tool_run_lint(ctx: "WorkflowContext", scope: str = "all") -> dict:
         return {"error": str(exc)}
 
 
+async def tool_get_page_states(ctx: "WorkflowContext", slugs: list[str]) -> dict:
+    """Return the current lifecycle state of one or more wiki pages by slug.
+
+    Returns::
+
+        {"pages": [{"slug": str, "state": str}]}
+
+    ``state`` is one of ``"active"``, ``"stale"``, ``"draft"``, ``"archived"``,
+    or ``"unknown"`` if the page has no lifecycle record yet.
+    """
+    results: list[dict] = []
+    for slug in slugs:
+        try:
+            row = await ctx.audit_db.get_page_state(slug)
+            state = row["state"] if row else "unknown"
+        except Exception:  # noqa: BLE001
+            state = "unknown"
+        results.append({"slug": slug, "state": state})
+    await ctx.send_sse_event(
+        "tool_progress",
+        {"tool": "get_page_states", "message": "Checking page states after re-ingest..."},
+    )
+    return {"pages": results}
+
+
 async def tool_confirm(
     ctx: "WorkflowContext",
     message: str,

--- a/synthadoc/agents/workflows/ingest_lint.py
+++ b/synthadoc/agents/workflows/ingest_lint.py
@@ -10,6 +10,7 @@ from synthadoc.agents.workflows._tools import (
     tool_confirm,
     tool_find_page_source,
     tool_find_stale_pages,
+    tool_get_page_states,
     tool_ingest_source,
     tool_poll_job,
     tool_run_lint,
@@ -39,6 +40,12 @@ run_lint — queue a lint run.
   Input: {"scope": str (default "all")}
   Output: {"job_id": str} | {"error": str}
 
+get_page_states — return the current lifecycle state of one or more pages.
+  Input: {"slugs": [str, ...]}
+  Output: {"pages": [{"slug": str, "state": str}]}
+  state is one of: "active", "stale", "draft", "archived", "unknown".
+  Call this AFTER lint completes to confirm whether the re-ingest achieved its goal.
+
 confirm — ask the user to confirm before proceeding.
   Input: {"message": str, "yes_label": str (default "Yes"), "no_label": str (default "No")}
   Output: {"confirmed": bool}
@@ -53,7 +60,10 @@ Workflow A — re-ingest ALL stale pages:
    at a time, waiting for each result before calling the next.
 4. Call run_lint — it returns a job_id.
 5. Call poll_job(job_id=<lint_job_id>) to wait for the lint job to complete.
-6. Plain-text summary of every re-ingest outcome AND the lint result (pass/fail).
+6. Call get_page_states with the slugs of every page you attempted to re-ingest.
+7. Plain-text summary of every re-ingest outcome, the lint result (pass/fail), and
+   a "Page states after re-ingest" section listing each slug with its current state.
+   Use ✓ for active, ✗ for stale, and ○ for draft/archived/unknown.
 
 Workflow B — re-ingest a SPECIFIC page by slug:
 1. Call find_page_source(slug=<slug>) to get its source path.
@@ -62,7 +72,9 @@ Workflow B — re-ingest a SPECIFIC page by slug:
 3. If confirmed, call ingest_source(source_path=<path>).
 4. Call run_lint — it returns a job_id.
 5. Call poll_job(job_id=<lint_job_id>) to wait for the lint job to complete.
-6. Plain-text summary of the ingest result and the lint result (pass/fail).
+6. Call get_page_states(slugs=[<slug>]) to check the page's current lifecycle state.
+7. Plain-text summary of the ingest result, the lint result (pass/fail), and the
+   final page state. Use ✓ for active, ✗ for stale, ○ for draft/archived/unknown.
 
 Plain text ends the workflow — use it ONLY in the final summary step or when
 confirm returns false. All intermediate steps must be tool calls, not plain text.
@@ -88,5 +100,6 @@ class IngestLintWorkflow(AgenticWorkflow):
             "ingest_source": functools.partial(tool_ingest_source, ctx),
             "poll_job": functools.partial(tool_poll_job, ctx),
             "run_lint": functools.partial(tool_run_lint, ctx),
+            "get_page_states": functools.partial(tool_get_page_states, ctx),
             "confirm": functools.partial(tool_confirm, ctx),
         }

--- a/tests/agents/workflows/test_ingest_lint.py
+++ b/tests/agents/workflows/test_ingest_lint.py
@@ -30,6 +30,7 @@ async def test_ingest_lint_system_prompt_mentions_tools():
     assert "find_stale_pages" in prompt
     assert "find_page_source" in prompt
     assert "ingest_source" in prompt
+    assert "get_page_states" in prompt
     assert "confirm" in prompt
 
 
@@ -39,7 +40,7 @@ def test_ingest_lint_tool_fns_are_all_callable():
     fns = wf.get_tool_fns(ctx)
     assert set(fns) == {
         "find_stale_pages", "find_page_source",
-        "ingest_source", "poll_job", "run_lint", "confirm",
+        "ingest_source", "poll_job", "run_lint", "get_page_states", "confirm",
     }
     for name, fn in fns.items():
         assert callable(fn), f"{name} not callable"

--- a/tests/agents/workflows/test_tools.py
+++ b/tests/agents/workflows/test_tools.py
@@ -16,6 +16,7 @@ from synthadoc.agents.workflows._tools import (
     tool_confirm,
     tool_find_page_source,
     tool_find_stale_pages,
+    tool_get_page_states,
     tool_ingest_source,
     tool_poll_job,
     tool_run_lint,
@@ -565,6 +566,44 @@ async def test_find_page_source_unknown_slug():
     result = await tool_find_page_source(ctx, "no-such-page")
     assert "error" in result
     assert "no-such-page" in result["error"]
+
+
+async def test_get_page_states_returns_state_for_each_slug():
+    """tool_get_page_states maps each slug to its current lifecycle state."""
+    audit_db = MagicMock()
+    audit_db.get_page_state = AsyncMock(side_effect=lambda slug: {
+        "slug": slug, "state": "active" if slug == "page-a" else "stale",
+        "updated_at": "2026-01-01", "triggered_by": "lint",
+    })
+    ctx, events = _make_ctx(audit_db=audit_db)
+    result = await tool_get_page_states(ctx, ["page-a", "page-b"])
+    assert result == {"pages": [{"slug": "page-a", "state": "active"}, {"slug": "page-b", "state": "stale"}]}
+    assert any(e["event"] == "tool_progress" for e in events)
+
+
+async def test_get_page_states_returns_unknown_when_no_db_row():
+    """Slug with no page_states row → state='unknown'."""
+    audit_db = MagicMock()
+    audit_db.get_page_state = AsyncMock(return_value=None)
+    ctx, _ = _make_ctx(audit_db=audit_db)
+    result = await tool_get_page_states(ctx, ["ghost-page"])
+    assert result == {"pages": [{"slug": "ghost-page", "state": "unknown"}]}
+
+
+async def test_get_page_states_handles_db_exception_gracefully():
+    """DB error for a slug → state='unknown', no exception raised."""
+    audit_db = MagicMock()
+    audit_db.get_page_state = AsyncMock(side_effect=RuntimeError("db error"))
+    ctx, _ = _make_ctx(audit_db=audit_db)
+    result = await tool_get_page_states(ctx, ["some-page"])
+    assert result == {"pages": [{"slug": "some-page", "state": "unknown"}]}
+
+
+async def test_get_page_states_empty_slugs_list():
+    """Empty slug list → empty pages list."""
+    ctx, _ = _make_ctx()
+    result = await tool_get_page_states(ctx, [])
+    assert result == {"pages": []}
 
 
 async def test_find_page_source_no_sources():

--- a/tests/live/test_agentic_ingest_lint_live.py
+++ b/tests/live/test_agentic_ingest_lint_live.py
@@ -775,6 +775,13 @@ def test_agentic_reingest_emits_tool_progress_events():
         assert lint_progress, (
             "Expected a run_lint tool_progress event — lint was not called"
         )
+
+        # get_page_states must be called after lint to confirm goal was achieved.
+        states_progress = [d for t, d in events if t == "tool_progress" and d.get("tool") == "get_page_states"]
+        assert states_progress, (
+            "Expected a get_page_states tool_progress event — page states were not checked after lint"
+        )
+
         full_text = "".join(d.get("text", "") for t, d in events if t == "token")
         assert any(
             kw in full_text.lower()
@@ -853,6 +860,16 @@ def test_agentic_reingest_stale_pages_become_draft():
             kw in full_text.lower()
             for kw in ("lint", "check")
         ), f"Expected lint result in narrative. Got: {full_text[:300]!r}"
+
+        # get_page_states must follow lint and page states must appear in the narrative.
+        states_progress = [d for t, d in events if t == "tool_progress" and d.get("tool") == "get_page_states"]
+        assert states_progress, (
+            "Expected a get_page_states tool_progress event — page states not checked after lint"
+        )
+        assert any(
+            kw in full_text.lower()
+            for kw in ("active", "stale", "page state", "✓", "✗")
+        ), f"Expected page state in narrative. Got: {full_text[:300]!r}"
     finally:
         _restore_stale_page(wiki_root, slug, source_path, orig_content, original_state=orig_state)
         _restore_isolated_pages(isolated_slugs)
@@ -992,6 +1009,17 @@ def test_agentic_partial_completion_continues_after_one_failure():
         pytest.skip("No second active or draft page with a local text source found for page B — skipping")
     slug_b, src_b, orig_b, orig_state_b = page_b
 
+    # Guard: if both pages resolve to the same source file, renaming src_b would
+    # also break src_a, making a partial-completion test impossible on this wiki.
+    if src_a == src_b:
+        _restore_stale_page(wiki_root, slug_a, src_a, orig_a, original_state=orig_state_a)
+        _restore_stale_page(wiki_root, slug_b, src_b, orig_b, original_state=orig_state_b)
+        _restore_isolated_pages(isolated_slugs)
+        pytest.skip(
+            f"Both manufactured pages share the same source file ({src_a.name!r}) — "
+            "cannot sabotage one without breaking the other; skipping partial-failure test"
+        )
+
     # Exclude manufactured slugs from isolated_slugs so _restore_isolated_pages
     # does not re-stale pages that the workflow just set to draft.
     isolated_slugs = [s for s in isolated_slugs if s not in {slug_a, slug_b}]
@@ -1114,6 +1142,16 @@ def test_agentic_reingest_by_slug_active_page_becomes_draft():
             kw in full_text.lower()
             for kw in ("lint", "check")
         ), f"Expected lint result in narrative. Got: {full_text[:300]!r}"
+
+        # get_page_states must be called and the final state of the slug reported.
+        states_progress = [d for t, d in events if t == "tool_progress" and d.get("tool") == "get_page_states"]
+        assert states_progress, (
+            "Expected a get_page_states tool_progress event — page state not checked after lint"
+        )
+        assert any(
+            kw in full_text.lower()
+            for kw in ("active", "stale", "page state", "✓", "✗")
+        ), f"Expected page state in narrative. Got: {full_text[:300]!r}"
     finally:
         _restore_stale_page(wiki_root, slug, source_path, orig_content, original_state=orig_state)
         _restore_isolated_pages(isolated_slugs)
@@ -1146,12 +1184,14 @@ def test_find_page_source_tool_rejects_unknown_slug():
         for kw in (
             "not found",
             "does not exist",
+            "doesn't exist",
             "no page",
             "no wiki page",
             "no source path",
             "unknown",
             "couldn't find",
             "could not find",
+            "don't exist",
         )
     ), (
         f"Expected 'not found' language for unknown slug. Got: {full_text[:300]!r}"


### PR DESCRIPTION
After the lint job completes, the workflow now calls get_page_states for every re-ingested page and includes a "Page states after re-ingest" section in the final summary (✓ active / ✗ stale / ○ other), making it clear whether the workflow goal was achieved.

Changes:
- _tools.py: add tool_get_page_states — queries audit_db.get_page_state per slug, returns {"pages": [{slug, state}]}, emits tool_progress SSE
- ingest_lint.py: register get_page_states in tool map; add tool description and step 6/7 to both Workflow A and B system prompts
- test_tools.py: import tool_get_page_states; add 4 unit tests (happy path, no DB row → unknown, DB exception → unknown, empty list)
- test_ingest_lint.py: add get_page_states to expected tool set and system prompt assertion
- test_agentic_ingest_lint_live.py: assert get_page_states tool_progress event in 3 e2e tests; assert page state appears in narrative for 2 of them; fix partial-completion test to skip when both manufactured pages share a source file; add contraction forms to unknown-slug keyword list