### PR TITLE
refactor(workflows): typed status constants and live-test timeout fix

### DIFF
--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -13,6 +13,7 @@ import difflib
 import os
 import re
 import time
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,10 +21,30 @@ if TYPE_CHECKING:
     from synthadoc.agents.workflows._base import WorkflowContext
 
 from synthadoc.agents.scaffold_agent import scaffold_output_paths
+from synthadoc.core.queue import JobStatus
 
 # Retry delays (seconds) when the job queue is temporarily unavailable.
 # The first attempt uses 0 delay; subsequent attempts use these values.
 _INGEST_RETRY_DELAYS: list[int] = [2, 4, 8]
+
+
+class ToolStatus(str, Enum):
+    """Tool-call result status codes returned by workflow tool functions.
+
+    Distinct from :class:`~synthadoc.core.queue.JobStatus`, which represents
+    the state of a queued background job.  These codes describe the *outcome
+    of a single tool call* as seen by the LLM loop.
+
+    Because this is a ``str`` mixin enum, members compare equal to their plain
+    string values (``ToolStatus.SUCCESS == "success"`` is ``True``).  Return
+    dicts therefore store plain string literals — transparent to LLM
+    serialisation via ``str(result_dict)`` — while comparison sites use the
+    typed members to eliminate magic strings.
+    """
+    SUCCESS = "success"
+    FAILED  = "failed"
+    TIMEOUT = "timeout"
+    ERROR   = "error"
 
 
 # ---------------------------------------------------------------------------
@@ -171,11 +192,13 @@ async def tool_ingest_source(ctx: "WorkflowContext", source_path: str) -> dict:
     result = await tool_poll_job(ctx, job_id, timeout_seconds=300, job_label=f"Ingest: {label}")
     result["job_id"] = job_id
 
-    status = result.get("status", "failed")
-    if status == "success":
+    status = result.get("status", ToolStatus.FAILED)
+    if status == ToolStatus.SUCCESS:
         await ctx.send_sse_event("tool_progress", {"tool": "ingest_source", "message": f"✓ {label} re-ingested"})
+    elif status == ToolStatus.TIMEOUT:
+        await ctx.send_sse_event("tool_progress", {"tool": "ingest_source", "message": f"✗ {label}: timed out"})
     else:
-        await ctx.send_sse_event("tool_progress", {"tool": "ingest_source", "message": f"✗ {label}: {status}"})
+        await ctx.send_sse_event("tool_progress", {"tool": "ingest_source", "message": f"✗ {label}: failed"})
     return result
 
 
@@ -210,7 +233,7 @@ async def tool_poll_job(
             return {"status": "failed", "message": f"Queue error for job {job_id}: {exc}"}
 
         if job is not None and job.status.is_terminal:
-            if job.status.value == "completed":
+            if job.status == JobStatus.COMPLETED:
                 return {
                     "status": "success",
                     "message": f"Job {job_id} completed successfully",
@@ -515,7 +538,7 @@ async def tool_run_scaffold(ctx: "WorkflowContext", domain: str) -> dict:
         return {"error": str(exc)}
 
     poll_result = await tool_poll_job(ctx, job_id, timeout_seconds=300, job_label="Scaffold")
-    if poll_result.get("status") != "success":
+    if poll_result.get("status") != ToolStatus.SUCCESS:
         return poll_result
 
     categories_updated = 0

--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -25,11 +25,6 @@ from synthadoc.agents.scaffold_agent import scaffold_output_paths
 # The first attempt uses 0 delay; subsequent attempts use these values.
 _INGEST_RETRY_DELAYS: list[int] = [2, 4, 8]
 
-# JobStatus.value strings that indicate the job has reached a terminal state.
-_TERMINAL_STATUSES: frozenset[str] = frozenset(
-    {"completed", "failed", "dead", "cancelled", "skipped"}
-)
-
 
 # ---------------------------------------------------------------------------
 # Internal helper
@@ -214,7 +209,7 @@ async def tool_poll_job(
         except Exception as exc:  # noqa: BLE001
             return {"status": "failed", "message": f"Queue error for job {job_id}: {exc}"}
 
-        if job is not None and job.status.value in _TERMINAL_STATUSES:
+        if job is not None and job.status.is_terminal:
             if job.status.value == "completed":
                 return {
                     "status": "success",

--- a/synthadoc/core/queue.py
+++ b/synthadoc/core/queue.py
@@ -20,6 +20,16 @@ class JobStatus(str, Enum):
     SKIPPED = "skipped"       # deliberately not retried (e.g. domain auto-blocked)
     CANCELLED = "cancelled"   # pending job cancelled by user
 
+    @property
+    def is_terminal(self) -> bool:
+        """True when the job has reached a final state and will not progress further.
+
+        Defined by exclusion: every status is terminal except PENDING and
+        IN_PROGRESS.  Adding a new status to this enum makes it terminal
+        automatically unless it is explicitly added here.
+        """
+        return self not in (JobStatus.PENDING, JobStatus.IN_PROGRESS)
+
 
 @dataclass
 class Job:

--- a/tests/agents/workflows/test_tools.py
+++ b/tests/agents/workflows/test_tools.py
@@ -885,6 +885,25 @@ async def test_ingest_source_failed_poll_returns_failed_status(tmp_path):
     assert any("✗" in m or "failed" in m.lower() for m in progress_msgs)
 
 
+async def test_ingest_source_timeout_poll_emits_timed_out_message(tmp_path):
+    """Poll times out → status=timeout and SSE progress message says 'timed out'."""
+    source_file = tmp_path / "doc.md"
+    source_file.write_text("content")
+
+    queue = MagicMock()
+    queue.enqueue = AsyncMock(return_value="job-timeout-1")
+
+    ctx, events = _make_ctx(queue=queue)
+    timeout_result = {"status": "timeout", "message": "Job job-timeout-1 timed out after 300s"}
+    with patch("synthadoc.agents.workflows._tools.tool_poll_job", AsyncMock(return_value=timeout_result)):
+        result = await tool_ingest_source(ctx, str(source_file))
+
+    assert result["status"] == "timeout"
+    progress_msgs = [e["data"]["message"] for e in events if e["event"] == "tool_progress"
+                     and e["data"].get("tool") == "ingest_source"]
+    assert any("timed out" in m for m in progress_msgs)
+
+
 # ---------------------------------------------------------------------------
 # tool_run_lint — enqueue failure branch (lines 255-256)
 # ---------------------------------------------------------------------------

--- a/tests/live/test_broken_wikilinks_live.py
+++ b/tests/live/test_broken_wikilinks_live.py
@@ -288,6 +288,7 @@ def _cleanup_stale_bwl_pages():
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_scan_detects_broken_links_and_emits_confirm():
     """
     Workflow scans active pages, finds broken [[wikilinks]], emits tool_progress
@@ -338,6 +339,7 @@ def test_scan_detects_broken_links_and_emits_confirm():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_fix_with_fuzzy_suggestion_updates_page_content():
     """
     Typo wikilink with a close fuzzy match is replaced with the corrected slug.
@@ -397,6 +399,7 @@ def test_fix_with_fuzzy_suggestion_updates_page_content():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_remove_link_with_no_fuzzy_match():
     """
     Completely alien broken ref (no close fuzzy match) is unlinked from the page.
@@ -431,6 +434,7 @@ def test_remove_link_with_no_fuzzy_match():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_declined_workflow_makes_no_changes():
     """Declining confirmation leaves page content byte-for-byte identical."""
     wiki_root = _wiki_root()
@@ -474,6 +478,7 @@ def test_declined_workflow_makes_no_changes():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_clean_wiki_reports_no_broken_links():
     """When only valid wikilinks exist, workflow reports clean — no confirm_request."""
     wiki_root = _wiki_root()
@@ -512,6 +517,7 @@ def test_clean_wiki_reports_no_broken_links():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_stale_pages_excluded_from_scan():
     """Broken links in stale pages are not reported; only active pages are scanned."""
     wiki_root = _wiki_root()
@@ -561,6 +567,7 @@ def test_stale_pages_excluded_from_scan():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_multi_page_scan_and_fix():
     """
     Three pages, each with a broken wikilink. All three are detected and fixed
@@ -619,6 +626,7 @@ def test_multi_page_scan_and_fix():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_mixed_fixable_and_removable_links_on_one_page():
     """
     One page has two broken refs: one with a fuzzy suggestion (corrected) and
@@ -658,6 +666,7 @@ def test_mixed_fixable_and_removable_links_on_one_page():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_lint_runs_after_fixes_and_get_page_states_fires():
     """
     After applying fixes, run_lint and get_page_states tool_progress events


### PR DESCRIPTION
A few targeted clean-ups across the job queue, workflow tools layer, and live test suite.

### `JobStatus.is_terminal` property (ca4d34f)

`_tools.py` maintained a private `_TERMINAL_STATUSES: frozenset[str]` that duplicated the set already implied by `JobStatus` in `core/queue.py`.  Added an `is_terminal` property to `JobStatus` (defined by exclusion — every status is terminal except `PENDING` and `IN_PROGRESS`) and deleted the frozenset.  Any future status added to the enum is automatically terminal unless explicitly
listed as non-terminal.

### `ToolStatus` enum + `JobStatus.COMPLETED` comparison (600934b)

`_tools.py` compared against bare string literals in two distinct ways:

- `job.status.value == "completed"` — bypasses the typed `JobStatus` enum unnecessarily; replaced with `job.status == JobStatus.COMPLETED`.
- `"success"`, `"failed"`, `"timeout"`, `"error"` scattered across comparison sites — these are *tool-call outcome* codes, distinct from `JobStatus` values (`"success"` ≠ `JobStatus.COMPLETED`; `"timeout"` has no job-state equivalent).

Added `ToolStatus(str, Enum)` in `_tools.py` with `SUCCESS / FAILED / TIMEOUT /ERROR` members.  Comparison sites now use the typed constants; return-dict literals stay as plain strings — `_loop.py` passes results to the LLM via `str(result_dict)`, which uses `repr()` on values and would produce `<ToolStatus.SUCCESS: 'success'>` instead of `'success'` if enum members were
stored in the dict.  The `str`-mixin makes `ToolStatus.SUCCESS == "success"` true, so comparisons against stored plain strings work correctly.

The `elif status == ToolStatus.TIMEOUT` branch in `tool_ingest_source` also gives a distinct SSE progress message ("timed out" vs "failed").

### `ToolStatus.TIMEOUT` test coverage (f07836f)

Added `test_ingest_source_timeout_poll_emits_timed_out_message`: patches `tool_poll_job` to return a timeout result and asserts the `ingest_source` SSE progress message contains "timed out". 

### Live-test timeout fix (f06c56c)

`test_broken_wikilinks_live.py` carried no `@pytest.mark.timeout` markers, leaving all nine tests at the global 60 s limit.  `test_multi_page_scan_and_fix` (3 pages × apply_link_fixes + run_lint + poll_job + get_page_states) needs 3–5 minutes and timed out; tests 8–9 were never reached.  Added `@pytest.mark.timeout(300)` to all nine tests, matching the pattern from
`test_lint_report_workflow_live.py`.