### PR TITLE
fix(live-tests): add request-framing verbs to _STOPWORDS; enforce run…

### DIFF
--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -165,6 +165,12 @@ _STOPWORDS = frozenset({
     # "cover" describe the wiki's own structure, not page content, so they never
     # appear frequently in pages and always trigger false-positive gap detection.
     "topic", "cover", "scope", "about",
+    # Request-framing verbs: "Tell me about X", "Show me X", "Explain X",
+    # "Describe X", "Give me …", "Find out about X", "List X".
+    # These verbs describe HOW the user wants the answer, not what the wiki
+    # covers — they never appear ≥2 times in any page and always produce
+    # Signal 5 false positives when they end up in the key-term set.
+    "tell", "show", "explain", "describe", "give", "find", "list",
     # Superlative/comparative query qualifiers: "Which company has the highest X?"
     # These are framing words in questions but rarely repeat in content pages —
     # a page saying "GreenField has the highest leverage" won't repeat "highest"

--- a/synthadoc/agents/workflows/ingest_lint.py
+++ b/synthadoc/agents/workflows/ingest_lint.py
@@ -59,7 +59,7 @@ Workflow A — re-ingest ALL stale pages:
    Use the confirm TOOL; never write plain text to ask (that exits the loop).
 3. If confirmed, call ingest_source for each page with a valid source_path — one page
    at a time, waiting for each result before calling the next.
-4. Call run_lint — it returns a job_id.
+4. Call run_lint — MANDATORY even if one or more ingests failed. Returns a job_id.
 5. Call poll_job(job_id=<lint_job_id>) to wait for the lint job to complete.
 6. Call get_page_states with the slugs of every page you attempted to re-ingest.
 7. Plain-text summary of every re-ingest outcome, the lint result (pass/fail), and
@@ -71,11 +71,16 @@ Workflow B — re-ingest a SPECIFIC page by slug:
 2. Call confirm IMMEDIATELY — include the slug and path in the message.
    Use the confirm TOOL; never write plain text to ask (that exits the loop).
 3. If confirmed, call ingest_source(source_path=<path>).
-4. Call run_lint — it returns a job_id.
+4. Call run_lint — MANDATORY regardless of whether the ingest succeeded. Returns a job_id.
 5. Call poll_job(job_id=<lint_job_id>) to wait for the lint job to complete.
 6. Call get_page_states(slugs=[<slug>]) to check the page's current lifecycle state.
 7. Plain-text summary of the ingest result, the lint result (pass/fail), and the
    final page state. Use ✓ for active, ✗ for stale, ○ for draft/archived/unknown.
+
+CRITICAL RULE: Steps 4→5→6 are REQUIRED after every confirmed ingest_source call.
+You MUST call run_lint, then poll_job, then get_page_states — in that order — before
+writing any plain-text response. Providing a summary without completing these three
+steps is NOT allowed, even if earlier steps encountered errors.
 
 Plain text ends the workflow — use it ONLY in the final summary step or when
 confirm returns false. All intermediate steps must be tool calls, not plain text.


### PR DESCRIPTION
…_lint in ingest-lint system prompt

Fix two live test failures:

1. GET /query/stream (context budget) — always returned 0 citations

   Root cause: 'tell' was not in _STOPWORDS. Every query starting with 'Tell me about …' placed 'tell' in _key_terms for Signal 5 gap detection. 'tell' never appears ≥2 times in wiki page content, so Signal 5 always fired → gap=True → citations=[]. Affected all queries from the graph panel's 'Tell me about' button as well.

   Fix: add 'tell', 'show', 'explain', 'describe', 'give', 'find', 'list' to _STOPWORDS. These are request-framing verbs that describe how the user wants the answer, not content words that recur in wiki pages. Gap detection now uses only the actual subject terms ('alan', 'turing') so Signal 5 fires only when the wiki genuinely lacks coverage.

   All 37 gap-detection tests pass unchanged.

2. test_agentic_reingest_emits_tool_progress_events — run_lint not called

   Root cause: after ingest_source completed, the LLM would sometimes write a plain-text summary without calling run_lint, treating the ingest step as the final action.

   Fix: strengthen the system prompt for both Workflow A and B. Each step 4 now reads 'MANDATORY regardless of ingest outcome', and a CRITICAL RULE block at the bottom explicitly forbids plain-text output before get_page_states returns. This closes the LLM's exit ramp between ingest_source and run_lint.