### PR TITLE
fix (audit-db): add secondary indexes on audit_events, lifecycle_event…

### DIFF
--- a/synthadoc/storage/log.py
+++ b/synthadoc/storage/log.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 
 import aiosqlite
 
-DB_SCHEMA_VERSION: int = 4
+DB_SCHEMA_VERSION: int = 5
 
 CITATION_EXCERPT_LEN = 100
 
@@ -118,6 +118,19 @@ class AuditDB:
                 await db.commit()
             except Exception:
                 pass  # column already exists
+
+        # Secondary indexes — idempotent via IF NOT EXISTS; placed after column
+        # migrations so referenced columns (e.g. content_snapshot) are guaranteed
+        # to exist before the partial index is created.
+        for sql in (
+            "CREATE INDEX IF NOT EXISTS idx_audit_events_event ON audit_events(event)",
+            "CREATE INDEX IF NOT EXISTS idx_lifecycle_events_slug ON lifecycle_events(slug)",
+            "CREATE INDEX IF NOT EXISTS idx_lifecycle_slug_snapshot ON lifecycle_events(slug) WHERE content_snapshot IS NOT NULL",
+            "CREATE INDEX IF NOT EXISTS idx_claim_citations_page_slug ON claim_citations(page_slug)",
+            "CREATE INDEX IF NOT EXISTS idx_claim_citations_source_file ON claim_citations(source_file)",
+        ):
+            await db.execute(sql)
+        await db.commit()
 
         # Data migrations — idempotent by SQL semantics
         # Remove duplicate claim_citations rows accumulated before

--- a/tests/integration/test_lifecycle_snapshots.py
+++ b/tests/integration/test_lifecycle_snapshots.py
@@ -11,8 +11,8 @@ from synthadoc.storage.log import AuditDB, DB_SCHEMA_VERSION
 
 # ── Task 1 tests ────────────────────────────────────────────────────────────
 
-def test_schema_version_is_4():
-    assert DB_SCHEMA_VERSION == 4
+def test_schema_version_is_5():
+    assert DB_SCHEMA_VERSION == 5
 
 
 @pytest.mark.asyncio

--- a/tests/storage/test_audit.py
+++ b/tests/storage/test_audit.py
@@ -1,7 +1,28 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2026 William Johnason / axoviq.com
+import aiosqlite
 import pytest
 from synthadoc.storage.log import AuditDB, LogWriter
+
+
+@pytest.mark.asyncio
+async def test_audit_db_indexes_exist(tmp_wiki):
+    """AuditDB.init() must create all expected secondary indexes."""
+    db = AuditDB(tmp_wiki / ".synthadoc" / "audit.db")
+    await db.init()
+    expected = {
+        "idx_audit_events_event",
+        "idx_lifecycle_events_slug",
+        "idx_lifecycle_slug_snapshot",
+        "idx_claim_citations_page_slug",
+        "idx_claim_citations_source_file",
+    }
+    async with aiosqlite.connect(tmp_wiki / ".synthadoc" / "audit.db") as conn:
+        async with conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'"
+        ) as cur:
+            found = {row[0] for row in await cur.fetchall()}
+    assert expected <= found
 
 
 @pytest.mark.asyncio

--- a/tests/test_audit_db.py
+++ b/tests/test_audit_db.py
@@ -67,4 +67,4 @@ async def test_write_claim_citations_no_op_for_empty_list(tmp_path):
 @pytest.mark.asyncio
 async def test_schema_version_bumped(tmp_path):
     from synthadoc.storage.log import DB_SCHEMA_VERSION
-    assert DB_SCHEMA_VERSION == 4
+    assert DB_SCHEMA_VERSION == 5


### PR DESCRIPTION
…s, claim_citations

Add five CREATE INDEX IF NOT EXISTS statements to _run_migrations() so frequent filter columns are covered: audit_events(event), lifecycle_events(slug), lifecycle_events(slug) WHERE content_snapshot IS NOT NULL, claim_citations(page_slug), claim_citations(source_file). Existing DBs gain all indexes on next server start. Bump DB_SCHEMA_VERSION to 5. Add test_audit_db_indexes_exist to verify all indexes via sqlite_master after init().

issue: https://github.com/axoviq-ai/synthadoc/issues/287