### PR TITLE
fix(scheduler): drain subprocess pipes after kill on timeout and canc…

### DIFF
--- a/synthadoc/core/scheduler.py
+++ b/synthadoc/core/scheduler.py
@@ -143,6 +143,15 @@ def _kill_proc(proc: object) -> None:
             pass
 
 
+async def _kill_and_drain_proc(proc: object) -> None:
+    """Kill a subprocess then wait for it to exit so pipe handles are released."""
+    _kill_proc(proc)
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5.0)  # type: ignore[union-attr]
+    except (asyncio.TimeoutError, ProcessLookupError):
+        pass
+
+
 async def _run_scheduled_job(
     entry: dict, wiki: str, wiki_root: Path, audit_db: "AuditDB",
     job_timeout_seconds: int,
@@ -183,12 +192,12 @@ async def _run_scheduled_job(
             logger.warning("[schedule] %s  %s  %.1fs  failed (%s)", run_id, op, duration, err)
     except asyncio.TimeoutError:
         duration = time.monotonic() - t0
-        _kill_proc(proc)
+        await _kill_and_drain_proc(proc)
         err = f"timed out after {job_timeout_seconds}s"
         await audit_db.record_scheduled_run_finish(run_id, "failed", duration, err)
         logger.warning("[schedule] %s  %s  %.1fs  %s", run_id, op, duration, err)
     except asyncio.CancelledError:
-        _kill_proc(proc)
+        await _kill_and_drain_proc(proc)
         duration = time.monotonic() - t0
         try:
             await audit_db.record_scheduled_run_finish(run_id, "cancelled", duration)

--- a/tests/core/test_scheduler.py
+++ b/tests/core/test_scheduler.py
@@ -43,7 +43,7 @@ def test_scheduler_apply_from_config(tmp_path):
 # ------------------------------------------------------------------
 
 async def test_run_scheduled_job_timeout_kills_proc(tmp_path):
-    """Hanging subprocess: TimeoutError kills the process and records 'failed'."""
+    """Hanging subprocess: TimeoutError kills the process, drains pipes, and records 'failed'."""
     audit_db = AsyncMock()
 
     async def _hang():
@@ -52,6 +52,7 @@ async def test_run_scheduled_job_timeout_kills_proc(tmp_path):
     mock_proc = MagicMock()
     mock_proc.kill = MagicMock()
     mock_proc.communicate = _hang
+    mock_proc.wait = AsyncMock(return_value=None)
 
     entry = {"id": "sched-test-timeout", "op": "lint"}
 
@@ -59,6 +60,7 @@ async def test_run_scheduled_job_timeout_kills_proc(tmp_path):
         await _run_scheduled_job(entry, "test-wiki", tmp_path, audit_db, job_timeout_seconds=0.05)
 
     mock_proc.kill.assert_called_once()
+    mock_proc.wait.assert_awaited_once()
     call = audit_db.record_scheduled_run_finish.call_args
     assert call.args[1] == "failed"
     assert "timed out" in call.args[3]
@@ -100,7 +102,7 @@ async def test_run_scheduled_job_nonzero_exit(tmp_path):
 
 
 async def test_run_scheduled_job_cancelled_records_finish_and_reraises(tmp_path):
-    """CancelledError: kills proc, records 'cancelled', then re-raises so the
+    """CancelledError: kills proc, drains pipes, records 'cancelled', then re-raises so the
     task is properly cancelled rather than swallowed."""
     audit_db = AsyncMock()
 
@@ -110,6 +112,7 @@ async def test_run_scheduled_job_cancelled_records_finish_and_reraises(tmp_path)
     mock_proc = MagicMock()
     mock_proc.kill = MagicMock()
     mock_proc.communicate = _hang
+    mock_proc.wait = AsyncMock(return_value=None)
 
     entry = {"id": "sched-test-cancel", "op": "lint"}
 
@@ -125,6 +128,7 @@ async def test_run_scheduled_job_cancelled_records_finish_and_reraises(tmp_path)
             pass
 
     mock_proc.kill.assert_called_once()
+    mock_proc.wait.assert_awaited_once()
     audit_db.record_scheduled_run_finish.assert_awaited_once()
     call = audit_db.record_scheduled_run_finish.call_args
     assert call.args[1] == "cancelled"


### PR DESCRIPTION
…ellation

Add _kill_and_drain_proc() helper that kills the process then awaits proc.wait() with a 5-second timeout, ensuring stdout/stderr pipe handles are released promptly instead of waiting for GC. Both the TimeoutError and CancelledError handlers now call this instead of bare _kill_proc().

issue: https://github.com/axoviq-ai/synthadoc/issues/288
