### PR TITLE
feat(workflow-cli): pluggable workflow CLI with --name dispatch and workflow list and extra args forwarded verbatim via query string

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -14,7 +14,7 @@
       '-+###############+-'
 
        S Y N T H A D O C
-    Community Edition  v1.2.1
+    Community Edition  v1.3.0
   ────────────────────────────────
   Domain-agnostic LLM wiki engine
 ```
@@ -34,7 +34,7 @@
 <a href="https://github.com/axoviq-ai/synthadoc"><img src="https://img.shields.io/badge/Community%20Edition-v1.2.1-brightgreen.svg" alt="Version"/></a>
 </p>
 
-**Document version: v1.2.1**
+**Document version: v1.3.0**
 
 **Engineered for solo users and enterprises alike, providing a domain-specific knowledge base that scales seamlessly while maintaining accuracy through autonomous self-optimization.**
 
@@ -115,13 +115,13 @@ Most knowledge-management tools retrieve and summarize at query time. Synthadoc 
 
 **Long-term alignment:**
 
-| Direction                | How Synthadoc moves there                                                                                                                                                                                               |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Agent orchestration      | Orchestrator dispatches parallel ingest, query, and lint sub-agents with cost guards and retry backoff                                                                                                       |
-| Sub-agent skills/plugins | Featuring a 3-tier lazy-load capability system, the platform allows for the injection of custom skills and hooks via a plug-and-play interface, ensuring core stability is never compromised during extension           |
-| LLM wiki vs. RAG         | Pre-compiled structured knowledge beats query-time synthesis for contradiction detection, graph traversal, and offline access                                                                                           |
-| CLI / HTTP               | A unified interface via CLI and RESTful endpoints, the system streamlines full-spectrum integration: from data ingestion and querying to automated linting, security auditing, and job orchestration                    |
-| Local-first              | All data stays on your machine; localhost-only network binding; no cloud dependency except the LLM API itself                                                                                                           |
+| Direction                | How Synthadoc moves there                                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent orchestration      | Orchestrator dispatches parallel ingest, query, and lint sub-agents with cost guards and retry backoff                                                                                                                                            |
+| Sub-agent skills/plugins | Featuring a 3-tier lazy-load capability system, the platform allows for the injection of custom skills and hooks via a plug-and-play interface, ensuring core stability is never compromised during extension                                     |
+| LLM wiki vs. RAG         | Pre-compiled structured knowledge beats query-time synthesis for contradiction detection, graph traversal, and offline access                                                                                                                     |
+| CLI / HTTP               | A unified interface via CLI and RESTful endpoints, the system streamlines full-spectrum integration: from data ingestion and querying to automated linting, security auditing, and job orchestration                                              |
+| Local-first              | All data stays on your machine; localhost-only network binding; no cloud dependency except the LLM API itself                                                                                                                                     |
 | Provider choice          | LLM backends including free-tier Gemini and Groq, paid Anthropic/OpenAI/DeepSeek/MiniMax/Qwen (DashScope), local Ollama and Qwen, and coding-tool CLI providers (Claude Code, Opencode) — no API key required if you already have a subscription |
 
 ---
@@ -130,19 +130,19 @@ Most knowledge-management tools retrieve and summarize at query time. Synthadoc 
 
 RAG retrieves document chunks at query time. Synthadoc **compiles** knowledge at ingest — synthesising sources into a linked, audited wiki graph so contradictions are caught, claims are traced to sources, and the artifact survives outside the tool.
 
-| Problem | Synthadoc approach |
-| --- | --- |
-| **Contradictions blended silently** | Ingest-time conflict detection; page flagged `status: contradicted`; auto-resolve or queue for human review |
-| **No links between related content** | `[[wikilinks]]` auto-built on every ingest pass; weighted graph (wikilink + co-source signals) with Louvain clustering in web UI |
-| **Orphan pages never surfaced** | Lint reports unreferenced pages with ready-to-paste index entries |
-| **LLM output can be overconfident** | Adversarial second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page |
-| **Claims lack source traceability** | `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint |
-| **Knowledge lifecycle invisible** | 5-state machine (`draft → active → contradicted / stale → archived`); auto-transitions via lint; immutable event log |
-| **Repeat ingest is expensive** | 3-layer cache (embedding, LLM, provider prompt) — repeat lint on unchanged pages costs near-zero tokens |
-| **Knowledge locked in proprietary tools** | Plain Markdown + YAML frontmatter; OKF v0.1 compatible; fully offline-readable in any editor |
-| **Wiki structure drifts with growth** | `scaffold` regenerates index, AGENTS.md, and purpose.md from current wiki state without touching linked pages |
-| **Migration requires full re-ingestion** | Single-zip backup + restore with port/domain rewriting; no re-ingestion needed |
-| **Cost and compliance exposure** | Localhost-only; per-job token+cost log; configurable soft-warn and hard-gate thresholds |
+| Problem                                   | Synthadoc approach                                                                                                               |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Contradictions blended silently**       | Ingest-time conflict detection; page flagged`status: contradicted`; auto-resolve or queue for human review                       |
+| **No links between related content**      | `[[wikilinks]]` auto-built on every ingest pass; weighted graph (wikilink + co-source signals) with Louvain clustering in web UI |
+| **Orphan pages never surfaced**           | Lint reports unreferenced pages with ready-to-paste index entries                                                                |
+| **LLM output can be overconfident**       | Adversarial second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page                    |
+| **Claims lack source traceability**       | `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint                      |
+| **Knowledge lifecycle invisible**         | 5-state machine (`draft → active → contradicted / stale → archived`); auto-transitions via lint; immutable event log          |
+| **Repeat ingest is expensive**            | 3-layer cache (embedding, LLM, provider prompt) — repeat lint on unchanged pages costs near-zero tokens                         |
+| **Knowledge locked in proprietary tools** | Plain Markdown + YAML frontmatter; OKF v0.1 compatible; fully offline-readable in any editor                                     |
+| **Wiki structure drifts with growth**     | `scaffold` regenerates index, AGENTS.md, and purpose.md from current wiki state without touching linked pages                    |
+| **Migration requires full re-ingestion**  | Single-zip backup + restore with port/domain rewriting; no re-ingestion needed                                                   |
+| **Cost and compliance exposure**          | Localhost-only; per-job token+cost log; configurable soft-warn and hard-gate thresholds                                          |
 
 > **Citation quality:** Generated pages include inline citations linking every claim to its source lines. Pages without citations trigger a model-compatibility warning — use Gemini 2.5 Flash or higher for reliable citation annotation.
 >
@@ -156,80 +156,80 @@ Every **Yes** below is a built-in feature — no add-ons or upgrades required.
 
 ### Knowledge Quality
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Ingest-time synthesis](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#ingestagent)** — sources compiled into the wiki at ingest; not re-summarised at query time | **Yes** | No | Partial | No |
-| **[Contradiction detection & resolution](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-9--resolve-a-contradiction)** — conflicting claims flagged `status: contradicted`; auto-resolve available; full conflict history | **Yes** | No | No | No |
-| **[Adversarial claim review + gate](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-11--run-the-adversarial-review)** — concurrent second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page; configurable gate auto-demotes pages that exceed the warning threshold to `contradicted` | **Yes** | No | No | No |
-| **[Claim-level provenance](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-20--establish-claim-level-provenance)** — `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint | **Yes** | No | Partial | No |
-| **[5-state lifecycle machine](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-8--manage-page-lifecycle)** — `draft → active → contradicted / stale → archived`; auto-transitions via lint; immutable event log; cascade link cleanup on archive; only `active` and `stale` pages enter the BM25 search index | **Yes** | No | No | No |
-| **[Pre-LLM source sanitizer](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#29-pre-llm-source-sanitizer)** — strips zero-width chars, bidi overrides, hidden HTML, and instruction-override phrases before any LLM call | **Yes** | No | No | No |
+| Capability                                                                                                                                                                                                                                                                                                          | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- | ---------- | --------- |
+| **[Ingest-time synthesis](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#ingestagent)** — sources compiled into the wiki at ingest; not re-summarised at query time                                                                                                                                                                                | **Yes**   | No          | Partial    | No        |
+| **[Contradiction detection & resolution](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-9--resolve-a-contradiction)** — conflicting claims flagged `status: contradicted`; auto-resolve available; full conflict history                                                                                                      | **Yes**   | No          | No         | No        |
+| **[Adversarial claim review + gate](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-11--run-the-adversarial-review)** — concurrent second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page; configurable gate auto-demotes pages that exceed the warning threshold to `contradicted` | **Yes**   | No          | No         | No        |
+| **[Claim-level provenance](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-20--establish-claim-level-provenance)** — `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint                                                                                               | **Yes**   | No          | Partial    | No        |
+| **[5-state lifecycle machine](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-8--manage-page-lifecycle)** — `draft → active → contradicted / stale → archived`; auto-transitions via lint; immutable event log; cascade link cleanup on archive; only `active` and `stale` pages enter the BM25 search index                | **Yes**   | No          | No         | No        |
+| **[Pre-LLM source sanitizer](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#29-pre-llm-source-sanitizer)** — strips zero-width chars, bidi overrides, hidden HTML, and instruction-override phrases before any LLM call                                                                                                                            | **Yes**   | No          | No         | No        |
 
 ### Knowledge Structure
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Weighted knowledge graph + D3 visualisation](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-24--knowledge-graph)** — `[[wikilinks]]` auto-built at ingest; co-source edges connect pages compiled from the same document; edge thickness reflects combined weight; dashed edges for co-source-only relationships; Louvain cluster colouring; click node to query; Obsidian graph panel: same graph inside Obsidian via Canvas, type filter, click node to open page | **Yes** | No | Partial | No |
-| **[Orphan page detection](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-10--fix-an-orphan-page)** — unreferenced pages surfaced by lint with ready-to-paste index entries | **Yes** | No | No | No |
-| **[Query-scoped routing](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-17--set-up-routingmd--scoped-search)** — ROUTING.md maps wiki branches to page slugs; queries auto-select relevant branches; new pages auto-slotted | **Yes** | No | No | No |
-| **[Candidates staging](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-18--configure-candidates-staging)** — ingest pages to a staging area first; review, promote, or discard before they enter the live wiki | **Yes** | No | No | No |
-| **[Scaffold automation](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-14--enrich-the-wiki-with-scaffold)** — regenerates index categories, AGENTS.md/CLAUDE.md/GEMINI.md, and purpose.md from current wiki state; protected pages never overwritten | **Yes** | No | No | No |
+| Capability                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ----------- | ---------- | --------- |
+| **[Weighted knowledge graph + D3 visualisation](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-24--knowledge-graph)** — `[[wikilinks]]` auto-built at ingest; co-source edges connect pages compiled from the same document; edge thickness reflects combined weight; dashed edges for co-source-only relationships; Louvain cluster colouring; click node to query; Obsidian graph panel: same graph inside Obsidian via Canvas, type filter, click node to open page | **Yes**   | No          | Partial    | No        |
+| **[Orphan page detection](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-10--fix-an-orphan-page)** — unreferenced pages surfaced by lint with ready-to-paste index entries                                                                                                                                                                                                                                                                                             | **Yes**   | No          | No         | No        |
+| **[Query-scoped routing](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-17--set-up-routingmd--scoped-search)** — ROUTING.md maps wiki branches to page slugs; queries auto-select relevant branches; new pages auto-slotted                                                                                                                                                                                                                                            | **Yes**   | No          | No         | No        |
+| **[Candidates staging](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-18--configure-candidates-staging)** — ingest pages to a staging area first; review, promote, or discard before they enter the live wiki                                                                                                                                                                                                                                                          | **Yes**   | No          | No         | No        |
+| **[Scaffold automation](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-14--enrich-the-wiki-with-scaffold)** — regenerates index categories, AGENTS.md/CLAUDE.md/GEMINI.md, and purpose.md from current wiki state; protected pages never overwritten                                                                                                                                                                                                                   | **Yes**   | No          | No         | No        |
 
 ### Search & Query
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Query decomposition + gap detection](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#knowledge-gap-detection)** — compound questions split into parallel BM25 sub-queries; thin results trigger a knowledge-gap callout with suggested web searches | **Yes** | Partial | No | No |
-| **[BM25 TF fallback + compound identifier search](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#queryagent)** — reliable results on small corpora (IDF collapse → TF fallback); underscore identifiers expanded at index and query time so `capex growth` matches `capex_growth` | **Yes** | No | No | No |
-| **[Web search → wiki pages](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — Tavily search fans out into parallel URL ingest jobs; gap callout in web UI suggests searches inline | **Yes** | No | No | No |
-| **[Semantic re-ranking](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#semantic-re-ranking)** — optional vector re-ranking (`BAAI/bge-small-en-v1.5`) improves recall on conceptually related queries; BM25 stays as fallback | **Yes** (optional) | Varies | No | No |
-| **[Streaming output + query cache](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-23--query-caching)** — token-by-token streaming; cache key = question + wiki version; auto-invalidates on ingest or lifecycle change | **Yes** | Partial | Partial | Partial |
-| **[Proportional context budget](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#31-proportional-context-budget)** — sources allocated proportionally to model context window (60 % wiki / 20 % history / 15 % system / 5 % index); replaces fixed top-N cap | **Yes** | No | No | No |
+| Capability                                                                                                                                                                                                                                          | Synthadoc          | Typical RAG | NotebookLM | Notion AI |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- | ---------- | --------- |
+| **[Query decomposition + gap detection](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#knowledge-gap-detection)** — compound questions split into parallel BM25 sub-queries; thin results trigger a knowledge-gap callout with suggested web searches              | **Yes**            | Partial     | No         | No        |
+| **[BM25 TF fallback + compound identifier search](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#queryagent)** — reliable results on small corpora (IDF collapse → TF fallback); underscore identifiers expanded at index and query time so `capex growth` matches `capex_growth` | **Yes**            | No          | No         | No        |
+| **[Web search → wiki pages](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — Tavily search fans out into parallel URL ingest jobs; gap callout in web UI suggests searches inline                                                | **Yes**            | No          | No         | No        |
+| **[Semantic re-ranking](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#semantic-re-ranking)** — optional vector re-ranking (`BAAI/bge-small-en-v1.5`) improves recall on conceptually related queries; BM25 stays as fallback                                                      | **Yes** (optional) | Varies      | No         | No        |
+| **[Streaming output + query cache](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-23--query-caching)** — token-by-token streaming; cache key = question + wiki version; auto-invalidates on ingest or lifecycle change                                        | **Yes**            | Partial     | Partial    | Partial   |
+| **[Proportional context budget](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#31-proportional-context-budget)** — sources allocated proportionally to model context window (60 % wiki / 20 % history / 15 % system / 5 % index); replaces fixed top-N cap                         | **Yes**            | No          | No         | No        |
 
 ### Interfaces & Integration
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Obsidian integration](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-3--open-the-vault-in-obsidian)** — native plugin: ingest modal, streaming query, lint report, lifecycle controls, context pack builder, provenance viewer, export modal, **knowledge graph panel** (Canvas force graph, type filter, hover tooltip, click-to-open page); **background vault monitoring** (auto-snapshot on every file save, 2 s debounce, dedup so unchanged saves are free); Reading View set as default on install so citation chips are visible immediately | **Yes** | No | No | No |
-| **[Web chat UI](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-22--use-the-web-chat-ui)** — `synthadoc web`: streaming answers, session sidebar, multi-turn history, knowledge-gap callouts, knowledge graph tab | **Yes** | No | Yes | Yes |
-| **[MCP server](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#27-mcp-server)** — 12 tools; Claude Desktop (stdio), Claude Code (SSE), n8n/LangGraph (HTTP/SSE); brain+memory architecture; no double-LLM cost for reads | **Yes** | No | No | No |
-| **[Context packs](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-19--build-a-context-pack)** — goal → sub-questions → token-budget evidence pack; REST + MCP callable; paste into any LLM chat as grounded context | **Yes** | No | No | No |
-| **[Export formats](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-21--export-your-wiki)** — `llms.txt`, `llms-full.txt`, GraphML, JSON (provenance + lifecycle), OKF v0.1 bundle; lifecycle-filtered; zero extra LLM calls | **Yes** | No | Partial | No |
-| **[Multi-platform agent skill files](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#multi-platform-agent-skill-files)** — `AGENTS.md` (Codex/OpenCode), `CLAUDE.md` (Claude Code), `GEMINI.md` (Gemini CLI); all include full CLI quick-reference, domain guidelines, MCP tool table; regenerated by `scaffold` | **Yes** | No | No | No |
+| Capability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- | ---------- | --------- |
+| **[Obsidian integration](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-3--open-the-vault-in-obsidian)** — native plugin: ingest modal, streaming query, lint report, lifecycle controls, context pack builder, provenance viewer, export modal, **knowledge graph panel** (Canvas force graph, type filter, hover tooltip, click-to-open page); **background vault monitoring** (auto-snapshot on every file save, 2 s debounce, dedup so unchanged saves are free); Reading View set as default on install so citation chips are visible immediately | **Yes**   | No          | No         | No        |
+| **[Web chat UI](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-22--use-the-web-chat-ui)** — `synthadoc web`: streaming answers, session sidebar, multi-turn history, knowledge-gap callouts, knowledge graph tab                                                                                                                                                                                                                                                                                                                                       | **Yes**   | No          | Yes        | Yes       |
+| **[MCP server](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#27-mcp-server)** — 12 tools; Claude Desktop (stdio), Claude Code (SSE), n8n/LangGraph (HTTP/SSE); brain+memory architecture; no double-LLM cost for reads                                                                                                                                                                                                                                                                                                                                                     | **Yes**   | No          | No         | No        |
+| **[Context packs](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-19--build-a-context-pack)** — goal → sub-questions → token-budget evidence pack; REST + MCP callable; paste into any LLM chat as grounded context                                                                                                                                                                                                                                                                                                                                   | **Yes**   | No          | No         | No        |
+| **[Export formats](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-21--export-your-wiki)** — `llms.txt`, `llms-full.txt`, GraphML, JSON (provenance + lifecycle), OKF v0.1 bundle; lifecycle-filtered; zero extra LLM calls                                                                                                                                                                                                                                                                                                                             | **Yes**   | No          | Partial    | No        |
+| **[Multi-platform agent skill files](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#multi-platform-agent-skill-files)** — `AGENTS.md` (Codex/OpenCode), `CLAUDE.md` (Claude Code), `GEMINI.md` (Gemini CLI); all include full CLI quick-reference, domain guidelines, MCP tool table; regenerated by `scaffold`                                                                                                                                                                                                                                                             | **Yes**   | No          | No         | No        |
 
 ### Content Sources
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Multi-format ingest](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#built-in-skills)** — PDF, DOCX, PPTX, XLSX/CSV, Markdown, TXT, images (vision), web URLs, YouTube transcripts, AI session transcripts (.jsonl) | **Yes** | Varies | Partial | Partial |
-| **[Web search decomposition](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — broad topics decomposed into focused Tavily keyword searches; results merged and deduplicated | **Yes** | No | No | Partial |
-| **[YouTube transcript ingest](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-13--ingest-a-youtube-video)** — timestamped transcript + executive summary; no API key; auto-generated captions supported | **Yes** | No | Yes | No |
-| **[Multilingual / CJK queries](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#queryagent)** — Chinese, Japanese, Korean — no false knowledge gaps | **Yes** | Limited | No | No |
-| **[Multiple LLM providers + coding tools](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#appendix-c--switching-llm-providers)** — Gemini, Groq, Qwen, MiniMax, DeepSeek, Anthropic, OpenAI, Ollama; Claude Code and Opencode (no API key needed) | **Yes** | No | No | No |
+| Capability                                                                                                                                                                                                                        | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- | ---------- | --------- |
+| **[Multi-format ingest](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#built-in-skills)** — PDF, DOCX, PPTX, XLSX/CSV, Markdown, TXT, images (vision), web URLs, YouTube transcripts, AI session transcripts (.jsonl)                                            | **Yes**   | Varies      | Partial    | Partial   |
+| **[Web search decomposition](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — broad topics decomposed into focused Tavily keyword searches; results merged and deduplicated                                     | **Yes**   | No          | No         | Partial   |
+| **[YouTube transcript ingest](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-13--ingest-a-youtube-video)** — timestamped transcript + executive summary; no API key; auto-generated captions supported                                      | **Yes**   | No          | Yes        | No        |
+| **[Multilingual / CJK queries](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#queryagent)** — Chinese, Japanese, Korean — no false knowledge gaps                                                                                                               | **Yes**   | Limited     | No         | No        |
+| **[Multiple LLM providers + coding tools](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#appendix-c--switching-llm-providers)** — Gemini, Groq, Qwen, MiniMax, DeepSeek, Anthropic, OpenAI, Ollama; Claude Code and Opencode (no API key needed) | **Yes**   | No          | No         | No        |
 
 ### Operations & Trust
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **Local-first + offline artifact** — source documents never leave your machine; compiled wiki is plain Markdown, fully readable offline in any editor without the server | **Yes** | Varies | No | No |
-| **[Portable backup / restore](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#28-backup--restore)** — single zip: wiki pages + audit/lifecycle DB + config; port and domain rewriting on restore; migrate machines without re-ingesting | **Yes** | No — re-ingest required | No — AI metadata lost | No |
-| **[Lifecycle content snapshots + rollback](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#snapshots-and-content-recovery)** — page body captured at every lifecycle transition (manual CLI/Obsidian, lint-driven auto-transition, or Obsidian vault save); deduplicated so unchanged saves cost nothing; browse per-page version history with `lifecycle history` (newest-first, with reason); restore any prior version with `lifecycle rollback`; rollback saves the current body first so it is always undoable | **Yes** | No | No | Partial — Notion has time-based edit history (plan-gated, no lifecycle tie, no auditable rollback) |
-| **[Cost guard + full audit trail](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-15--audit-features)** — per-job token + cost log; soft-warn and hard-gate thresholds; `audit citations` validates every claim citation; immutable event log | **Yes** | No | No | No |
-| **[Resumable job queue + retry](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#14-job-queue)** — every ingest/lint job persisted with status and error; batch a hundred documents and resume after a crash | **Yes** | No | No | No |
-| **[Custom skills + CI hooks](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#11-hook-system)** — subclass `BaseSkill` for new file formats; 2 hook events (`on_ingest_complete` + `on_lint_complete`); example git auto-commit hook included; blocking hooks can gate operations | **Yes** | Limited | No | No |
-| **[Per-source truncation flag](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#30-per-source-truncation-flag)** — `--max-source-chars` caps any source (PDF, DOCX, web page, plain text) before the LLM call; truncated sources flagged with `truncated: true` in frontmatter and warned in lint output | **Yes** | No | No | No |
-| **[Multi-wiki isolation](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#wiki-targeting)** — each wiki on its own port with independent config, audit trail, and job queue; switch with `synthadoc use` | **Yes** | No | Partial | No |
-| **[Agentic maintenance workflows](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#agentic-workflows)** — six conversational workflows (re-ingest stale pages, re-ingest by slug, broken wikilinks scan and fix, lint report, scaffold regeneration, **contradiction resolver**) via web UI, Obsidian query modal, or `synthadoc query` CLI; confirm-before-act gate on all destructive operations; contradiction resolver shows full diff before every write and never applies a change without approval; graph sidebar chips trigger workflows with one click — no terminal required | **Yes** | No | No | No |
+| Capability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Synthadoc | Typical RAG              | NotebookLM             | Notion AI                                                                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------ | ---------------------- | --------------------------------------------------------------------------------------------------- |
+| **Local-first + offline artifact** — source documents never leave your machine; compiled wiki is plain Markdown, fully readable offline in any editor without the server                                                                                                                                                                                                                                                                                                                                                                                              | **Yes**   | Varies                   | No                     | No                                                                                                  |
+| **[Portable backup / restore](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#28-backup--restore)** — single zip: wiki pages + audit/lifecycle DB + config; port and domain rewriting on restore; migrate machines without re-ingesting                                                                                                                                                                                                                                                                                                                                                                | **Yes**   | No — re-ingest required | No — AI metadata lost | No                                                                                                  |
+| **[Lifecycle content snapshots + rollback](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#snapshots-and-content-recovery)** — page body captured at every lifecycle transition (manual CLI/Obsidian, lint-driven auto-transition, or Obsidian vault save); deduplicated so unchanged saves cost nothing; browse per-page version history with `lifecycle history` (newest-first, with reason); restore any prior version with `lifecycle rollback`; rollback saves the current body first so it is always undoable                                                                    | **Yes**   | No                       | No                     | Partial — Notion has time-based edit history (plan-gated, no lifecycle tie, no auditable rollback) |
+| **[Cost guard + full audit trail](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-15--audit-features)** — per-job token + cost log; soft-warn and hard-gate thresholds; `audit citations` validates every claim citation; immutable event log                                                                                                                                                                                                                                                                                                                                     | **Yes**   | No                       | No                     | No                                                                                                  |
+| **[Resumable job queue + retry](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#14-job-queue)** — every ingest/lint job persisted with status and error; batch a hundred documents and resume after a crash                                                                                                                                                                                                                                                                                                                                                                                            | **Yes**   | No                       | No                     | No                                                                                                  |
+| **[Custom skills + CI hooks](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#11-hook-system)** — subclass `BaseSkill` for new file formats; 2 hook events (`on_ingest_complete` + `on_lint_complete`); example git auto-commit hook included; blocking hooks can gate operations                                                                                                                                                                                                                                                                                                                       | **Yes**   | Limited                  | No                     | No                                                                                                  |
+| **[Per-source truncation flag](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#30-per-source-truncation-flag)** — `--max-source-chars` caps any source (PDF, DOCX, web page, plain text) before the LLM call; truncated sources flagged with `truncated: true` in frontmatter and warned in lint output                                                                                                                                                                                                                                                                                                | **Yes**   | No                       | No                     | No                                                                                                  |
+| **[Multi-wiki isolation](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#wiki-targeting)** — each wiki on its own port with independent config, audit trail, and job queue; switch with `synthadoc use`                                                                                                                                                                                                                                                                                                                                                                                                | **Yes**   | No                       | Partial                | No                                                                                                  |
+| **[Agentic maintenance workflows](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#agentic-workflows)** — six conversational workflows (re-ingest stale pages, re-ingest by slug, broken wikilinks scan and fix, lint report, scaffold regeneration, **contradiction resolver**) via web UI, Obsidian query modal, or `synthadoc query` CLI; confirm-before-act gate on all destructive operations; contradiction resolver shows full diff before every write and never applies a change without approval; graph sidebar chips trigger workflows with one click — no terminal required | **Yes**   | No                       | No                     | No                                                                                                  |
 
 ### Business value
 
-| Value | How |
-| --- | --- |
-| **Faster onboarding** | New team members query the wiki instead of digging through documents |
-| **Audit trail** | Every ingest recorded in `audit.db` with source hash, token count, and timestamp |
-| **Cost control** | Configurable thresholds; 3-layer cache reduces repeat spend |
-| **Compliance** | Local-first — source documents and compiled knowledge never leave your machine |
-| **Extensibility** | Hooks fire on every event; custom skills load without a server restart |
+| Value                 | How                                                                             |
+| --------------------- | ------------------------------------------------------------------------------- |
+| **Faster onboarding** | New team members query the wiki instead of digging through documents            |
+| **Audit trail**       | Every ingest recorded in`audit.db` with source hash, token count, and timestamp |
+| **Cost control**      | Configurable thresholds; 3-layer cache reduces repeat spend                     |
+| **Compliance**        | Local-first — source documents and compiled knowledge never leave your machine |
+| **Extensibility**     | Hooks fire on every event; custom skills load without a server restart          |
 
 ---
 
@@ -313,18 +313,18 @@ cd ..
 
 Synthadoc defaults to **Gemini Flash** — free tier, no credit card, 1 million tokens per day. Get a key at **aistudio.google.com/app/apikey** (click "Create API key").
 
-| Provider         | Free tier                                                | Vision          | Get key                                                           |
-| ---------------- | -------------------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| **Gemini Flash** | Yes — 15 RPM / 1M tokens/day, no credit card            | Yes             | [aistudio.google.com](https://aistudio.google.com/app/apikey)    |
-| Groq             | Yes — rate-limited                                       | No              | [console.groq.com](https://console.groq.com/keys)                |
-| Ollama           | Yes — runs locally, no key (**GPU required**)            | Model-dependent | [ollama.com](https://ollama.com)                                  |
-| Qwen             | Yes — 1M free tokens (90-day trial), then paid DashScope | Model-dependent | [bailian.console.aliyun.com](https://bailian.console.aliyun.com/) |
-| MiniMax          | No — pay-per-token                                       | Yes             | [platform.minimax.io](https://platform.minimax.io/)               |
-| DeepSeek         | No — pay-per-token (very cheap text rates)               | No              | [platform.deepseek.com](https://platform.deepseek.com/api_keys)  |
-| Anthropic        | No                                                       | Yes             | [console.anthropic.com](https://console.anthropic.com/)           |
-| OpenAI           | No                                                       | Yes             | [platform.openai.com](https://platform.openai.com/api-keys)      |
-| **Claude Code**  | Included with subscription — no API key                  | No              | Set `provider = "claude-code"` in config.toml                    |
-| **Opencode**     | Free via Opencode Zen — no API key                       | No              | Set `provider = "opencode", model = "opencode/big-pickle"` in config.toml; connect first: run `opencode` → `/connect` → select Zen |
+| Provider         | Free tier                                                 | Vision          | Get key                                                                                                                             |
+| ---------------- | --------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Gemini Flash** | Yes — 15 RPM / 1M tokens/day, no credit card             | Yes             | [aistudio.google.com](https://aistudio.google.com/app/apikey)                                                                       |
+| Groq             | Yes — rate-limited                                       | No              | [console.groq.com](https://console.groq.com/keys)                                                                                   |
+| Ollama           | Yes — runs locally, no key (**GPU required**)            | Model-dependent | [ollama.com](https://ollama.com)                                                                                                    |
+| Qwen             | Yes — 1M free tokens (90-day trial), then paid DashScope | Model-dependent | [bailian.console.aliyun.com](https://bailian.console.aliyun.com/)                                                                   |
+| MiniMax          | No — pay-per-token                                       | Yes             | [platform.minimax.io](https://platform.minimax.io/)                                                                                 |
+| DeepSeek         | No — pay-per-token (very cheap text rates)               | No              | [platform.deepseek.com](https://platform.deepseek.com/api_keys)                                                                     |
+| Anthropic        | No                                                        | Yes             | [console.anthropic.com](https://console.anthropic.com/)                                                                             |
+| OpenAI           | No                                                        | Yes             | [platform.openai.com](https://platform.openai.com/api-keys)                                                                         |
+| **Claude Code**  | Included with subscription — no API key                  | No              | Set`provider = "claude-code"` in config.toml                                                                                        |
+| **Opencode**     | Free via Opencode Zen — no API key                       | No              | Set`provider = "opencode", model = "opencode/big-pickle"` in config.toml; connect first: run `opencode` → `/connect` → select Zen |
 
 ```bash
 # macOS / Linux — add to ~/.bashrc or ~/.zshrc to persist
@@ -459,13 +459,13 @@ synthadoc status                        # confirm the wiki registered correctly 
 
 `--domain` is a free-text description of the subject area — the LLM uses it to generate five domain-aware starter files via scaffold:
 
-| File                | Purpose                                                                     |
-| ------------------- | --------------------------------------------------------------------------- |
-| `wiki/index.md`     | Table of contents — domain-relevant categories with `[[wikilinks]]`        |
-| `wiki/purpose.md`   | Scope declaration — used by the ingest agent to filter out-of-scope sources at ingest time, and injected as a pinned preamble into every query synthesis prompt so the LLM understands the wiki's domain boundaries when answering |
-| `AGENTS.md`         | LLM behaviour guidelines (tone, terminology, synthesis style) — read by Codex CLI, OpenCode, and generic OpenAI Agents tooling |
-| `CLAUDE.md`         | Same content as `AGENTS.md` — loaded automatically by Claude Code when the wiki folder is open |
-| `GEMINI.md`         | Same content as `AGENTS.md` — loaded automatically by Gemini CLI |
+| File              | Purpose                                                                                                                                                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wiki/index.md`   | Table of contents — domain-relevant categories with`[[wikilinks]]`                                                                                                                                                                 |
+| `wiki/purpose.md` | Scope declaration — used by the ingest agent to filter out-of-scope sources at ingest time, and injected as a pinned preamble into every query synthesis prompt so the LLM understands the wiki's domain boundaries when answering |
+| `AGENTS.md`       | LLM behaviour guidelines (tone, terminology, synthesis style) — read by Codex CLI, OpenCode, and generic OpenAI Agents tooling                                                                                                     |
+| `CLAUDE.md`       | Same content as`AGENTS.md` — loaded automatically by Claude Code when the wiki folder is open                                                                                                                                      |
+| `GEMINI.md`       | Same content as`AGENTS.md` — loaded automatically by Gemini CLI                                                                                                                                                                    |
 
 `wiki/dashboard.md` is also created during install (a static template — not LLM-generated). `ROUTING.md` is optional and generated separately via `synthadoc routing init` after pages accumulate.
 
@@ -956,23 +956,23 @@ synthadoc schedule history --limit 50 -w my-wiki
 
 **Cron expression format:** `minute  hour  day-of-month  month  day-of-week`
 
-| Field | Range | Examples |
-|-------|-------|---------|
-| minute | 0–59 | `0` = on the hour |
-| hour | 0–23 | `2` = 2 AM, `22` = 10 PM |
-| day of month | 1–31 | `*` = every day |
-| month | 1–12 | `*` = every month |
-| day of week | 0–6 | `0` = Sunday, `1` = Monday |
+| Field        | Range | Examples                   |
+| ------------ | ----- | -------------------------- |
+| minute       | 0–59 | `0` = on the hour          |
+| hour         | 0–23 | `2` = 2 AM, `22` = 10 PM   |
+| day of month | 1–31 | `*` = every day            |
+| month        | 1–12 | `*` = every month          |
+| day of week  | 0–6  | `0` = Sunday, `1` = Monday |
 
 Common schedules:
 
-| Expression | Meaning |
-|------------|---------|
-| `0 2 * * *` | Every day at 2 AM |
-| `0 22 * * *` | Every night at 10 PM |
-| `0 3 * * 0` | Every Sunday at 3 AM |
-| `0 */6 * * *` | Every 6 hours |
-| `30 8 * * 1-5` | Weekdays at 8:30 AM |
+| Expression     | Meaning              |
+| -------------- | -------------------- |
+| `0 2 * * *`    | Every day at 2 AM    |
+| `0 22 * * *`   | Every night at 10 PM |
+| `0 3 * * 0`    | Every Sunday at 3 AM |
+| `0 */6 * * *`  | Every 6 hours        |
+| `30 8 * * 1-5` | Weekdays at 8:30 AM  |
 
 ### Routing
 
@@ -1258,4 +1258,5 @@ Custom skills, LLM providers, hooks, cache control, and per-wiki AGENTS.md are d
 - Design document: [docs/design.md](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md)
 - Customization: [docs/design.md — Customization](https://github.com/axoviq-ai/synthadoc/blob/main/docs/design.md#customization)
 - Quick-Start Guide: [docs/user-quick-start-guide.md](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md)
+
 - GitHub: [axoviq-ai/synthadoc](https://github.com/axoviq-ai/synthadoc)

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -777,23 +777,32 @@ synthadoc lint report -w my-wiki
 Agentic workflows run as interactive tool-call loops — they stream progress inline, ask for approval before any destructive change, and exit cleanly if you decline.
 
 ```bash
-# Resolve all contradicted pages (shows cost estimate + diff for each page before writing)
-synthadoc workflow run contradiction-resolver -w my-wiki
+# List all available workflows (with descriptions and accepted parameters)
+synthadoc workflow list
+
+# Run a workflow by name
+synthadoc workflow run --name lint-report -w my-wiki
+synthadoc workflow run --name broken-wikilinks -w my-wiki
+synthadoc workflow run --name scaffold -w my-wiki
+synthadoc workflow run --name ingest-lint -w my-wiki
+
+# Contradiction resolver — resolve all contradicted pages
+synthadoc workflow run --name contradiction-resolver -w my-wiki
 
 # Resolve only one page by slug
-synthadoc workflow run contradiction-resolver --slug alan-turing -w my-wiki
+synthadoc workflow run --name contradiction-resolver --slug alan-turing -w my-wiki
 
 # Scope to pages demoted by the adversarial gate
-synthadoc workflow run contradiction-resolver --type adversarial -w my-wiki
+synthadoc workflow run --name contradiction-resolver --type adversarial -w my-wiki
 
 # Scope to pages with source-level contradictions
-synthadoc workflow run contradiction-resolver --type source-conflict -w my-wiki
+synthadoc workflow run --name contradiction-resolver --type source-conflict -w my-wiki
 
 # Custom timeout (default 3600 s)
-synthadoc workflow run contradiction-resolver --timeout 7200 -w my-wiki
+synthadoc workflow run --name contradiction-resolver --timeout 7200 -w my-wiki
 ```
 
-The resolver lists contradicted pages, estimates cost, then walks through each page: reads the content and conflicting sources, proposes a rewrite, shows the full unified diff, and waits for your approval. After an approved write it re-lints the page and promotes it to *active* on pass, or escalates after 3 failed attempts.
+The contradiction resolver lists contradicted pages, estimates cost, then walks through each page: reads the content and conflicting sources, proposes a rewrite, shows the full unified diff, and waits for your approval. After an approved write it re-lints the page and promotes it to *active* on pass, or escalates after 3 failed attempts.
 
 → Full walkthrough and web UI path: [Quick-Start Guide — Step 9](https://github.com/axoviq-ai/synthadoc/blob/main/docs/user-quick-start-guide.md#step-9--resolve-a-contradiction)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
       '-+###############+-'
 
        S Y N T H A D O C
-    Community Edition  v1.2.1
+    Community Edition  v1.3.0
   ────────────────────────────────
   Domain-agnostic LLM wiki engine
 ```
@@ -34,7 +34,7 @@
 <a href="https://github.com/axoviq-ai/synthadoc"><img src="https://img.shields.io/badge/Community%20Edition-v1.2.1-brightgreen.svg" alt="Version"/></a>
 </p>
 
-**Document version: v1.2.1**
+**Document version: v1.3.0**
 
 **Engineered for solo users and enterprises alike, providing a domain-specific knowledge base that scales seamlessly while maintaining accuracy through autonomous self-optimization.**
 
@@ -71,11 +71,12 @@ Synthadoc reads your raw source documents — PDFs, spreadsheets, PPTs, web page
 </table>
 
 <!-- pypi-strip-start -->
+
 <p align="center">
   <a href="docs/media/README.md">📝 Blogs & Media — YouTube · Coderlegion · DEV.to · Medium</a>
 </p>
 <p align="center">
-  <a href="docs/example/aquaflow/README.md">📂 End-to-end Example — AquaFlow Capital M&amp;A due diligence walkthrough</a>
+  <a href="docs/example/aquaflow/README.md">📂 End-to-end Example — AquaFlow Capital M&A due diligence walkthrough</a>
 </p>
 <!-- pypi-strip-end -->
 
@@ -126,13 +127,13 @@ Most knowledge-management tools retrieve and summarize at query time. Synthadoc 
 **Long-term alignment:**
 
 
-| Direction                | How Synthadoc moves there                                                                                                                                                                                               |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Agent orchestration      | Orchestrator dispatches parallel ingest, query, and lint sub-agents with cost guards and retry backoff                                                                                                       |
-| Sub-agent skills/plugins | Featuring a 3-tier lazy-load capability system, the platform allows for the injection of custom skills and hooks via a plug-and-play interface, ensuring core stability is never compromised during extension           |
-| LLM wiki vs. RAG         | Pre-compiled structured knowledge beats query-time synthesis for contradiction detection, graph traversal, and offline access                                                                                           |
-| CLI / HTTP               | A unified interface via CLI and RESTful endpoints, the system streamlines full-spectrum integration: from data ingestion and querying to automated linting, security auditing, and job orchestration                    |
-| Local-first              | All data stays on your machine; localhost-only network binding; no cloud dependency except the LLM API itself                                                                                                           |
+| Direction                | How Synthadoc moves there                                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Agent orchestration      | Orchestrator dispatches parallel ingest, query, and lint sub-agents with cost guards and retry backoff                                                                                                                                            |
+| Sub-agent skills/plugins | Featuring a 3-tier lazy-load capability system, the platform allows for the injection of custom skills and hooks via a plug-and-play interface, ensuring core stability is never compromised during extension                                     |
+| LLM wiki vs. RAG         | Pre-compiled structured knowledge beats query-time synthesis for contradiction detection, graph traversal, and offline access                                                                                                                     |
+| CLI / HTTP               | A unified interface via CLI and RESTful endpoints, the system streamlines full-spectrum integration: from data ingestion and querying to automated linting, security auditing, and job orchestration                                              |
+| Local-first              | All data stays on your machine; localhost-only network binding; no cloud dependency except the LLM API itself                                                                                                                                     |
 | Provider choice          | LLM backends including free-tier Gemini and Groq, paid Anthropic/OpenAI/DeepSeek/MiniMax/Qwen (DashScope), local Ollama and Qwen, and coding-tool CLI providers (Claude Code, Opencode) — no API key required if you already have a subscription |
 
 ---
@@ -141,19 +142,20 @@ Most knowledge-management tools retrieve and summarize at query time. Synthadoc 
 
 RAG retrieves document chunks at query time. Synthadoc **compiles** knowledge at ingest — synthesising sources into a linked, audited wiki graph so contradictions are caught, claims are traced to sources, and the artifact survives outside the tool.
 
-| Problem | Synthadoc approach |
-| --- | --- |
-| **Contradictions blended silently** | Ingest-time conflict detection; page flagged `status: contradicted`; auto-resolve or queue for human review |
-| **No links between related content** | `[[wikilinks]]` auto-built on every ingest pass; weighted graph (wikilink + co-source signals) with Louvain clustering in web UI |
-| **Orphan pages never surfaced** | Lint reports unreferenced pages with ready-to-paste index entries |
-| **LLM output can be overconfident** | Adversarial second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page |
-| **Claims lack source traceability** | `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint |
-| **Knowledge lifecycle invisible** | 5-state machine (`draft → active → contradicted / stale → archived`); auto-transitions via lint; immutable event log |
-| **Repeat ingest is expensive** | 3-layer cache (embedding, LLM, provider prompt) — repeat lint on unchanged pages costs near-zero tokens |
-| **Knowledge locked in proprietary tools** | Plain Markdown + YAML frontmatter; OKF v0.1 compatible; fully offline-readable in any editor |
-| **Wiki structure drifts with growth** | `scaffold` regenerates index, AGENTS.md, and purpose.md from current wiki state without touching linked pages |
-| **Migration requires full re-ingestion** | Single-zip backup + restore with port/domain rewriting; no re-ingestion needed |
-| **Cost and compliance exposure** | Localhost-only; per-job token+cost log; configurable soft-warn and hard-gate thresholds |
+
+| Problem                                   | Synthadoc approach                                                                                                               |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Contradictions blended silently**       | Ingest-time conflict detection; page flagged`status: contradicted`; auto-resolve or queue for human review                       |
+| **No links between related content**      | `[[wikilinks]]` auto-built on every ingest pass; weighted graph (wikilink + co-source signals) with Louvain clustering in web UI |
+| **Orphan pages never surfaced**           | Lint reports unreferenced pages with ready-to-paste index entries                                                                |
+| **LLM output can be overconfident**       | Adversarial second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page                    |
+| **Claims lack source traceability**       | `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint                      |
+| **Knowledge lifecycle invisible**         | 5-state machine (`draft → active → contradicted / stale → archived`); auto-transitions via lint; immutable event log          |
+| **Repeat ingest is expensive**            | 3-layer cache (embedding, LLM, provider prompt) — repeat lint on unchanged pages costs near-zero tokens                         |
+| **Knowledge locked in proprietary tools** | Plain Markdown + YAML frontmatter; OKF v0.1 compatible; fully offline-readable in any editor                                     |
+| **Wiki structure drifts with growth**     | `scaffold` regenerates index, AGENTS.md, and purpose.md from current wiki state without touching linked pages                    |
+| **Migration requires full re-ingestion**  | Single-zip backup + restore with port/domain rewriting; no re-ingestion needed                                                   |
+| **Cost and compliance exposure**          | Localhost-only; per-job token+cost log; configurable soft-warn and hard-gate thresholds                                          |
 
 > **Citation quality:** Generated pages include inline citations linking every claim to its source lines. Pages without citations trigger a model-compatibility warning — use Gemini 2.5 Flash or higher for reliable citation annotation.
 >
@@ -167,80 +169,87 @@ Every **Yes** below is a built-in feature — no add-ons or upgrades required.
 
 ### Knowledge Quality
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Ingest-time synthesis](docs/design.md#ingestagent)** — sources compiled into the wiki at ingest; not re-summarised at query time | **Yes** | No | Partial | No |
-| **[Contradiction detection & resolution](docs/user-quick-start-guide.md#step-9--resolve-a-contradiction)** — conflicting claims flagged `status: contradicted`; auto-resolve available; full conflict history | **Yes** | No | No | No |
-| **[Adversarial claim review + gate](docs/user-quick-start-guide.md#step-11--run-the-adversarial-review)** — concurrent second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page; configurable gate auto-demotes pages that exceed the warning threshold to `contradicted` | **Yes** | No | No | No |
-| **[Claim-level provenance](docs/user-quick-start-guide.md#step-20--establish-claim-level-provenance)** — `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint | **Yes** | No | Partial | No |
-| **[5-state lifecycle machine](docs/user-quick-start-guide.md#step-8--manage-page-lifecycle)** — `draft → active → contradicted / stale → archived`; auto-transitions via lint; immutable event log; cascade link cleanup on archive; only `active` and `stale` pages enter the BM25 search index | **Yes** | No | No | No |
-| **[Pre-LLM source sanitizer](docs/design.md#29-pre-llm-source-sanitizer)** — strips zero-width chars, bidi overrides, hidden HTML, and instruction-override phrases before any LLM call | **Yes** | No | No | No |
+
+| Capability                                                                                                                                                                                                                                                                                                          | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- | ---------- | --------- |
+| **[Ingest-time synthesis](docs/design.md#ingestagent)** — sources compiled into the wiki at ingest; not re-summarised at query time                                                                                                                                                                                | **Yes**   | No          | Partial    | No        |
+| **[Contradiction detection & resolution](docs/user-quick-start-guide.md#step-9--resolve-a-contradiction)** — conflicting claims flagged `status: contradicted`; auto-resolve available; full conflict history                                                                                                      | **Yes**   | No          | No         | No        |
+| **[Adversarial claim review + gate](docs/user-quick-start-guide.md#step-11--run-the-adversarial-review)** — concurrent second-LLM pass flags overstated claims, unsupported superlatives, and contestable facts per page; configurable gate auto-demotes pages that exceed the warning threshold to `contradicted` | **Yes**   | No          | No         | No        |
+| **[Claim-level provenance](docs/user-quick-start-guide.md#step-20--establish-claim-level-provenance)** — `^[file:L-L]` citation on every claim; Source Viewer in Obsidian; PDF page resolution; broken-citation lint                                                                                               | **Yes**   | No          | Partial    | No        |
+| **[5-state lifecycle machine](docs/user-quick-start-guide.md#step-8--manage-page-lifecycle)** — `draft → active → contradicted / stale → archived`; auto-transitions via lint; immutable event log; cascade link cleanup on archive; only `active` and `stale` pages enter the BM25 search index                | **Yes**   | No          | No         | No        |
+| **[Pre-LLM source sanitizer](docs/design.md#29-pre-llm-source-sanitizer)** — strips zero-width chars, bidi overrides, hidden HTML, and instruction-override phrases before any LLM call                                                                                                                            | **Yes**   | No          | No         | No        |
 
 ### Knowledge Structure
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Weighted knowledge graph + D3 visualisation](docs/user-quick-start-guide.md#step-24--knowledge-graph)** — `[[wikilinks]]` auto-built at ingest; co-source edges connect pages compiled from the same document; edge thickness reflects combined weight; dashed edges for co-source-only relationships; Louvain cluster colouring; click node to query; Obsidian graph panel: same graph inside Obsidian via Canvas, type filter, click node to open page | **Yes** | No | Partial | No |
-| **[Orphan page detection](docs/user-quick-start-guide.md#step-10--fix-an-orphan-page)** — unreferenced pages surfaced by lint with ready-to-paste index entries | **Yes** | No | No | No |
-| **[Query-scoped routing](docs/user-quick-start-guide.md#step-17--set-up-routingmd--scoped-search)** — ROUTING.md maps wiki branches to page slugs; queries auto-select relevant branches; new pages auto-slotted | **Yes** | No | No | No |
-| **[Candidates staging](docs/user-quick-start-guide.md#step-18--configure-candidates-staging)** — ingest pages to a staging area first; review, promote, or discard before they enter the live wiki | **Yes** | No | No | No |
-| **[Scaffold automation](docs/user-quick-start-guide.md#step-14--enrich-the-wiki-with-scaffold)** — regenerates index categories, AGENTS.md/CLAUDE.md/GEMINI.md, and purpose.md from current wiki state; protected pages never overwritten | **Yes** | No | No | No |
+
+| Capability                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ----------- | ---------- | --------- |
+| **[Weighted knowledge graph + D3 visualisation](docs/user-quick-start-guide.md#step-24--knowledge-graph)** — `[[wikilinks]]` auto-built at ingest; co-source edges connect pages compiled from the same document; edge thickness reflects combined weight; dashed edges for co-source-only relationships; Louvain cluster colouring; click node to query; Obsidian graph panel: same graph inside Obsidian via Canvas, type filter, click node to open page | **Yes**   | No          | Partial    | No        |
+| **[Orphan page detection](docs/user-quick-start-guide.md#step-10--fix-an-orphan-page)** — unreferenced pages surfaced by lint with ready-to-paste index entries                                                                                                                                                                                                                                                                                             | **Yes**   | No          | No         | No        |
+| **[Query-scoped routing](docs/user-quick-start-guide.md#step-17--set-up-routingmd--scoped-search)** — ROUTING.md maps wiki branches to page slugs; queries auto-select relevant branches; new pages auto-slotted                                                                                                                                                                                                                                            | **Yes**   | No          | No         | No        |
+| **[Candidates staging](docs/user-quick-start-guide.md#step-18--configure-candidates-staging)** — ingest pages to a staging area first; review, promote, or discard before they enter the live wiki                                                                                                                                                                                                                                                          | **Yes**   | No          | No         | No        |
+| **[Scaffold automation](docs/user-quick-start-guide.md#step-14--enrich-the-wiki-with-scaffold)** — regenerates index categories, AGENTS.md/CLAUDE.md/GEMINI.md, and purpose.md from current wiki state; protected pages never overwritten                                                                                                                                                                                                                   | **Yes**   | No          | No         | No        |
 
 ### Search & Query
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Query decomposition + gap detection](docs/user-quick-start-guide.md#knowledge-gap-detection)** — compound questions split into parallel BM25 sub-queries; thin results trigger a knowledge-gap callout with suggested web searches | **Yes** | Partial | No | No |
-| **[BM25 TF fallback + compound identifier search](docs/design.md#queryagent)** — reliable results on small corpora (IDF collapse → TF fallback); underscore identifiers expanded at index and query time so `capex growth` matches `capex_growth` | **Yes** | No | No | No |
-| **[Web search → wiki pages](docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — Tavily search fans out into parallel URL ingest jobs; gap callout in web UI suggests searches inline | **Yes** | No | No | No |
-| **[Semantic re-ranking](docs/design.md#semantic-re-ranking)** — optional vector re-ranking (`BAAI/bge-small-en-v1.5`) improves recall on conceptually related queries; BM25 stays as fallback | **Yes** (optional) | Varies | No | No |
-| **[Streaming output + query cache](docs/user-quick-start-guide.md#step-23--query-caching)** — token-by-token streaming; cache key = question + wiki version; auto-invalidates on ingest or lifecycle change | **Yes** | Partial | Partial | Partial |
-| **[Proportional context budget](docs/design.md#31-proportional-context-budget)** — sources allocated proportionally to model context window (60 % wiki / 20 % history / 15 % system / 5 % index); replaces fixed top-N cap | **Yes** | No | No | No |
+
+| Capability                                                                                                                                                                                                                                          | Synthadoc          | Typical RAG | NotebookLM | Notion AI |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ----------- | ---------- | --------- |
+| **[Query decomposition + gap detection](docs/user-quick-start-guide.md#knowledge-gap-detection)** — compound questions split into parallel BM25 sub-queries; thin results trigger a knowledge-gap callout with suggested web searches              | **Yes**            | Partial     | No         | No        |
+| **[BM25 TF fallback + compound identifier search](docs/design.md#queryagent)** — reliable results on small corpora (IDF collapse → TF fallback); underscore identifiers expanded at index and query time so `capex growth` matches `capex_growth` | **Yes**            | No          | No         | No        |
+| **[Web search → wiki pages](docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — Tavily search fans out into parallel URL ingest jobs; gap callout in web UI suggests searches inline                                                | **Yes**            | No          | No         | No        |
+| **[Semantic re-ranking](docs/design.md#semantic-re-ranking)** — optional vector re-ranking (`BAAI/bge-small-en-v1.5`) improves recall on conceptually related queries; BM25 stays as fallback                                                      | **Yes** (optional) | Varies      | No         | No        |
+| **[Streaming output + query cache](docs/user-quick-start-guide.md#step-23--query-caching)** — token-by-token streaming; cache key = question + wiki version; auto-invalidates on ingest or lifecycle change                                        | **Yes**            | Partial     | Partial    | Partial   |
+| **[Proportional context budget](docs/design.md#31-proportional-context-budget)** — sources allocated proportionally to model context window (60 % wiki / 20 % history / 15 % system / 5 % index); replaces fixed top-N cap                         | **Yes**            | No          | No         | No        |
 
 ### Interfaces & Integration
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Obsidian integration](docs/user-quick-start-guide.md#step-3--open-the-vault-in-obsidian)** — native plugin: ingest modal, streaming query, lint report, lifecycle controls, context pack builder, provenance viewer, export modal, **knowledge graph panel** (Canvas force graph, type filter, hover tooltip, click-to-open page); **background vault monitoring** (auto-snapshot on every file save, 2 s debounce, dedup so unchanged saves are free); Reading View set as default on install so citation chips are visible immediately | **Yes** | No | No | No |
-| **[Web chat UI](docs/user-quick-start-guide.md#step-22--use-the-web-chat-ui)** — `synthadoc web`: streaming answers, session sidebar, multi-turn history, knowledge-gap callouts, knowledge graph tab | **Yes** | No | Yes | Yes |
-| **[MCP server](docs/design.md#27-mcp-server)** — 12 tools; Claude Desktop (stdio), Claude Code (SSE), n8n/LangGraph (HTTP/SSE); brain+memory architecture; no double-LLM cost for reads | **Yes** | No | No | No |
-| **[Context packs](docs/user-quick-start-guide.md#step-19--build-a-context-pack)** — goal → sub-questions → token-budget evidence pack; REST + MCP callable; paste into any LLM chat as grounded context | **Yes** | No | No | No |
-| **[Export formats](docs/user-quick-start-guide.md#step-21--export-your-wiki)** — `llms.txt`, `llms-full.txt`, GraphML, JSON (provenance + lifecycle), OKF v0.1 bundle; lifecycle-filtered; zero extra LLM calls | **Yes** | No | Partial | No |
-| **[Multi-platform agent skill files](docs/design.md#multi-platform-agent-skill-files)** — `AGENTS.md` (Codex/OpenCode), `CLAUDE.md` (Claude Code), `GEMINI.md` (Gemini CLI); all include full CLI quick-reference, domain guidelines, MCP tool table; regenerated by `scaffold` | **Yes** | No | No | No |
+
+| Capability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- | ---------- | --------- |
+| **[Obsidian integration](docs/user-quick-start-guide.md#step-3--open-the-vault-in-obsidian)** — native plugin: ingest modal, streaming query, lint report, lifecycle controls, context pack builder, provenance viewer, export modal, **knowledge graph panel** (Canvas force graph, type filter, hover tooltip, click-to-open page); **background vault monitoring** (auto-snapshot on every file save, 2 s debounce, dedup so unchanged saves are free); Reading View set as default on install so citation chips are visible immediately | **Yes**   | No          | No         | No        |
+| **[Web chat UI](docs/user-quick-start-guide.md#step-22--use-the-web-chat-ui)** — `synthadoc web`: streaming answers, session sidebar, multi-turn history, knowledge-gap callouts, knowledge graph tab                                                                                                                                                                                                                                                                                                                                       | **Yes**   | No          | Yes        | Yes       |
+| **[MCP server](docs/design.md#27-mcp-server)** — 12 tools; Claude Desktop (stdio), Claude Code (SSE), n8n/LangGraph (HTTP/SSE); brain+memory architecture; no double-LLM cost for reads                                                                                                                                                                                                                                                                                                                                                     | **Yes**   | No          | No         | No        |
+| **[Context packs](docs/user-quick-start-guide.md#step-19--build-a-context-pack)** — goal → sub-questions → token-budget evidence pack; REST + MCP callable; paste into any LLM chat as grounded context                                                                                                                                                                                                                                                                                                                                   | **Yes**   | No          | No         | No        |
+| **[Export formats](docs/user-quick-start-guide.md#step-21--export-your-wiki)** — `llms.txt`, `llms-full.txt`, GraphML, JSON (provenance + lifecycle), OKF v0.1 bundle; lifecycle-filtered; zero extra LLM calls                                                                                                                                                                                                                                                                                                                             | **Yes**   | No          | Partial    | No        |
+| **[Multi-platform agent skill files](docs/design.md#multi-platform-agent-skill-files)** — `AGENTS.md` (Codex/OpenCode), `CLAUDE.md` (Claude Code), `GEMINI.md` (Gemini CLI); all include full CLI quick-reference, domain guidelines, MCP tool table; regenerated by `scaffold`                                                                                                                                                                                                                                                             | **Yes**   | No          | No         | No        |
 
 ### Content Sources
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **[Multi-format ingest](docs/design.md#built-in-skills)** — PDF, DOCX, PPTX, XLSX/CSV, Markdown, TXT, images (vision), web URLs, YouTube transcripts, AI session transcripts (.jsonl) | **Yes** | Varies | Partial | Partial |
-| **[Web search decomposition](docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — broad topics decomposed into focused Tavily keyword searches; results merged and deduplicated | **Yes** | No | No | Partial |
-| **[YouTube transcript ingest](docs/user-quick-start-guide.md#step-13--ingest-a-youtube-video)** — timestamped transcript + executive summary; no API key; auto-generated captions supported | **Yes** | No | Yes | No |
-| **[Multilingual / CJK queries](docs/design.md#queryagent)** — Chinese, Japanese, Korean — no false knowledge gaps | **Yes** | Limited | No | No |
-| **[Multiple LLM providers + coding tools](docs/user-quick-start-guide.md#appendix-c--switching-llm-providers)** — Gemini, Groq, Qwen, MiniMax, DeepSeek, Anthropic, OpenAI, Ollama; Claude Code and Opencode (no API key needed) | **Yes** | No | No | No |
+
+| Capability                                                                                                                                                                                                                        | Synthadoc | Typical RAG | NotebookLM | Notion AI |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- | ---------- | --------- |
+| **[Multi-format ingest](docs/design.md#built-in-skills)** — PDF, DOCX, PPTX, XLSX/CSV, Markdown, TXT, images (vision), web URLs, YouTube transcripts, AI session transcripts (.jsonl)                                            | **Yes**   | Varies      | Partial    | Partial   |
+| **[Web search decomposition](docs/user-quick-start-guide.md#step-12--web-search-ingestion)** — broad topics decomposed into focused Tavily keyword searches; results merged and deduplicated                                     | **Yes**   | No          | No         | Partial   |
+| **[YouTube transcript ingest](docs/user-quick-start-guide.md#step-13--ingest-a-youtube-video)** — timestamped transcript + executive summary; no API key; auto-generated captions supported                                      | **Yes**   | No          | Yes        | No        |
+| **[Multilingual / CJK queries](docs/design.md#queryagent)** — Chinese, Japanese, Korean — no false knowledge gaps                                                                                                               | **Yes**   | Limited     | No         | No        |
+| **[Multiple LLM providers + coding tools](docs/user-quick-start-guide.md#appendix-c--switching-llm-providers)** — Gemini, Groq, Qwen, MiniMax, DeepSeek, Anthropic, OpenAI, Ollama; Claude Code and Opencode (no API key needed) | **Yes**   | No          | No         | No        |
 
 ### Operations & Trust
 
-| Capability | Synthadoc | Typical RAG | NotebookLM | Notion AI |
-| --- | --- | --- | --- | --- |
-| **Local-first + offline artifact** — source documents never leave your machine; compiled wiki is plain Markdown, fully readable offline in any editor without the server | **Yes** | Varies | No | No |
-| **[Portable backup / restore](docs/design.md#28-backup--restore)** — single zip: wiki pages + audit/lifecycle DB + config; port and domain rewriting on restore; migrate machines without re-ingesting | **Yes** | No — re-ingest required | No — AI metadata lost | No |
-| **[Lifecycle content snapshots + rollback](docs/user-quick-start-guide.md#snapshots-and-content-recovery)** — page body captured at every lifecycle transition (manual CLI/Obsidian, lint-driven auto-transition, or Obsidian vault save); deduplicated so unchanged saves cost nothing; browse per-page version history with `lifecycle history` (newest-first, with reason); restore any prior version with `lifecycle rollback`; rollback saves the current body first so it is always undoable | **Yes** | No | No | Partial — Notion has time-based edit history (plan-gated, no lifecycle tie, no auditable rollback) |
-| **[Cost guard + full audit trail](docs/user-quick-start-guide.md#step-15--audit-features)** — per-job token + cost log; soft-warn and hard-gate thresholds; `audit citations` validates every claim citation; immutable event log | **Yes** | No | No | No |
-| **[Resumable job queue + retry](docs/design.md#14-job-queue)** — every ingest/lint job persisted with status and error; batch a hundred documents and resume after a crash | **Yes** | No | No | No |
-| **[Custom skills + CI hooks](docs/design.md#11-hook-system)** — subclass `BaseSkill` for new file formats; 2 hook events (`on_ingest_complete` + `on_lint_complete`); example git auto-commit hook included; blocking hooks can gate operations | **Yes** | Limited | No | No |
-| **[Per-source truncation flag](docs/design.md#30-per-source-truncation-flag)** — `--max-source-chars` caps any source (PDF, DOCX, web page, plain text) before the LLM call; truncated sources flagged with `truncated: true` in frontmatter and warned in lint output | **Yes** | No | No | No |
-| **[Multi-wiki isolation](docs/design.md#wiki-targeting)** — each wiki on its own port with independent config, audit trail, and job queue; switch with `synthadoc use` | **Yes** | No | Partial | No |
-| **[Agentic maintenance workflows](docs/user-quick-start-guide.md#agentic-workflows)** — six conversational workflows (re-ingest stale pages, re-ingest by slug, broken wikilinks scan and fix, lint report, scaffold regeneration, **contradiction resolver**) via web UI, Obsidian query modal, or `synthadoc query` CLI; confirm-before-act gate on all destructive operations; contradiction resolver shows full diff before every write and never applies a change without approval; graph sidebar chips trigger workflows with one click — no terminal required | **Yes** | No | No | No |
+
+| Capability                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Synthadoc | Typical RAG              | NotebookLM             | Notion AI                                                                                           |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------------------ | ---------------------- | --------------------------------------------------------------------------------------------------- |
+| **Local-first + offline artifact** — source documents never leave your machine; compiled wiki is plain Markdown, fully readable offline in any editor without the server                                                                                                                                                                                                                                                                                                                                                                                              | **Yes**   | Varies                   | No                     | No                                                                                                  |
+| **[Portable backup / restore](docs/design.md#28-backup--restore)** — single zip: wiki pages + audit/lifecycle DB + config; port and domain rewriting on restore; migrate machines without re-ingesting                                                                                                                                                                                                                                                                                                                                                                | **Yes**   | No — re-ingest required | No — AI metadata lost | No                                                                                                  |
+| **[Lifecycle content snapshots + rollback](docs/user-quick-start-guide.md#snapshots-and-content-recovery)** — page body captured at every lifecycle transition (manual CLI/Obsidian, lint-driven auto-transition, or Obsidian vault save); deduplicated so unchanged saves cost nothing; browse per-page version history with `lifecycle history` (newest-first, with reason); restore any prior version with `lifecycle rollback`; rollback saves the current body first so it is always undoable                                                                    | **Yes**   | No                       | No                     | Partial — Notion has time-based edit history (plan-gated, no lifecycle tie, no auditable rollback) |
+| **[Cost guard + full audit trail](docs/user-quick-start-guide.md#step-15--audit-features)** — per-job token + cost log; soft-warn and hard-gate thresholds; `audit citations` validates every claim citation; immutable event log                                                                                                                                                                                                                                                                                                                                     | **Yes**   | No                       | No                     | No                                                                                                  |
+| **[Resumable job queue + retry](docs/design.md#14-job-queue)** — every ingest/lint job persisted with status and error; batch a hundred documents and resume after a crash                                                                                                                                                                                                                                                                                                                                                                                            | **Yes**   | No                       | No                     | No                                                                                                  |
+| **[Custom skills + CI hooks](docs/design.md#11-hook-system)** — subclass `BaseSkill` for new file formats; 2 hook events (`on_ingest_complete` + `on_lint_complete`); example git auto-commit hook included; blocking hooks can gate operations                                                                                                                                                                                                                                                                                                                       | **Yes**   | Limited                  | No                     | No                                                                                                  |
+| **[Per-source truncation flag](docs/design.md#30-per-source-truncation-flag)** — `--max-source-chars` caps any source (PDF, DOCX, web page, plain text) before the LLM call; truncated sources flagged with `truncated: true` in frontmatter and warned in lint output                                                                                                                                                                                                                                                                                                | **Yes**   | No                       | No                     | No                                                                                                  |
+| **[Multi-wiki isolation](docs/design.md#wiki-targeting)** — each wiki on its own port with independent config, audit trail, and job queue; switch with `synthadoc use`                                                                                                                                                                                                                                                                                                                                                                                                | **Yes**   | No                       | Partial                | No                                                                                                  |
+| **[Agentic maintenance workflows](docs/user-quick-start-guide.md#agentic-workflows)** — six conversational workflows (re-ingest stale pages, re-ingest by slug, broken wikilinks scan and fix, lint report, scaffold regeneration, **contradiction resolver**) via web UI, Obsidian query modal, or `synthadoc query` CLI; confirm-before-act gate on all destructive operations; contradiction resolver shows full diff before every write and never applies a change without approval; graph sidebar chips trigger workflows with one click — no terminal required | **Yes**   | No                       | No                     | No                                                                                                  |
 
 ### Business value
 
-| Value | How |
-| --- | --- |
-| **Faster onboarding** | New team members query the wiki instead of digging through documents |
-| **Audit trail** | Every ingest recorded in `audit.db` with source hash, token count, and timestamp |
-| **Cost control** | Configurable thresholds; 3-layer cache reduces repeat spend |
-| **Compliance** | Local-first — source documents and compiled knowledge never leave your machine |
-| **Extensibility** | Hooks fire on every event; custom skills load without a server restart |
+
+| Value                 | How                                                                             |
+| --------------------- | ------------------------------------------------------------------------------- |
+| **Faster onboarding** | New team members query the wiki instead of digging through documents            |
+| **Audit trail**       | Every ingest recorded in`audit.db` with source hash, token count, and timestamp |
+| **Cost control**      | Configurable thresholds; 3-layer cache reduces repeat spend                     |
+| **Compliance**        | Local-first — source documents and compiled knowledge never leave your machine |
+| **Extensibility**     | Hooks fire on every event; custom skills load without a server restart          |
 
 ---
 
@@ -324,18 +333,19 @@ cd ..
 
 Synthadoc defaults to **Gemini Flash** — free tier, no credit card, 1 million tokens per day. Get a key at **aistudio.google.com/app/apikey** (click "Create API key").
 
-| Provider         | Free tier                                                | Vision          | Get key                                                           |
-| ---------------- | -------------------------------------------------------- | --------------- | ----------------------------------------------------------------- |
-| **Gemini Flash** | Yes — 15 RPM / 1M tokens/day, no credit card            | Yes             | [aistudio.google.com](https://aistudio.google.com/app/apikey)    |
-| Groq             | Yes — rate-limited                                       | No              | [console.groq.com](https://console.groq.com/keys)                |
-| Ollama           | Yes — runs locally, no key (**GPU required**)            | Model-dependent | [ollama.com](https://ollama.com)                                  |
-| Qwen             | Yes — 1M free tokens (90-day trial), then paid DashScope | Model-dependent | [bailian.console.aliyun.com](https://bailian.console.aliyun.com/) |
-| MiniMax          | No — pay-per-token                                       | Yes             | [platform.minimax.io](https://platform.minimax.io/)               |
-| DeepSeek         | No — pay-per-token (very cheap text rates)               | No              | [platform.deepseek.com](https://platform.deepseek.com/api_keys)  |
-| Anthropic        | No                                                       | Yes             | [console.anthropic.com](https://console.anthropic.com/)           |
-| OpenAI           | No                                                       | Yes             | [platform.openai.com](https://platform.openai.com/api-keys)      |
-| **Claude Code**  | Included with subscription — no API key                  | No              | Set `provider = "claude-code"` in config.toml                    |
-| **Opencode**     | Free via Opencode Zen — no API key                       | No              | Set `provider = "opencode", model = "opencode/big-pickle"` in config.toml; connect first: run `opencode` → `/connect` → select Zen |
+
+| Provider         | Free tier                                                 | Vision          | Get key                                                                                                                             |
+| ---------------- | --------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Gemini Flash** | Yes — 15 RPM / 1M tokens/day, no credit card             | Yes             | [aistudio.google.com](https://aistudio.google.com/app/apikey)                                                                       |
+| Groq             | Yes — rate-limited                                       | No              | [console.groq.com](https://console.groq.com/keys)                                                                                   |
+| Ollama           | Yes — runs locally, no key (**GPU required**)            | Model-dependent | [ollama.com](https://ollama.com)                                                                                                    |
+| Qwen             | Yes — 1M free tokens (90-day trial), then paid DashScope | Model-dependent | [bailian.console.aliyun.com](https://bailian.console.aliyun.com/)                                                                   |
+| MiniMax          | No — pay-per-token                                       | Yes             | [platform.minimax.io](https://platform.minimax.io/)                                                                                 |
+| DeepSeek         | No — pay-per-token (very cheap text rates)               | No              | [platform.deepseek.com](https://platform.deepseek.com/api_keys)                                                                     |
+| Anthropic        | No                                                        | Yes             | [console.anthropic.com](https://console.anthropic.com/)                                                                             |
+| OpenAI           | No                                                        | Yes             | [platform.openai.com](https://platform.openai.com/api-keys)                                                                         |
+| **Claude Code**  | Included with subscription — no API key                  | No              | Set`provider = "claude-code"` in config.toml                                                                                        |
+| **Opencode**     | Free via Opencode Zen — no API key                       | No              | Set`provider = "opencode", model = "opencode/big-pickle"` in config.toml; connect first: run `opencode` → `/connect` → select Zen |
 
 ```bash
 # macOS / Linux — add to ~/.bashrc or ~/.zshrc to persist
@@ -470,13 +480,14 @@ synthadoc status                        # confirm the wiki registered correctly 
 
 `--domain` is a free-text description of the subject area — the LLM uses it to generate five domain-aware starter files via scaffold:
 
-| File                | Purpose                                                                     |
-| ------------------- | --------------------------------------------------------------------------- |
-| `wiki/index.md`     | Table of contents — domain-relevant categories with `[[wikilinks]]`        |
-| `wiki/purpose.md`   | Scope declaration — used by the ingest agent to filter out-of-scope sources at ingest time, and injected as a pinned preamble into every query synthesis prompt so the LLM understands the wiki's domain boundaries when answering |
-| `AGENTS.md`         | LLM behaviour guidelines (tone, terminology, synthesis style) — read by Codex CLI, OpenCode, and generic OpenAI Agents tooling |
-| `CLAUDE.md`         | Same content as `AGENTS.md` — loaded automatically by Claude Code when the wiki folder is open |
-| `GEMINI.md`         | Same content as `AGENTS.md` — loaded automatically by Gemini CLI |
+
+| File              | Purpose                                                                                                                                                                                                                             |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wiki/index.md`   | Table of contents — domain-relevant categories with`[[wikilinks]]`                                                                                                                                                                 |
+| `wiki/purpose.md` | Scope declaration — used by the ingest agent to filter out-of-scope sources at ingest time, and injected as a pinned preamble into every query synthesis prompt so the LLM understands the wiki's domain boundaries when answering |
+| `AGENTS.md`       | LLM behaviour guidelines (tone, terminology, synthesis style) — read by Codex CLI, OpenCode, and generic OpenAI Agents tooling                                                                                                     |
+| `CLAUDE.md`       | Same content as`AGENTS.md` — loaded automatically by Claude Code when the wiki folder is open                                                                                                                                      |
+| `GEMINI.md`       | Same content as`AGENTS.md` — loaded automatically by Gemini CLI                                                                                                                                                                    |
 
 `wiki/dashboard.md` is also created during install (a static template — not LLM-generated). `ROUTING.md` is optional and generated separately via `synthadoc routing init` after pages accumulate.
 
@@ -967,23 +978,25 @@ synthadoc schedule history --limit 50 -w my-wiki
 
 **Cron expression format:** `minute  hour  day-of-month  month  day-of-week`
 
-| Field | Range | Examples |
-|-------|-------|---------|
-| minute | 0–59 | `0` = on the hour |
-| hour | 0–23 | `2` = 2 AM, `22` = 10 PM |
-| day of month | 1–31 | `*` = every day |
-| month | 1–12 | `*` = every month |
-| day of week | 0–6 | `0` = Sunday, `1` = Monday |
+
+| Field        | Range | Examples                   |
+| ------------ | ----- | -------------------------- |
+| minute       | 0–59 | `0` = on the hour          |
+| hour         | 0–23 | `2` = 2 AM, `22` = 10 PM   |
+| day of month | 1–31 | `*` = every day            |
+| month        | 1–12 | `*` = every month          |
+| day of week  | 0–6  | `0` = Sunday, `1` = Monday |
 
 Common schedules:
 
-| Expression | Meaning |
-|------------|---------|
-| `0 2 * * *` | Every day at 2 AM |
-| `0 22 * * *` | Every night at 10 PM |
-| `0 3 * * 0` | Every Sunday at 3 AM |
-| `0 */6 * * *` | Every 6 hours |
-| `30 8 * * 1-5` | Weekdays at 8:30 AM |
+
+| Expression     | Meaning              |
+| -------------- | -------------------- |
+| `0 2 * * *`    | Every day at 2 AM    |
+| `0 22 * * *`   | Every night at 10 PM |
+| `0 3 * * 0`    | Every Sunday at 3 AM |
+| `0 */6 * * *`  | Every 6 hours        |
+| `30 8 * * 1-5` | Weekdays at 8:30 AM  |
 
 ### Routing
 
@@ -1268,12 +1281,19 @@ Custom skills, LLM providers, hooks, cache control, and per-wiki AGENTS.md are d
 ## Links
 
 <!-- pypi-strip-start -->
+
 - Blogs & Media: [docs/media/](docs/media/README.md) — YouTube, Coderlegion, DEV.to, Medium
+
 <!-- pypi-strip-end -->
+
 - Design document: [docs/design.md](docs/design.md)
 - Customization: [docs/design.md — Customization](docs/design.md#customization)
 - Quick-Start Guide: [docs/user-quick-start-guide.md](docs/user-quick-start-guide.md)
+
 <!-- pypi-strip-start -->
+
 - Contributing: [CONTRIBUTING.md](CONTRIBUTING.md)
+
 <!-- pypi-strip-end -->
+
 - GitHub: [axoviq-ai/synthadoc](https://github.com/axoviq-ai/synthadoc)

--- a/README.md
+++ b/README.md
@@ -788,23 +788,32 @@ synthadoc lint report -w my-wiki
 Agentic workflows run as interactive tool-call loops — they stream progress inline, ask for approval before any destructive change, and exit cleanly if you decline.
 
 ```bash
-# Resolve all contradicted pages (shows cost estimate + diff for each page before writing)
-synthadoc workflow run contradiction-resolver -w my-wiki
+# List all available workflows (with descriptions and accepted parameters)
+synthadoc workflow list
+
+# Run a workflow by name
+synthadoc workflow run --name lint-report -w my-wiki
+synthadoc workflow run --name broken-wikilinks -w my-wiki
+synthadoc workflow run --name scaffold -w my-wiki
+synthadoc workflow run --name ingest-lint -w my-wiki
+
+# Contradiction resolver — resolve all contradicted pages
+synthadoc workflow run --name contradiction-resolver -w my-wiki
 
 # Resolve only one page by slug
-synthadoc workflow run contradiction-resolver --slug alan-turing -w my-wiki
+synthadoc workflow run --name contradiction-resolver --slug alan-turing -w my-wiki
 
 # Scope to pages demoted by the adversarial gate
-synthadoc workflow run contradiction-resolver --type adversarial -w my-wiki
+synthadoc workflow run --name contradiction-resolver --type adversarial -w my-wiki
 
 # Scope to pages with source-level contradictions
-synthadoc workflow run contradiction-resolver --type source-conflict -w my-wiki
+synthadoc workflow run --name contradiction-resolver --type source-conflict -w my-wiki
 
 # Custom timeout (default 3600 s)
-synthadoc workflow run contradiction-resolver --timeout 7200 -w my-wiki
+synthadoc workflow run --name contradiction-resolver --timeout 7200 -w my-wiki
 ```
 
-The resolver lists contradicted pages, estimates cost, then walks through each page: reads the content and conflicting sources, proposes a rewrite, shows the full unified diff, and waits for your approval. After an approved write it re-lints the page and promotes it to *active* on pass, or escalates after 3 failed attempts.
+The contradiction resolver lists contradicted pages, estimates cost, then walks through each page: reads the content and conflicting sources, proposes a rewrite, shows the full unified diff, and waits for your approval. After an approved write it re-lints the page and promotes it to *active* on pass, or escalates after 3 failed attempts.
 
 → Full walkthrough and web UI path: [Quick-Start Guide — Step 9](docs/user-quick-start-guide.md#step-9--resolve-a-contradiction)
 

--- a/docs/badges.json
+++ b/docs/badges.json
@@ -1,5 +1,5 @@
 {
-  "cli_commands": 53,
+  "cli_commands": 54,
   "obsidian_commands": 15,
   "skills": 10,
   "hooks": 1,

--- a/docs/design.md
+++ b/docs/design.md
@@ -1012,8 +1012,12 @@ synthadoc
 │   └── lifecycle
 │       └── purge -w wiki (--before <date> | --keep-latest <n>)
 ├── workflow
-│   └── run
-│       └── contradiction-resolver [--slug SLUG] [--type adversarial|source-conflict] [-w wiki] [--timeout N]
+│   ├── list
+│   └── run --name NAME [WORKFLOW_ARGS...] [-w wiki] [--timeout N]
+│       # NAME is one of: lint-report | broken-wikilinks | scaffold
+│       #                  contradiction-resolver | ingest-lint
+│       # Workflow-specific args (forwarded verbatim):
+│       #   contradiction-resolver: [--slug SLUG] [--type adversarial|source-conflict|gate|conflict]
 ├── backup [-w wiki] [--output <dir>] [--no-sources] [--no-exports] [--no-cache]
 ├── restore <backup.zip> [--name <wiki>] [--target <dir>] [--port <N>]
 ├── cache clear [-w wiki]
@@ -3550,16 +3554,16 @@ being needed first:
 
 **CLI:**
 ```bash
-synthadoc run contradiction-resolver              # all contradicted pages
-synthadoc run contradiction-resolver --slug alan-turing   # one page
-synthadoc run contradiction-resolver --type gate  # gate-demoted pages only
-synthadoc run contradiction-resolver --type conflict  # source conflicts only
+synthadoc workflow run --name contradiction-resolver              # all contradicted pages
+synthadoc workflow run --name contradiction-resolver --slug alan-turing   # one page
+synthadoc workflow run --name contradiction-resolver --type adversarial   # gate-demoted pages only
+synthadoc workflow run --name contradiction-resolver --type source-conflict  # source conflicts only
 ```
 
 `--slug` still calls `tool_get_contradicted_pages(scope="all")` internally and
-filters to the given slug after the list is returned. `--type gate` matches pages
-that carry `lint_warnings`; `--type conflict` matches pages that carry a
-`contradiction_note`. Both flags can be combined with `--slug`.
+filters to the given slug after the list is returned. `--type adversarial` (alias `gate`)
+matches pages that carry `lint_warnings`; `--type source-conflict` (alias `conflict`) matches
+pages that carry a `contradiction_note`. Both flags can be combined with `--slug`.
 
 ### Scoped re-lint
 
@@ -3605,6 +3609,7 @@ either does not abort the workflow. The page file is written first via
 - **Adversarial Lint Gate** — a new `adversarial_gate_threshold` config key (default `None`, disabled) triggers automatic lifecycle demotion of any page whose adversarial-reviewer warning count reaches or exceeds the threshold. When the gate fires, the page transitions from its current state to `contradicted` and the reason is recorded in the lifecycle audit trail as `auto-demoted: adversarial gate`. A companion guard prevents `--auto-resolve` from re-promoting gate-demoted pages in the same lint run (cycling prevention), recorded as `auto-resolve skipped: adversarial gate`. `adversarial_max_per_page` caps the flagged-claim count per page (default 5). See [§21 Adversarial Review](#21-adversarial-review).
 - **Contradiction Resolver Workflow** — an interactive agentic loop (`synthadoc workflow run contradiction-resolver`) that resolves pages in `contradicted` state one at a time. The workflow: lists all contradicted pages and shows a cost estimate (requiring confirmation); for each page reads the current content and the conflicting source or flagged claims, proposes a reconciling rewrite, and displays the full unified diff before writing; runs a scoped lint pass on the changed page; promotes to `active` on pass; tries up to 3 alternative strategies on failure (web ingest, force re-ingest, cross-page resolution) before escalating with a plain-language diagnosis. Supports `--slug` (single page), `--type adversarial` / `--type source-conflict` (scoped), and `--timeout` flags. Accessible from the web UI via the **"Run contradiction resolver"** hint chip (shown whenever the wiki has contradicted pages), via the pre-filled `done.pre_prompt` suggestion after any response that mentions contradicted pages, or via free-text query. See [§35 Contradiction Resolver Workflow](#35-contradiction-resolver-workflow).
 - **Generic workflow tool extensions** — `tool_propose_and_apply` and `tool_transition_lifecycle_state` added to the shared workflow tool library; any future workflow can reuse diff-before-write approval and lifecycle state transitions without re-implementing them.
+- **Pluggable workflow CLI** — `synthadoc workflow run` is now a single generic command with `--name NAME` instead of one hardcoded subcommand per workflow. All 5 registered workflows (`lint-report`, `broken-wikilinks`, `scaffold`, `contradiction-resolver`, `ingest-lint`) are exposed automatically via `NAME`/`DESCRIPTION` class attributes and `CLI_REGISTRY`. `synthadoc workflow list` enumerates all registered workflows with descriptions. Workflow-specific options (e.g. `--slug`, `--type`) are forwarded verbatim to the workflow and parsed by its own `build_initial_message`. Adding a new workflow requires no CLI changes.
 
 ### v1.2.1
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # Synthadoc — Design Document
 
-**Version:** 1.2.1  
+**Version:** 1.3.0
 **Audience:** Product users who want to understand how the system works; developers adding features, skills, and plugins.
 
 **Document owners:** Paul Chen, William Johnason
@@ -46,6 +46,7 @@
 35. [Contradiction Resolver Workflow](#35-contradiction-resolver-workflow)
 
 **Appendices**
+
 - [Appendix A — Release Feature Index](#appendix-a--release-feature-index)
 
 ---
@@ -124,24 +125,26 @@ Content with [[wikilinks]] to related pages…
 
 `resource` and `sources` are complementary, not duplicates:
 
-| | `resource` | `sources` |
-|---|---|---|
-| Purpose | OKF external citation — one clean URL for agents and humans to follow | Synthadoc internal provenance — full audit record per contributing file |
-| Cardinality | Single string (or absent) | Array — grows as more files are ingested into the same page |
-| Contents | URL only | File path, SHA-256 hash, byte size, ingestion timestamp |
-| Used for | OKF compatibility; agent consumption without Synthadoc-specific knowledge | Dedup, stale detection, cost audit trail |
-| Local file sources | Absent | Present (file path + hash) |
-| URL sources | Set to the source URL | Also present (URL + hash of URL string) |
+
+|                    | `resource`                                                                | `sources`                                                                |
+| ------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Purpose            | OKF external citation — one clean URL for agents and humans to follow    | Synthadoc internal provenance — full audit record per contributing file |
+| Cardinality        | Single string (or absent)                                                 | Array — grows as more files are ingested into the same page             |
+| Contents           | URL only                                                                  | File path, SHA-256 hash, byte size, ingestion timestamp                  |
+| Used for           | OKF compatibility; agent consumption without Synthadoc-specific knowledge | Dedup, stale detection, cost audit trail                                 |
+| Local file sources | Absent                                                                    | Present (file path + hash)                                               |
+| URL sources        | Set to the source URL                                                     | Also present (URL + hash of URL string)                                  |
 
 **`status` values:**
 
-| Value | Meaning |
-|-------|---------|
-| `draft` | Newly compiled — not yet lint-reviewed |
-| `active` | Lint-reviewed, current, trusted |
+
+| Value          | Meaning                                                 |
+| -------------- | ------------------------------------------------------- |
+| `draft`        | Newly compiled — not yet lint-reviewed                 |
+| `active`       | Lint-reviewed, current, trusted                         |
 | `contradicted` | A new source conflicts with this page; needs resolution |
-| `stale` | Source file changed since last ingest |
-| `archived` | Source removed or manually retired |
+| `stale`        | Source file changed since last ingest                   |
+| `archived`     | Source removed or manually retired                      |
 
 New pages are created with `status: draft`. Lint promotes them to `active` automatically when all checks pass. See [§23 Lifecycle Machine](#23-lifecycle-machine) for full transition rules.
 
@@ -211,16 +214,17 @@ All agents are async Python classes. They receive a job context, write results t
 
 Five-pass pipeline:
 
-| Pass | Model | Purpose |
-|------|-------|---------|
-| 0 — Vision (optional) | Default | Extract text from image sources (`is_image=True`); requires a vision-capable provider |
-| 0b — Key Data Extraction | None (regex) | Deterministic pre-processor: extracts numbers, percentages, currency amounts, ratios, formulas, underscore identifiers, and date ranges from source text via regex; appends them as a `[Key Data — extracted by pre-processor]` section before any LLM sees the text. Zero token cost; cannot hallucinate. Anchors the synthesis LLM to all quantitative candidates. |
-| 1 — Analysis (`_analyse()`) | Default | Extract entities, tags, and a 3-sentence summary from raw text. Result cached under key `analyse-v1` keyed by SHA-256 of the text. |
-| 2 — Candidate search | None (BM25) | Find existing wiki pages related to extracted entities |
-| 3 — Decision | Default | LLM reads the full source text (bounded by `max_source_chars`) + BM25 candidates + `purpose.md` scope + status of each candidate page. Outputs per-page action: `create`, `update`, `flag`, `skip`. **RULE 1b:** a page with `status='active'` is human-reviewed and authoritative — when the source provides a conflicting value, date, formula, or conclusion, the action must be `flag`, not `update`. The only exception is a source that adds a topic the page does not yet mention at all. Decision cache version: `v2`. |
-| 4 — Citation annotation (`_annotate_citations()`) | Default | For each page section being written, the LLM reads the section alongside the numbered source text and inserts `^[filename:L-L]` inline citation markers at the end of substantive paragraphs. Results cached by section SHA-256. Falls back gracefully (returns original section) on any LLM or parse failure — ingest always completes. Citations are recorded in `audit.db` `claim_citations` table. If no citation markers are present in the returned body, a `citation_pass4_no_markers` WARNING audit event is written — the page is still saved but the condition is flagged for re-ingest with a more capable model. Zero-citation results are not cached so a subsequent re-ingest can succeed. |
-| 5 — Write | None | Apply actions; update frontmatter; write `[[wikilinks]]`; fire hooks. For local sources, writes a `.txt` sidecar to `.synthadoc/extracted/` (all file types) and a pagemap JSON sidecar when PDF page boundaries are available. |
-| 6 — Overview | Default | Regenerate `wiki/overview.md` if any pages were created or updated |
+
+| Pass                                               | Model        | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0 — Vision (optional)                             | Default      | Extract text from image sources (`is_image=True`); requires a vision-capable provider                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| 0b — Key Data Extraction                          | None (regex) | Deterministic pre-processor: extracts numbers, percentages, currency amounts, ratios, formulas, underscore identifiers, and date ranges from source text via regex; appends them as a`[Key Data — extracted by pre-processor]` section before any LLM sees the text. Zero token cost; cannot hallucinate. Anchors the synthesis LLM to all quantitative candidates.                                                                                                                                                                                                                                                                                                                                      |
+| 1 — Analysis (`_analyse()`)                       | Default      | Extract entities, tags, and a 3-sentence summary from raw text. Result cached under key`analyse-v1` keyed by SHA-256 of the text.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| 2 — Candidate search                              | None (BM25)  | Find existing wiki pages related to extracted entities                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| 3 — Decision                                      | Default      | LLM reads the full source text (bounded by`max_source_chars`) + BM25 candidates + `purpose.md` scope + status of each candidate page. Outputs per-page action: `create`, `update`, `flag`, `skip`. **RULE 1b:** a page with `status='active'` is human-reviewed and authoritative — when the source provides a conflicting value, date, formula, or conclusion, the action must be `flag`, not `update`. The only exception is a source that adds a topic the page does not yet mention at all. Decision cache version: `v2`.                                                                                                                                                                            |
+| 4 — Citation annotation (`_annotate_citations()`) | Default      | For each page section being written, the LLM reads the section alongside the numbered source text and inserts`^[filename:L-L]` inline citation markers at the end of substantive paragraphs. Results cached by section SHA-256. Falls back gracefully (returns original section) on any LLM or parse failure — ingest always completes. Citations are recorded in `audit.db` `claim_citations` table. If no citation markers are present in the returned body, a `citation_pass4_no_markers` WARNING audit event is written — the page is still saved but the condition is flagged for re-ingest with a more capable model. Zero-citation results are not cached so a subsequent re-ingest can succeed. |
+| 5 — Write                                         | None         | Apply actions; update frontmatter; write`[[wikilinks]]`; fire hooks. For local sources, writes a `.txt` sidecar to `.synthadoc/extracted/` (all file types) and a pagemap JSON sidecar when PDF page boundaries are available.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| 6 — Overview                                      | Default      | Regenerate`wiki/overview.md` if any pages were created or updated                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 
 **Analysis caching:** The analysis step is expensive (full text read + LLM call). Results are cached in `cache.db` by text SHA-256. Subsequent ingests of the same source (e.g. after a `--force` that hits the decision cache miss) re-use the analysis result without a new LLM call.
 
@@ -266,6 +270,7 @@ Question
 ```
 
 **Decomposition behaviour:**
+
 - Simple questions decompose to a single sub-question — identical behaviour to v0.1
 - Compound questions (e.g. "Who invented FORTRAN and what was the Bombe machine?") decompose into one sub-question per part — each part retrieved independently, pages merged before synthesis
 - Comparative questions (e.g. "Compare Turing's contributions with Von Neumann's") retrieve both subjects in parallel
@@ -320,6 +325,7 @@ User input: "search for: yard gardening in Canadian climate zones"
 ```
 
 **Key design decisions:**
+
 - Uses a **separate prompt** from `QueryAgent.decompose()` — query decomposition asks "what distinct *questions* does this ask?" (natural-language sub-questions) while search decomposition asks "what distinct *search strings* would find the best authoritative sources?" (terse keyword phrases). The outputs are fundamentally different — they must not share a prompt.
 - Implemented as `SearchDecomposeAgent` in `synthadoc/agents/search_decompose_agent.py` — kept separate to avoid coupling the two decomposition strategies.
 - Cap: 4 search strings maximum — prevents runaway Tavily API spend.
@@ -363,6 +369,7 @@ to ~/.cache/fastembed/. This is a one-time download.
 **Fallback:** If `embeddings.db` is empty, the model is unavailable, or `fastembed` is not installed, BM25 ranking is used automatically with no error.
 
 **Performance notes:**
+
 - First enable on a large wiki may take several minutes to embed all pages. Subsequent server starts are instant (model and embeddings already cached).
 - The re-ranking step is CPU-only and adds single-digit milliseconds per query after migration.
 - Set `vector = false` to revert to BM25-only at any time. Existing embeddings are not deleted.
@@ -373,18 +380,19 @@ to ~/.cache/fastembed/. This is a one-time download.
 
 Runs against the entire wiki or a scoped subset:
 
-| Check | What it finds |
-|-------|---------------|
-| Contradiction | Pages with `status: contradicted` |
-| Orphan | Pages with zero inbound `[[wikilinks]]` |
-| Stale | Pages whose `sources[]` entries no longer exist on disk |
-| Missing link | Entity mentioned in page body but no wikilink created |
-| Adversarial review _(v0.5.0)_ | Independent LLM pass that flags overstated claims, unsupported assertions, and high-confidence statements the source material does not support |
-| Lifecycle — archived detection _(v0.6.0)_ | Source file no longer on disk → transition page to `archived` |
-| Lifecycle — stale detection _(v0.6.0)_ | SHA-256 hash of source on disk ≠ recorded ingest hash → transition page to `stale` |
-| Lifecycle — draft promotion _(v0.6.0)_ | `draft` page with no active issues → transition to `active` |
-| Lifecycle — manual-edit sync _(v0.6.0)_ | Frontmatter `status` differs from `page_states` DB record → reconcile DB to match |
-| Citation presence (Check 5b) | Page body has ≥ 50 words and zero `^[filename:L-L]` citation markers → WARNING. Diagnostic only — does not block promotion to `active`. Indicates the annotation pass failed to produce markers, usually a model-compatibility issue (use Gemini 2.5 Flash or higher for reliable citation annotation). |
+
+| Check                                     | What it finds                                                                                                                                                                                                                                                                                             |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Contradiction                             | Pages with`status: contradicted`                                                                                                                                                                                                                                                                          |
+| Orphan                                    | Pages with zero inbound`[[wikilinks]]`                                                                                                                                                                                                                                                                    |
+| Stale                                     | Pages whose`sources[]` entries no longer exist on disk                                                                                                                                                                                                                                                    |
+| Missing link                              | Entity mentioned in page body but no wikilink created                                                                                                                                                                                                                                                     |
+| Adversarial review_(v0.5.0)_              | Independent LLM pass that flags overstated claims, unsupported assertions, and high-confidence statements the source material does not support                                                                                                                                                            |
+| Lifecycle — archived detection_(v0.6.0)_ | Source file no longer on disk → transition page to`archived`                                                                                                                                                                                                                                             |
+| Lifecycle — stale detection_(v0.6.0)_    | SHA-256 hash of source on disk ≠ recorded ingest hash → transition page to`stale`                                                                                                                                                                                                                       |
+| Lifecycle — draft promotion_(v0.6.0)_    | `draft` page with no active issues → transition to `active`                                                                                                                                                                                                                                              |
+| Lifecycle — manual-edit sync_(v0.6.0)_   | Frontmatter`status` differs from `page_states` DB record → reconcile DB to match                                                                                                                                                                                                                         |
+| Citation presence (Check 5b)              | Page body has ≥ 50 words and zero`^[filename:L-L]` citation markers → WARNING. Diagnostic only — does not block promotion to `active`. Indicates the annotation pass failed to produce markers, usually a model-compatibility issue (use Gemini 2.5 Flash or higher for reliable citation annotation). |
 
 **Auto-resolution:** For contradictions, LintAgent asks the LLM to propose a resolution with a confidence score. If score ≥ `auto_resolve_confidence_threshold` (default 0.85), applies automatically. Below threshold, queues for human review.
 
@@ -408,13 +416,14 @@ When a source is a URL or an intent phrase (e.g. `search for: Dennis Ritchie`), 
 
 Serialises the wiki to one of five formats with zero additional LLM calls. Invoked via `synthadoc export --format <fmt>` or the Obsidian **Export Wiki** command.
 
-| Format | Output |
-|--------|--------|
-| `llms.txt` | Active pages as a compact index (title + first-line summary) in the [llmstxt.org](https://llmstxt.org) spec; pages with `contradicted` or `stale` status appear in a **Needs Review** section |
-| `llms-full.txt` | Full page content for all pages, separated by `---` dividers with status and confidence headers; no size limit |
-| `graphml` | Directed wikilink graph — one node per page, one edge per `[[wikilink]]`; includes `label` (Gephi), `y:NodeLabel` (yEd), status, confidence, orphan flag, inbound link count, and routing branch per node |
-| `json` | Full structured dump: content, tags, sources, claims (from audit DB), lifecycle history, routing branch memberships, per-page `ingest_cost_usd` and `ingest_tokens`, and total compilation cost |
-| `okf` | [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle directory — one Markdown file per page with conformant YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`); `index.md` grouped by knowledge type; `log.md` lifecycle history; `[[wikilinks]]` rewritten to relative OKF paths |
+
+| Format          | Output                                                                                                                                                                                                                                                                                                                                                          |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `llms.txt`      | Active pages as a compact index (title + first-line summary) in the[llmstxt.org](https://llmstxt.org) spec; pages with `contradicted` or `stale` status appear in a **Needs Review** section                                                                                                                                                                    |
+| `llms-full.txt` | Full page content for all pages, separated by`---` dividers with status and confidence headers; no size limit                                                                                                                                                                                                                                                   |
+| `graphml`       | Directed wikilink graph — one node per page, one edge per`[[wikilink]]`; includes `label` (Gephi), `y:NodeLabel` (yEd), status, confidence, orphan flag, inbound link count, and routing branch per node                                                                                                                                                       |
+| `json`          | Full structured dump: content, tags, sources, claims (from audit DB), lifecycle history, routing branch memberships, per-page`ingest_cost_usd` and `ingest_tokens`, and total compilation cost                                                                                                                                                                  |
+| `okf`           | [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle directory — one Markdown file per page with conformant YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`); `index.md` grouped by knowledge type; `log.md` lifecycle history; `[[wikilinks]]` rewritten to relative OKF paths |
 
 **Status filter:** All formats accept `--status-filter active|contradicted|stale|archived|draft|all` (default `all`) to scope the export to a lifecycle subset. For `okf`, the accepted values are `all` (active + contradicted, the default) or `active` only — draft, stale, and archived pages are always excluded from OKF bundles regardless of the flag.
 
@@ -484,11 +493,12 @@ The Markdown body is for human readers and LLMs — never engine-parsed. Use it 
 
 ### 3-Tier Lazy Loading
 
-| Tier | What loads | When |
-|------|-----------|------|
-| 1 — Metadata | `SkillMeta` parsed from `SKILL.md` frontmatter | Always; startup |
-| 2 — Body | Full skill class via `importlib.util` | When a matching source is encountered |
-| 3 — Resources | Files from `assets/` or `references/` via `get_resource()` | On first access within the skill |
+
+| Tier           | What loads                                                | When                                  |
+| -------------- | --------------------------------------------------------- | ------------------------------------- |
+| 1 — Metadata  | `SkillMeta` parsed from `SKILL.md` frontmatter            | Always; startup                       |
+| 2 — Body      | Full skill class via`importlib.util`                      | When a matching source is encountered |
+| 3 — Resources | Files from`assets/` or `references/` via `get_resource()` | On first access within the skill      |
 
 This means importing 20 skills costs essentially zero memory until they are needed.
 
@@ -504,18 +514,19 @@ For URL sources, **longest prefix wins**: the matched extension string length de
 
 ### Built-in Skills
 
-| Skill | Extensions | Intent phrases | Notes |
-|-------|-----------|---------------|-------|
-| `pdf` | `.pdf` | `pdf`, `research paper`, `document` | pypdf primary; pdfminer.six fallback if yield < 50 chars/page |
-| `url` | `http://`, `https://` | `fetch url`, `web page`, `website` | httpx fetch + BeautifulSoup clean |
-| `markdown` | `.md`, `.txt` | `markdown`, `text file`, `notes` | Direct read |
-| `docx` | `.docx` | `word document`, `docx` | python-docx |
-| `pptx` | `.pptx` | `powerpoint`, `presentation`, `pptx` | python-pptx; each slide rendered as a titled section; speaker notes appended when present |
-| `xlsx` | `.xlsx`, `.csv` | `spreadsheet`, `excel`, `csv` | openpyxl |
-| `image` | `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.tiff` | `image`, `screenshot`, `diagram`, `photo` | Base64 + vision LLM |
-| `web_search` | _(none)_ | `search for`, `find on the web`, `look up`, `web search`, `browse` | Calls Tavily API; returns top result URLs as child sources enqueued individually. Requires `TAVILY_API_KEY`. |
-| `youtube` | `https://www.youtube.com/`, `https://youtu.be/` | `youtube video`, `youtube lecture`, `youtube talk` | Extracts captions via YouTube caption system; no API key or audio download needed. Generates an executive summary (what the video covers, main topics, key takeaway) followed by the full timestamped transcript. Skips gracefully when no captions are available. |
-| `session` | `.jsonl` | `claude session`, `codex session`, `cursor session`, `ai session`, `session history` | Extracts human-readable turns from AI coding session transcripts. Supports Claude Code JSONL format and Codex/Cursor format. Filters tool calls, thinking blocks, and sub-agent scaffolding. Short turns (< 20 assistant words, < 3 user words) are skipped. No external dependencies. |
+
+| Skill        | Extensions                                        | Intent phrases                                                                       | Notes                                                                                                                                                                                                                                                                                  |
+| ------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pdf`        | `.pdf`                                            | `pdf`, `research paper`, `document`                                                  | pypdf primary; pdfminer.six fallback if yield < 50 chars/page                                                                                                                                                                                                                          |
+| `url`        | `http://`, `https://`                             | `fetch url`, `web page`, `website`                                                   | httpx fetch + BeautifulSoup clean                                                                                                                                                                                                                                                      |
+| `markdown`   | `.md`, `.txt`                                     | `markdown`, `text file`, `notes`                                                     | Direct read                                                                                                                                                                                                                                                                            |
+| `docx`       | `.docx`                                           | `word document`, `docx`                                                              | python-docx                                                                                                                                                                                                                                                                            |
+| `pptx`       | `.pptx`                                           | `powerpoint`, `presentation`, `pptx`                                                 | python-pptx; each slide rendered as a titled section; speaker notes appended when present                                                                                                                                                                                              |
+| `xlsx`       | `.xlsx`, `.csv`                                   | `spreadsheet`, `excel`, `csv`                                                        | openpyxl                                                                                                                                                                                                                                                                               |
+| `image`      | `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.tiff` | `image`, `screenshot`, `diagram`, `photo`                                            | Base64 + vision LLM                                                                                                                                                                                                                                                                    |
+| `web_search` | _(none)_                                          | `search for`, `find on the web`, `look up`, `web search`, `browse`                   | Calls Tavily API; returns top result URLs as child sources enqueued individually. Requires`TAVILY_API_KEY`.                                                                                                                                                                            |
+| `youtube`    | `https://www.youtube.com/`, `https://youtu.be/`   | `youtube video`, `youtube lecture`, `youtube talk`                                   | Extracts captions via YouTube caption system; no API key or audio download needed. Generates an executive summary (what the video covers, main topics, key takeaway) followed by the full timestamped transcript. Skips gracefully when no captions are available.                     |
+| `session`    | `.jsonl`                                          | `claude session`, `codex session`, `cursor session`, `ai session`, `session history` | Extracts human-readable turns from AI coding session transcripts. Supports Claude Code JSONL format and Codex/Cursor format. Filters tool calls, thinking blocks, and sub-agent scaffolding. Short turns (< 20 assistant words, < 3 user words) are skipped. No external dependencies. |
 
 ### Session Skill — AI Session History Ingestion
 
@@ -523,26 +534,28 @@ The `session` skill turns AI coding session history files (`.jsonl`) into search
 
 **Supported formats**
 
-| Format | File origin | Detection |
-|--------|-------------|-----------|
-| Claude Code | `~/.claude/projects/<hash>/<session-id>.jsonl` | `obj.type` ∈ `{"user", "assistant"}` with nested `obj.message` |
-| Codex / Cursor | Export from OpenAI Codex or Cursor IDE | `obj.role` at top level, no `message` wrapper |
+
+| Format         | File origin                                    | Detection                                                       |
+| -------------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| Claude Code    | `~/.claude/projects/<hash>/<session-id>.jsonl` | `obj.type` ∈ `{"user", "assistant"}` with nested `obj.message` |
+| Codex / Cursor | Export from OpenAI Codex or Cursor IDE         | `obj.role` at top level, no `message` wrapper                   |
 
 Format is auto-detected from the first 30 parseable lines. Files that match neither format are parsed as Codex (fallback).
 
 **Filtering rules**
 
-| Content | Kept? | Reason |
-|---------|-------|--------|
-| User text ≥ 3 words | ✓ | Substantive question or instruction |
-| Assistant text ≥ 20 words | ✓ | Substantive answer |
-| User text < 3 words (`"ok"`, `"yes"`) | ✗ | Too terse to be useful |
-| Assistant text < 20 words | ✗ | Acknowledgement or one-liner |
-| `isSidechain: true` lines | ✗ | Sub-agent scaffolding (not the user's conversation) |
-| `tool_use` blocks | ✗ | Shell commands / file writes — not final output |
-| `tool_result` blocks | ✗ | Raw output — avoids leaking file contents or credentials |
-| `thinking` blocks | ✗ | Internal reasoning — not the final answer |
-| `permission-mode`, `system`, `last-prompt` lines | ✗ | Session metadata, not conversation |
+
+| Content                                          | Kept? | Reason                                                    |
+| ------------------------------------------------ | ----- | --------------------------------------------------------- |
+| User text ≥ 3 words                             | ✓    | Substantive question or instruction                       |
+| Assistant text ≥ 20 words                       | ✓    | Substantive answer                                        |
+| User text < 3 words (`"ok"`, `"yes"`)            | ✗    | Too terse to be useful                                    |
+| Assistant text < 20 words                        | ✗    | Acknowledgement or one-liner                              |
+| `isSidechain: true` lines                        | ✗    | Sub-agent scaffolding (not the user's conversation)       |
+| `tool_use` blocks                                | ✗    | Shell commands / file writes — not final output          |
+| `tool_result` blocks                             | ✗    | Raw output — avoids leaking file contents or credentials |
+| `thinking` blocks                                | ✗    | Internal reasoning — not the final answer                |
+| `permission-mode`, `system`, `last-prompt` lines | ✗    | Session metadata, not conversation                        |
 
 After extraction the text passes through Synthadoc's standard pre-LLM source sanitizer
 (zero-width characters, bidi overrides, HTML comments, hidden CSS spans, base64 blobs ≥ 200 chars,
@@ -578,13 +591,14 @@ The skill sets `metadata["suggested_slug"]` to `session-YYYY-MM-DD-<topic>` wher
 
 Skills are discovered from five locations in priority order:
 
-| Source | Path | Override priority |
-|--------|------|------------------|
-| `extra_dirs` (programmatic) | Passed at `SkillAgent()` init | Highest |
-| Local wiki | `<wiki-root>/skills/` | High |
-| Global user | `~/.synthadoc/skills/` | Medium |
-| pip entry points | `entry_points('synthadoc.skills')` | Low |
-| Built-in | Ships with package (`synthadoc/skills/`) | Lowest |
+
+| Source                      | Path                                     | Override priority |
+| --------------------------- | ---------------------------------------- | ----------------- |
+| `extra_dirs` (programmatic) | Passed at`SkillAgent()` init             | Highest           |
+| Local wiki                  | `<wiki-root>/skills/`                    | High              |
+| Global user                 | `~/.synthadoc/skills/`                   | Medium            |
+| pip entry points            | `entry_points('synthadoc.skills')`       | Low               |
+| Built-in                    | Ships with package (`synthadoc/skills/`) | Lowest            |
 
 No server restart needed — registry cache detects changes automatically on next startup.
 
@@ -638,75 +652,81 @@ SQLite. Two key tables:
 
 **`ingest_log`**
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | INTEGER PK | |
-| `source` | TEXT | Original path or URL |
-| `hash` | TEXT | `sha256:<hex>` |
-| `size` | INTEGER | Bytes |
-| `cost_usd` | REAL | |
-| `tokens` | INTEGER | |
-| `pages_created` | TEXT | JSON array of slugs |
-| `pages_updated` | TEXT | JSON array of slugs |
-| `ingested_at` | TEXT | UTC ISO-8601 |
+
+| Column          | Type       | Notes                |
+| --------------- | ---------- | -------------------- |
+| `id`            | INTEGER PK |                      |
+| `source`        | TEXT       | Original path or URL |
+| `hash`          | TEXT       | `sha256:<hex>`       |
+| `size`          | INTEGER    | Bytes                |
+| `cost_usd`      | REAL       |                      |
+| `tokens`        | INTEGER    |                      |
+| `pages_created` | TEXT       | JSON array of slugs  |
+| `pages_updated` | TEXT       | JSON array of slugs  |
+| `ingested_at`   | TEXT       | UTC ISO-8601         |
 
 **`audit_events`**
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | INTEGER PK | |
-| `event` | TEXT | e.g. `contradiction_found`, `auto_resolved`, `cost_gate_triggered` |
-| `details` | TEXT | JSON |
-| `recorded_at` | TEXT | UTC ISO-8601 |
+
+| Column        | Type       | Notes                                                             |
+| ------------- | ---------- | ----------------------------------------------------------------- |
+| `id`          | INTEGER PK |                                                                   |
+| `event`       | TEXT       | e.g.`contradiction_found`, `auto_resolved`, `cost_gate_triggered` |
+| `details`     | TEXT       | JSON                                                              |
+| `recorded_at` | TEXT       | UTC ISO-8601                                                      |
 
 **`queries`** _(added in v0.2.0)_
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | INTEGER PK | |
-| `question` | TEXT | Original question text |
-| `sub_questions_count` | INTEGER | Number of sub-questions decomposed (1 for simple questions) |
-| `tokens` | INTEGER | Answer call token usage |
-| `cost_usd` | REAL | Approximate cost (answer tokens × rate) |
-| `queried_at` | TEXT | UTC ISO-8601 |
+
+| Column                | Type       | Notes                                                       |
+| --------------------- | ---------- | ----------------------------------------------------------- |
+| `id`                  | INTEGER PK |                                                             |
+| `question`            | TEXT       | Original question text                                      |
+| `sub_questions_count` | INTEGER    | Number of sub-questions decomposed (1 for simple questions) |
+| `tokens`              | INTEGER    | Answer call token usage                                     |
+| `cost_usd`            | REAL       | Approximate cost (answer tokens × rate)                    |
+| `queried_at`          | TEXT       | UTC ISO-8601                                                |
 
 **`claim_citations`** _(added in v0.5.0)_
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | INTEGER PK | |
-| `page_slug` | TEXT | Wiki page the citation belongs to |
-| `source_file` | TEXT | Filename of the raw source (basename only) |
-| `line_start` | INTEGER | First line of the supporting passage |
-| `line_end` | INTEGER | Last line of the supporting passage |
-| `claim_excerpt` | TEXT | First ~100 chars of the annotated paragraph (for display) |
-| `ingested_at` | TEXT | UTC ISO-8601 |
+
+| Column          | Type       | Notes                                                     |
+| --------------- | ---------- | --------------------------------------------------------- |
+| `id`            | INTEGER PK |                                                           |
+| `page_slug`     | TEXT       | Wiki page the citation belongs to                         |
+| `source_file`   | TEXT       | Filename of the raw source (basename only)                |
+| `line_start`    | INTEGER    | First line of the supporting passage                      |
+| `line_end`      | INTEGER    | Last line of the supporting passage                       |
+| `claim_excerpt` | TEXT       | First ~100 chars of the annotated paragraph (for display) |
+| `ingested_at`   | TEXT       | UTC ISO-8601                                              |
 
 **`page_states`** _(added in v0.6.0)_
 
 Fast slug-keyed current state index. One row per wiki page.
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `slug` | TEXT PK | Wiki page slug |
-| `state` | TEXT | One of: `draft`, `active`, `contradicted`, `stale`, `archived` |
-| `updated_at` | TEXT | UTC ISO-8601 — when this row was last modified |
-| `triggered_by` | TEXT | Who caused the last transition: `ingest`, `lint`, `cli`, `api` |
+
+| Column         | Type    | Notes                                                         |
+| -------------- | ------- | ------------------------------------------------------------- |
+| `slug`         | TEXT PK | Wiki page slug                                                |
+| `state`        | TEXT    | One of:`draft`, `active`, `contradicted`, `stale`, `archived` |
+| `updated_at`   | TEXT    | UTC ISO-8601 — when this row was last modified               |
+| `triggered_by` | TEXT    | Who caused the last transition:`ingest`, `lint`, `cli`, `api` |
 
 **`lifecycle_events`** _(added in v0.6.0)_
 
 Immutable append-only audit log of every lifecycle transition.
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | INTEGER PK | |
-| `slug` | TEXT | Wiki page slug |
-| `from_state` | TEXT | Previous state (`null` on first creation) |
-| `to_state` | TEXT | New state |
-| `reason` | TEXT | Human-readable reason (empty string if none provided) |
-| `triggered_by` | TEXT | `ingest`, `lint`, `cli`, `api` |
-| `timestamp` | TEXT | UTC ISO-8601 |
-| `content_snapshot` | TEXT | Full page body at the moment of the event; NULL when the event carries no content change (e.g. ingest-agent transitions). See [§23 Page Content Snapshots](#page-content-snapshots) for the full capture policy. |
+
+| Column             | Type       | Notes                                                                                                                                                                                                            |
+| ------------------ | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`               | INTEGER PK |                                                                                                                                                                                                                  |
+| `slug`             | TEXT       | Wiki page slug                                                                                                                                                                                                   |
+| `from_state`       | TEXT       | Previous state (`null` on first creation)                                                                                                                                                                        |
+| `to_state`         | TEXT       | New state                                                                                                                                                                                                        |
+| `reason`           | TEXT       | Human-readable reason (empty string if none provided)                                                                                                                                                            |
+| `triggered_by`     | TEXT       | `ingest`, `lint`, `cli`, `api`                                                                                                                                                                                   |
+| `timestamp`        | TEXT       | UTC ISO-8601                                                                                                                                                                                                     |
+| `content_snapshot` | TEXT       | Full page body at the moment of the event; NULL when the event carries no content change (e.g. ingest-agent transitions). See[§23 Page Content Snapshots](#page-content-snapshots) for the full capture policy. |
 
 ### jobs.db — Job queue
 
@@ -753,40 +773,42 @@ Note: BM25 IDF requires a minimum of 3 documents in the corpus for non-zero scor
 
 ### Endpoints
 
-| Method | Path | Request | Response |
-|--------|------|---------|----------|
-| `POST` | `/jobs/ingest` | `{source: str}` | `{job_id: str}` |
-| `POST` | `/jobs/lint` | `{scope?: str}` | `{job_id: str}` |
-| `GET` | `/jobs` | `?status=<filter>&sort=<col>&order=<dir>` | `[Job]` |
-| `GET` | `/jobs/{id}` | — | `Job` |
-| `DELETE` | `/jobs/{id}` | — | `{deleted: job_id}` |
-| `POST` | `/jobs/{id}/retry` | — | `{retried: job_id}` — resets a `dead` or `failed` job to `pending`; returns an optional `warning` field if the job status is unusual |
-| `GET` | `/query` | `?q=<question>` | `{answer: str, citations: [str]}` |
-| `POST` | `/query` | `{question: str, save?: bool}` | `{answer: str, citations: [str], slug?: str}` |
-| `GET` | `/status` | — | `WikiStatus` |
-| `GET` | `/lint/report` | — | `LintReport` |
-| `GET` | `/health` | — | `{status: "ok"}` |
-| `GET` | `/provenance/citations` _(v0.5.0)_ | `?page=<slug>&source=<file>&broken=<bool>&limit=N&offset=N&sort=<col>&order=<dir>` | `{total: int, citations: [CitationRow]}` |
-| `GET` | `/lifecycle/status` _(v0.6.0)_ | — | `{draft: int, active: int, contradicted: int, stale: int, archived: int}` |
-| `GET` | `/lifecycle/events` _(v0.6.0)_ | `?slug=<slug>&to_state=<state>&limit=N&offset=N` | `{total: int, events: [LifecycleEvent]}` |
-| `POST` | `/lifecycle/transition` _(v0.6.0)_ | `{slug: str, to_state: str, reason?: str}` | `{slug, from_state, to_state, timestamp, cascade_links_removed_from: [str]}` _(cascade field added v1.0.2)_ |
-| `GET` | `/query/stream` _(v0.7.0)_ | `?q=<question>&no_cache=<bool>&timeout_seconds=N` _(timeout added v0.8.0)_ | SSE stream of `data: <token>\n\n` events, terminated by `data: [DONE]\n\n` |
-| `GET` | `/app` _(v0.7.0)_ | — | Serves the React SPA (web chat UI) |
-| `GET` | `/sessions` _(v0.8.0)_ | — | `[{session_id, first_q, last_active, turn_count, questions: [str]}]` |
-| `GET` | `/sessions/{session_id}/messages` _(v0.8.0)_ | — | `[{role, content, timestamp}]` |
-| `GET` | `/graph` _(v1.0.0)_ | — | `{status, node_count, edge_count, cluster_count, nodes: [...], edges: [...]}` or `{status: "computing"}` on first call |
-| `GET` | `/pages/{slug}/history` | `?index=N&include_content=true` | List content snapshots; ?index=N&include_content=true for single |
-| `POST` | `/pages/{slug}/rollback` | `{index: int, reason: str}` | Restore page body to snapshot N |
-| `POST` | `/pages/{slug}/snapshot` | `{content: str, reason?: str}` | Record a content snapshot only when content differs from the last stored snapshot (`recorded: true/false`). Called by the Obsidian plugin on vault modify events. |
-| `DELETE` | `/pages/{slug}/history` | — | Delete all lifecycle events (including snapshots) for a slug; intended for test teardown. |
+
+| Method   | Path                                         | Request                                                                            | Response                                                                                                                                                          |
+| -------- | -------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST`   | `/jobs/ingest`                               | `{source: str}`                                                                    | `{job_id: str}`                                                                                                                                                   |
+| `POST`   | `/jobs/lint`                                 | `{scope?: str}`                                                                    | `{job_id: str}`                                                                                                                                                   |
+| `GET`    | `/jobs`                                      | `?status=<filter>&sort=<col>&order=<dir>`                                          | `[Job]`                                                                                                                                                           |
+| `GET`    | `/jobs/{id}`                                 | —                                                                                 | `Job`                                                                                                                                                             |
+| `DELETE` | `/jobs/{id}`                                 | —                                                                                 | `{deleted: job_id}`                                                                                                                                               |
+| `POST`   | `/jobs/{id}/retry`                           | —                                                                                 | `{retried: job_id}` — resets a `dead` or `failed` job to `pending`; returns an optional `warning` field if the job status is unusual                             |
+| `GET`    | `/query`                                     | `?q=<question>`                                                                    | `{answer: str, citations: [str]}`                                                                                                                                 |
+| `POST`   | `/query`                                     | `{question: str, save?: bool}`                                                     | `{answer: str, citations: [str], slug?: str}`                                                                                                                     |
+| `GET`    | `/status`                                    | —                                                                                 | `WikiStatus`                                                                                                                                                      |
+| `GET`    | `/lint/report`                               | —                                                                                 | `LintReport`                                                                                                                                                      |
+| `GET`    | `/health`                                    | —                                                                                 | `{status: "ok"}`                                                                                                                                                  |
+| `GET`    | `/provenance/citations` _(v0.5.0)_           | `?page=<slug>&source=<file>&broken=<bool>&limit=N&offset=N&sort=<col>&order=<dir>` | `{total: int, citations: [CitationRow]}`                                                                                                                          |
+| `GET`    | `/lifecycle/status` _(v0.6.0)_               | —                                                                                 | `{draft: int, active: int, contradicted: int, stale: int, archived: int}`                                                                                         |
+| `GET`    | `/lifecycle/events` _(v0.6.0)_               | `?slug=<slug>&to_state=<state>&limit=N&offset=N`                                   | `{total: int, events: [LifecycleEvent]}`                                                                                                                          |
+| `POST`   | `/lifecycle/transition` _(v0.6.0)_           | `{slug: str, to_state: str, reason?: str}`                                         | `{slug, from_state, to_state, timestamp, cascade_links_removed_from: [str]}` _(cascade field added v1.0.2)_                                                       |
+| `GET`    | `/query/stream` _(v0.7.0)_                   | `?q=<question>&no_cache=<bool>&timeout_seconds=N` _(timeout added v0.8.0)_         | SSE stream of`data: <token>\n\n` events, terminated by `data: [DONE]\n\n`                                                                                         |
+| `GET`    | `/app` _(v0.7.0)_                            | —                                                                                 | Serves the React SPA (web chat UI)                                                                                                                                |
+| `GET`    | `/sessions` _(v0.8.0)_                       | —                                                                                 | `[{session_id, first_q, last_active, turn_count, questions: [str]}]`                                                                                              |
+| `GET`    | `/sessions/{session_id}/messages` _(v0.8.0)_ | —                                                                                 | `[{role, content, timestamp}]`                                                                                                                                    |
+| `GET`    | `/graph` _(v1.0.0)_                          | —                                                                                 | `{status, node_count, edge_count, cluster_count, nodes: [...], edges: [...]}` or `{status: "computing"}` on first call                                            |
+| `GET`    | `/pages/{slug}/history`                      | `?index=N&include_content=true`                                                    | List content snapshots; ?index=N&include_content=true for single                                                                                                  |
+| `POST`   | `/pages/{slug}/rollback`                     | `{index: int, reason: str}`                                                        | Restore page body to snapshot N                                                                                                                                   |
+| `POST`   | `/pages/{slug}/snapshot`                     | `{content: str, reason?: str}`                                                     | Record a content snapshot only when content differs from the last stored snapshot (`recorded: true/false`). Called by the Obsidian plugin on vault modify events. |
+| `DELETE` | `/pages/{slug}/history`                      | —                                                                                 | Delete all lifecycle events (including snapshots) for a slug; intended for test teardown.                                                                         |
 
 **`GET /jobs` query parameters:**
 
-| Parameter | Values | Default | Description |
-|-----------|--------|---------|-------------|
-| `status` | `pending` \| `in_progress` \| `completed` \| `failed` \| `skipped` \| `dead` \| `cancelled` | _(all)_ | Filter to one status |
-| `sort` | `created_at` \| `status` \| `operation` | `created_at` | Column to sort by |
-| `order` | `asc` \| `desc` | `asc` | Sort direction |
+
+| Parameter | Values                                                                                      | Default      | Description          |
+| --------- | ------------------------------------------------------------------------------------------- | ------------ | -------------------- |
+| `status`  | `pending` \| `in_progress` \| `completed` \| `failed` \| `skipped` \| `dead` \| `cancelled` | _(all)_      | Filter to one status |
+| `sort`    | `created_at` \| `status` \| `operation`                                                     | `created_at` | Column to sort by    |
+| `order`   | `asc` \| `desc`                                                                             | `asc`        | Sort direction       |
 
 **Operation types:** `ingest` (file/URL/web-search ingest jobs) and `lint` (lint pass jobs).
 
@@ -849,6 +871,7 @@ The `progress` field is updated in real time during execution (e.g. `{"phase": "
 ### Path resolution
 
 `POST /jobs/ingest` accepts:
+
 - Absolute path: `/home/user/docs/report.pdf`
 - Vault-relative path: `raw_sources/report.pdf` (resolved against `wiki_root`)
 - URL: `https://example.com/article`
@@ -864,13 +887,14 @@ for example, Claude Code session transcripts at `~/.claude/projects/<hash>/<id>.
 
 **Client behaviour summary:**
 
-| Client | Sends `allow_external_paths` | Can ingest outside wiki root? |
-|--------|------------------------------|-------------------------------|
-| CLI (`synthadoc ingest <path>`) | `true` (automatic, local file paths only) | Yes — server is localhost |
-| Obsidian plugin | Never sent (field omitted → defaults `false`) | No — wiki-relative paths and URLs only |
-| Web UI | Never sent (field omitted → defaults `false`) | No — wiki-relative paths and URLs only |
-| Direct HTTP API (localhost) | Set manually in request body | Yes — if request from 127.0.0.1/::1 |
-| Direct HTTP API (remote) | Ignored by server | No — server silently treats as `false` |
+
+| Client                          | Sends`allow_external_paths`                   | Can ingest outside wiki root?           |
+| ------------------------------- | --------------------------------------------- | --------------------------------------- |
+| CLI (`synthadoc ingest <path>`) | `true` (automatic, local file paths only)     | Yes — server is localhost              |
+| Obsidian plugin                 | Never sent (field omitted → defaults`false`) | No — wiki-relative paths and URLs only |
+| Web UI                          | Never sent (field omitted → defaults`false`) | No — wiki-relative paths and URLs only |
+| Direct HTTP API (localhost)     | Set manually in request body                  | Yes — if request from 127.0.0.1/::1    |
+| Direct HTTP API (remote)        | Ignored by server                             | No — server silently treats as`false`  |
 
 ### Background worker
 
@@ -880,8 +904,8 @@ The HTTP server runs a background task that polls `jobs.db` every 2 seconds and 
 
 ## 8. Obsidian Plugin
 
-**Package:** `synthadoc-obsidian` (TypeScript)  
-**Location:** `obsidian-plugin/` in the repo  
+**Package:** `synthadoc-obsidian` (TypeScript)
+**Location:** `obsidian-plugin/` in the repo
 **Version:** 1.1.0
 
 Each vault configures its server URL in plugin settings (default `http://127.0.0.1:7070`).
@@ -894,21 +918,22 @@ Reload the plugin (toggle off/on) after copying — a full Obsidian restart is n
 
 ### Command palette
 
-| Command | Behaviour |
-|---------|-----------|
-| `Synthadoc: Ingest...` | Tabbed modal with four ingest modes. **Web search** — type a topic, set max results (1–50, default 20) and poll interval (500–10 000 ms, default 2000 ms); polls live showing phase text, pages list, and per-URL errors until all fan-out jobs settle. `Ctrl/Cmd+Enter` to submit. **From URL** — paste any URL and queue it for ingest; polls job status live. **All sources in folder** — queues every supported file in the configured raw sources folder. **Pick files** — click **Browse…** to select a folder from the OS picker, then **Scan** to list supported files; wiki sub-folder contents and common system files are excluded automatically; select files and click **Ingest selected**. |
-| `Synthadoc: Query: ask the wiki...` | Responsive modal (min 520px, 60vw, max 860px); markdown-rendered answer with citation footer; stays open when clicking elsewhere — must be closed explicitly via ✕ or Escape |
-| `Synthadoc: Lint: report` | 3-tab modal — **Contradictions**, **Orphans**, **Adversarial** _(v0.5.0)_. The Adversarial tab shows each flagged claim (orange) with its concern and suggested re-ingest commands. |
-| `Synthadoc: Lint: run...` | Modal with **Auto-resolve** and **Skip adversarial review** _(v0.5.0)_ checkboxes. Queues a lint job; polls progress live; reports contradiction, orphan, and adversarial warning counts when complete. Tick **Skip adversarial review** to run structural-only lint (also clears existing `lint_warnings`). |
-| `Synthadoc: View Page Provenance` _(v0.5.0)_ | Sortable, paginated table of every claim citation recorded across the wiki — page, claim excerpt, source file, line range, and ingest timestamp. Draggable; all cell content is selectable and copyable. Click any row to open the Source Viewer showing the exact source lines with ±5 lines of context. For PDF sources a page-jump button opens the native PDF viewer at the correct page. |
-| `Synthadoc: Manage Page Lifecycle` _(v0.6.0)_ | Three-tab modal. **Current States** — sortable, filterable, paginated table (dynamic row count based on modal height) of all wiki pages with their current lifecycle state and last transition timestamp; click column headers to sort; each row shows valid transition buttons with a reason dialog before committing; draft/stale badge links on the lint modal and jobs panel open the table pre-filtered to that state. **Audit Log** — full history of every state transition across all pages, searchable by slug, filterable by target state, sortable by any column, with pagination and a purge footer (keep latest N per slug, or purge events before a date). **Content Snapshots** _(v1.2.0)_ — flat list of all snapshots across all pages, grouped by slug and sorted by index when unfiltered; filter-by-slug input with a × clear button; each row shows slug, snapshot index, state transition, triggered-by, timestamp, and size; click a row to open the corresponding wiki page; **View** button shows the snapshot diff against the current file body (LCS diff, YAML frontmatter stripped); **Rollback** button restores the page body to that snapshot (saves current body first, making rollback undoable). |
-| `Synthadoc: Jobs...` | Modal with status-filter checkboxes (pending, in_progress, completed, failed, skipped, dead, cancelled), sortable results table (click **Status**, **Operation**, or **Created** headers to sort ascending; click again to reverse; ▲/▼ indicates active sort, ⇅ indicates unsorted; default: newest first), error detail rows for failed/dead/cancelled jobs, pagination (25 per page), auto-refresh countdown, a **Retry selected** button (enabled when ≥ 1 selected job is failed/dead/cancelled) and a **Delete selected** button (enabled when ≥ 1 job is selected). A **Purge old jobs** footer row lets you set a day threshold and remove old completed/dead jobs in one click. |
-| `Synthadoc: Routing: manage ROUTING.md...` | Modal panel with three buttons. **Init** creates ROUTING.md from the current index.md branch structure (enabled only when ROUTING.md does not exist). **Validate** reports two things: dangling slugs (pages listed in ROUTING.md that no longer exist in the wiki) and unassigned slugs (pages that exist in index.md but are not listed in any ROUTING.md branch). Enabled only when ROUTING.md exists. **Clean** removes dangling slugs from ROUTING.md (enabled only when ROUTING.md exists). After each action the result appears inline with per-entry `[Branch] [[slug]]` detail rows. |
-| `Synthadoc: Staging: manage staging policy...` | Modal panel showing the current policy state. A segmented control switches between **Off**, **All**, and **Threshold**. When **Threshold** is selected, a second segmented control sets the minimum confidence (**High** / **Medium** / **Low**). A **Save** button persists the change via the HTTP API and updates the inline status. A footer link opens the Candidates modal directly. |
-| `Synthadoc: Candidates: review candidate pages...` | Paginated table (50 per page) of all staged candidate pages. Each row shows the slug, a colour-coded confidence badge, and a checkbox. **Promote All** and **Discard All** act on every candidate; **Promote Selected** and **Discard Selected** act on checked rows. The table reloads automatically after each action. A footer link opens the Staging policy modal. |
-| `Synthadoc: Context: build context pack...` | Modal with a goal/question text area, a token budget field (default 4000), and a **Build Context Pack** button (`Ctrl/Cmd+Enter` also triggers). The server decomposes the goal, retrieves and ranks wiki pages via BM25, and packs them within the budget. The result is rendered as cited Markdown in a read-only text area. **Copy to Clipboard** copies the content to the OS clipboard. **Save as .md** downloads the Markdown file with a slug-derived filename. |
-| `Synthadoc: Audit...` | Tabbed modal with four audit views, each loading automatically on open. **Query history** — paginated (50 per page) query records with question, sub-question count, token use, cost, and timestamp; ← Prev / Page X of Y (Z total) / Next → / ↻ Reload controls. **Ingest history** — paginated (50 per page) ingest records with source filename, wiki page slug, tokens, cost, and ingested-at timestamp; same pager controls. **Events** — paginated (100 per page) raw audit events with timestamp, job ID, event type, and metadata; same pager controls. **Cost summary** — total tokens and cost over the last N days (default 30) plus per-day breakdown. |
-| `Graph: show knowledge graph` _(v1.1.0)_ | Open the knowledge graph panel — draggable modal with Canvas force-directed graph, type filter dropdown, cluster legend, hover tooltip showing title/slug/type/state/cluster/connections, and click-to-open page in current pane. System pages (index, overview, dashboard, purpose, log) are excluded. Capped at 300 most-connected nodes for large wikis with an explanatory banner. |
+
+| Command                                            | Behaviour                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Synthadoc: Ingest...`                             | Tabbed modal with four ingest modes.**Web search** — type a topic, set max results (1–50, default 20) and poll interval (500–10 000 ms, default 2000 ms); polls live showing phase text, pages list, and per-URL errors until all fan-out jobs settle. `Ctrl/Cmd+Enter` to submit. **From URL** — paste any URL and queue it for ingest; polls job status live. **All sources in folder** — queues every supported file in the configured raw sources folder. **Pick files** — click **Browse…** to select a folder from the OS picker, then **Scan** to list supported files; wiki sub-folder contents and common system files are excluded automatically; select files and click **Ingest selected**.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `Synthadoc: Query: ask the wiki...`                | Responsive modal (min 520px, 60vw, max 860px); markdown-rendered answer with citation footer; stays open when clicking elsewhere — must be closed explicitly via ✕ or Escape                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `Synthadoc: Lint: report`                          | 3-tab modal —**Contradictions**, **Orphans**, **Adversarial** _(v0.5.0)_. The Adversarial tab shows each flagged claim (orange) with its concern and suggested re-ingest commands.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `Synthadoc: Lint: run...`                          | Modal with**Auto-resolve** and **Skip adversarial review** _(v0.5.0)_ checkboxes. Queues a lint job; polls progress live; reports contradiction, orphan, and adversarial warning counts when complete. Tick **Skip adversarial review** to run structural-only lint (also clears existing `lint_warnings`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `Synthadoc: View Page Provenance` _(v0.5.0)_       | Sortable, paginated table of every claim citation recorded across the wiki — page, claim excerpt, source file, line range, and ingest timestamp. Draggable; all cell content is selectable and copyable. Click any row to open the Source Viewer showing the exact source lines with ±5 lines of context. For PDF sources a page-jump button opens the native PDF viewer at the correct page.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `Synthadoc: Manage Page Lifecycle` _(v0.6.0)_      | Three-tab modal.**Current States** — sortable, filterable, paginated table (dynamic row count based on modal height) of all wiki pages with their current lifecycle state and last transition timestamp; click column headers to sort; each row shows valid transition buttons with a reason dialog before committing; draft/stale badge links on the lint modal and jobs panel open the table pre-filtered to that state. **Audit Log** — full history of every state transition across all pages, searchable by slug, filterable by target state, sortable by any column, with pagination and a purge footer (keep latest N per slug, or purge events before a date). **Content Snapshots** _(v1.2.0)_ — flat list of all snapshots across all pages, grouped by slug and sorted by index when unfiltered; filter-by-slug input with a × clear button; each row shows slug, snapshot index, state transition, triggered-by, timestamp, and size; click a row to open the corresponding wiki page; **View** button shows the snapshot diff against the current file body (LCS diff, YAML frontmatter stripped); **Rollback** button restores the page body to that snapshot (saves current body first, making rollback undoable). |
+| `Synthadoc: Jobs...`                               | Modal with status-filter checkboxes (pending, in_progress, completed, failed, skipped, dead, cancelled), sortable results table (click**Status**, **Operation**, or **Created** headers to sort ascending; click again to reverse; ▲/▼ indicates active sort, ⇅ indicates unsorted; default: newest first), error detail rows for failed/dead/cancelled jobs, pagination (25 per page), auto-refresh countdown, a **Retry selected** button (enabled when ≥ 1 selected job is failed/dead/cancelled) and a **Delete selected** button (enabled when ≥ 1 job is selected). A **Purge old jobs** footer row lets you set a day threshold and remove old completed/dead jobs in one click.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `Synthadoc: Routing: manage ROUTING.md...`         | Modal panel with three buttons.**Init** creates ROUTING.md from the current index.md branch structure (enabled only when ROUTING.md does not exist). **Validate** reports two things: dangling slugs (pages listed in ROUTING.md that no longer exist in the wiki) and unassigned slugs (pages that exist in index.md but are not listed in any ROUTING.md branch). Enabled only when ROUTING.md exists. **Clean** removes dangling slugs from ROUTING.md (enabled only when ROUTING.md exists). After each action the result appears inline with per-entry `[Branch] [[slug]]` detail rows.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `Synthadoc: Staging: manage staging policy...`     | Modal panel showing the current policy state. A segmented control switches between**Off**, **All**, and **Threshold**. When **Threshold** is selected, a second segmented control sets the minimum confidence (**High** / **Medium** / **Low**). A **Save** button persists the change via the HTTP API and updates the inline status. A footer link opens the Candidates modal directly.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `Synthadoc: Candidates: review candidate pages...` | Paginated table (50 per page) of all staged candidate pages. Each row shows the slug, a colour-coded confidence badge, and a checkbox.**Promote All** and **Discard All** act on every candidate; **Promote Selected** and **Discard Selected** act on checked rows. The table reloads automatically after each action. A footer link opens the Staging policy modal.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `Synthadoc: Context: build context pack...`        | Modal with a goal/question text area, a token budget field (default 4000), and a**Build Context Pack** button (`Ctrl/Cmd+Enter` also triggers). The server decomposes the goal, retrieves and ranks wiki pages via BM25, and packs them within the budget. The result is rendered as cited Markdown in a read-only text area. **Copy to Clipboard** copies the content to the OS clipboard. **Save as .md** downloads the Markdown file with a slug-derived filename.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `Synthadoc: Audit...`                              | Tabbed modal with four audit views, each loading automatically on open.**Query history** — paginated (50 per page) query records with question, sub-question count, token use, cost, and timestamp; ← Prev / Page X of Y (Z total) / Next → / ↻ Reload controls. **Ingest history** — paginated (50 per page) ingest records with source filename, wiki page slug, tokens, cost, and ingested-at timestamp; same pager controls. **Events** — paginated (100 per page) raw audit events with timestamp, job ID, event type, and metadata; same pager controls. **Cost summary** — total tokens and cost over the last N days (default 30) plus per-day breakdown.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `Graph: show knowledge graph` _(v1.1.0)_           | Open the knowledge graph panel — draggable modal with Canvas force-directed graph, type filter dropdown, cluster legend, hover tooltip showing title/slug/type/state/cluster/connections, and click-to-open page in current pane. System pages (index, overview, dashboard, purpose, log) are excluded. Capped at 300 most-connected nodes for large wikis with an explanatory banner.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 
 ### Ribbon icon
 
@@ -921,10 +946,11 @@ If the icon is not visible, make sure the plugin is enabled under **Settings →
 
 ### Settings
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| Server URL | `http://127.0.0.1:7070` | HTTP server for this vault |
-| Raw sources folder | `raw_sources` | Folder scanned by "Ingest all sources" |
+
+| Setting            | Default                 | Description                            |
+| ------------------ | ----------------------- | -------------------------------------- |
+| Server URL         | `http://127.0.0.1:7070` | HTTP server for this vault             |
+| Raw sources folder | `raw_sources`           | Folder scanned by "Ingest all sources" |
 
 ### Background vault monitoring _(v1.2.0)_
 
@@ -952,7 +978,6 @@ without requiring any explicit user action.
 ---
 
 ## 9. CLI
-
 
 The CLI is a thin HTTP client — it posts jobs to the running server and polls for results. No LLM agents run in the CLI process.
 
@@ -1034,14 +1059,15 @@ synthadoc
 
 ### `schedule` sub-commands
 
-| Command | Description |
-|---|---|
-| `schedule add --op "<cmd>" --cron "<expr>"` | Register a single recurring job with the scheduler |
-| `schedule apply` | Bulk-register all jobs declared in `[[schedule.jobs]]` in `config.toml`; idempotent alternative to running `schedule add` once per job |
-| `schedule list` | List all registered jobs with their cron expression, next run time, last run time, and last result |
-| `schedule remove <id>` | Remove a registered job by ID |
-| `schedule run --op "<cmd>"` | Execute an operation immediately and record the result in the audit trail |
-| `schedule history` | Show recent scheduled run history from the audit trail |
+
+| Command                                     | Description                                                                                                                           |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `schedule add --op "<cmd>" --cron "<expr>"` | Register a single recurring job with the scheduler                                                                                    |
+| `schedule apply`                            | Bulk-register all jobs declared in`[[schedule.jobs]]` in `config.toml`; idempotent alternative to running `schedule add` once per job |
+| `schedule list`                             | List all registered jobs with their cron expression, next run time, last run time, and last result                                    |
+| `schedule remove <id>`                      | Remove a registered job by ID                                                                                                         |
+| `schedule run --op "<cmd>"`                 | Execute an operation immediately and record the result in the audit trail                                                             |
+| `schedule history`                          | Show recent scheduled run history from the audit trail                                                                                |
 
 `schedule apply` is the recommended setup path when jobs are declared in `config.toml`. It reads the `[[schedule.jobs]]` array and registers every entry in one command, making schedule configuration reproducible and version-controllable:
 
@@ -1061,12 +1087,13 @@ synthadoc schedule apply -w my-wiki
 
 ### `query` options
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--save` | off | Save the answer as a new wiki page |
-| `--no-stream` | off | Disable token-by-token streaming; print the full answer when complete. Use in scripts, pipes, or terminals that do not handle ANSI escape codes. |
-| `--no-cache` | off | Bypass the query result cache and always call the LLM. |
-| `--timeout N` | `60` | Seconds to wait for the LLM response. Increase for slower providers (e.g. `--timeout 120` for MiniMax reasoning models) |
+
+| Flag          | Default | Description                                                                                                                                      |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--save`      | off     | Save the answer as a new wiki page                                                                                                               |
+| `--no-stream` | off     | Disable token-by-token streaming; print the full answer when complete. Use in scripts, pipes, or terminals that do not handle ANSI escape codes. |
+| `--no-cache`  | off     | Bypass the query result cache and always call the LLM.                                                                                           |
+| `--timeout N` | `60`    | Seconds to wait for the LLM response. Increase for slower providers (e.g.`--timeout 120` for MiniMax reasoning models)                           |
 
 ### `ingest --analyse-only`
 
@@ -1145,33 +1172,34 @@ Every user-facing error carries a stable code in the format `[ERR-<CATEGORY>-<NN
 
 **File:** `synthadoc/errors.py`
 
-| Code | Meaning |
-|------|---------|
-| `ERR-SRV-001` | No server listening for the requested wiki |
-| `ERR-SRV-002` | Port already bound by another process |
-| `ERR-SRV-003` | Server returned a 4xx/5xx HTTP response |
-| `ERR-SRV-004` | Background server process exited immediately |
-| `ERR-WIKI-001` | Wiki root directory does not exist |
-| `ERR-WIKI-002` | Directory exists but missing `wiki/` subfolder |
-| `ERR-WIKI-003` | `wiki/` directory is not writable |
-| `ERR-WIKI-004` | Install target already exists on disk |
-| `ERR-WIKI-005` | Unknown demo template name |
-| `ERR-WIKI-006` | Name not in `~/.synthadoc/wikis.json` |
-| `ERR-WIKI-007` | Backup requires a newer `db_schema_version` than installed |
-| `ERR-CFG-001` | Required API key environment variable not set |
-| `ERR-CFG-002` | Provider name not recognised |
-| `ERR-SKILL-001` | No skill matched the source string |
-| `ERR-SKILL-002` | Required pip package for skill not installed |
-| `ERR-SKILL-003` | URL returned 403 (bot/paywall protection) |
-| `ERR-SKILL-004` | `TAVILY_API_KEY` not set for web search |
-| `ERR-INGEST-001` | Source file or directory not found |
-| `ERR-INGEST-002` | Source file exists but is empty |
-| `ERR-INGEST-003` | `--batch` target is not a directory |
-| `ERR-QUERY-001` | LLM synthesis timed out; retry the query |
-| `ERR-JOB-001` | Job ID does not exist in `jobs.db` |
-| `ERR-PROV-001` | Daily API quota exhausted for today |
-| `ERR-PROV-002` | Coding tool CLI usage quota exhausted |
-| `ERR-AGENT-001` | LLM agent call failed (empty response, bad JSON, timeout) |
+
+| Code             | Meaning                                                   |
+| ---------------- | --------------------------------------------------------- |
+| `ERR-SRV-001`    | No server listening for the requested wiki                |
+| `ERR-SRV-002`    | Port already bound by another process                     |
+| `ERR-SRV-003`    | Server returned a 4xx/5xx HTTP response                   |
+| `ERR-SRV-004`    | Background server process exited immediately              |
+| `ERR-WIKI-001`   | Wiki root directory does not exist                        |
+| `ERR-WIKI-002`   | Directory exists but missing`wiki/` subfolder             |
+| `ERR-WIKI-003`   | `wiki/` directory is not writable                         |
+| `ERR-WIKI-004`   | Install target already exists on disk                     |
+| `ERR-WIKI-005`   | Unknown demo template name                                |
+| `ERR-WIKI-006`   | Name not in`~/.synthadoc/wikis.json`                      |
+| `ERR-WIKI-007`   | Backup requires a newer`db_schema_version` than installed |
+| `ERR-CFG-001`    | Required API key environment variable not set             |
+| `ERR-CFG-002`    | Provider name not recognised                              |
+| `ERR-SKILL-001`  | No skill matched the source string                        |
+| `ERR-SKILL-002`  | Required pip package for skill not installed              |
+| `ERR-SKILL-003`  | URL returned 403 (bot/paywall protection)                 |
+| `ERR-SKILL-004`  | `TAVILY_API_KEY` not set for web search                   |
+| `ERR-INGEST-001` | Source file or directory not found                        |
+| `ERR-INGEST-002` | Source file exists but is empty                           |
+| `ERR-INGEST-003` | `--batch` target is not a directory                       |
+| `ERR-QUERY-001`  | LLM synthesis timed out; retry the query                  |
+| `ERR-JOB-001`    | Job ID does not exist in`jobs.db`                         |
+| `ERR-PROV-001`   | Daily API quota exhausted for today                       |
+| `ERR-PROV-002`   | Coding tool CLI usage quota exhausted                     |
+| `ERR-AGENT-001`  | LLM agent call failed (empty response, bad JSON, timeout) |
 
 **CLI errors** go through the `cli_error(code, message, hint)` helper, which prints `[ERR-XXX-NNN] message` to stderr with an optional hint line and exits with code 1. **Agent and skill errors** embed the code directly in the exception message string so it surfaces in the job `error` field.
 
@@ -1214,22 +1242,24 @@ default = { provider = "gemini", model = "gemini-2.5-flash" }
 
 Required environment variables per provider:
 
-| Provider | Env var | Free tier | Vision |
-|----------|---------|-----------|--------|
-| `anthropic` | `ANTHROPIC_API_KEY` | No (pay-per-token) | Yes |
-| `openai` | `OPENAI_API_KEY` | No (pay-per-token) | Yes |
-| `gemini` | `GEMINI_API_KEY` | **Yes** — 15 RPM / 1M tokens/day on Flash | Yes |
-| `groq` | `GROQ_API_KEY` | **Yes** — generous free tier on Llama/Mixtral models | No |
-| `minimax` | `MINIMAX_API_KEY` | No (pay-per-token) | Yes (M2.5 / M2.7 natively multimodal) |
-| `deepseek` | `DEEPSEEK_API_KEY` | No (pay-per-token, very cheap) | No (text-only) |
-| `qwen` | `QWEN_API_KEY` | Yes — 1M free tokens (90-day trial), then paid DashScope | Model-dependent |
-| `ollama` | _(none)_ | **Yes** — fully local; **GPU required** — CPU-only inference is too slow for interactive use | Model-dependent |
+
+| Provider    | Env var             | Free tier                                                                                      | Vision                                |
+| ----------- | ------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `anthropic` | `ANTHROPIC_API_KEY` | No (pay-per-token)                                                                             | Yes                                   |
+| `openai`    | `OPENAI_API_KEY`    | No (pay-per-token)                                                                             | Yes                                   |
+| `gemini`    | `GEMINI_API_KEY`    | **Yes** — 15 RPM / 1M tokens/day on Flash                                                     | Yes                                   |
+| `groq`      | `GROQ_API_KEY`      | **Yes** — generous free tier on Llama/Mixtral models                                          | No                                    |
+| `minimax`   | `MINIMAX_API_KEY`   | No (pay-per-token)                                                                             | Yes (M2.5 / M2.7 natively multimodal) |
+| `deepseek`  | `DEEPSEEK_API_KEY`  | No (pay-per-token, very cheap)                                                                 | No (text-only)                        |
+| `qwen`      | `QWEN_API_KEY`      | Yes — 1M free tokens (90-day trial), then paid DashScope                                      | Model-dependent                       |
+| `ollama`    | _(none)_            | **Yes** — fully local; **GPU required** — CPU-only inference is too slow for interactive use | Model-dependent                       |
 
 ### Coding tool CLI providers — no API key needed
 
 If you have an active **Claude Code** subscription, or want to use the free **Opencode Zen** tier, you can use either as the LLM provider with no separate API key.
 
 **Requirements:** the CLI tool must be installed and reachable on `PATH`:
+
 - Claude Code: `claude` binary — install via `npm install -g @anthropic-ai/claude-code`
 - Opencode: `opencode` binary — install via `npm install -g opencode`
 
@@ -1255,6 +1285,7 @@ synthadoc serve -w <wiki-name> --provider claude-code
 ```
 
 **Limitations:**
+
 - Vector search (`search.vector = true`) is not supported — search falls back to BM25-only. Sufficient for wikis up to a few hundred pages.
 - Quota is shared with your coding tool usage. Heavy batch ingest consumes from the same daily budget. Quota exhaustion permanently fails the job (no retry) with a clear message.
 
@@ -1323,62 +1354,63 @@ cron = "0 3 * * 0"   # every Sunday at 03:00
 
 ### Config keys reference
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `wiki.domain` | str | `"General"` | Topic scope of the wiki. Used in prompts to keep ingest focused. Example: `"Machine Learning"` or `"Quantum Computing"`. |
-| `agents.default.provider` | str | `"gemini"` | LLM provider: `anthropic`, `openai`, `gemini`, `groq`, `minimax`, `deepseek`, `qwen`, `ollama` |
-| `agents.default.model` | str | `"gemini-2.5-flash"` | Model ID passed to the provider API |
-| `agents.default.base_url` | str | `""` | Override the provider's API endpoint. Use this to point any OpenAI-compatible provider at a custom URL (e.g. a local proxy or a private deployment). |
-| `agents.default.thinking` | str | `""` | Reasoning mode: `"disabled"` turns off chain-of-thought (faster, cheaper on MiniMax M3 and Qwen); `"enabled"` or `"adaptive"` turns it on. Empty string uses the provider's default. Applies to `minimax`, `qwen` (DashScope), and `deepseek` providers; ignored by others. |
-| `agents.ingest.provider` | str | (inherits default) | Override provider/model for the ingest agent only. Useful to use a cheap fast model for ingest while keeping a high-quality model for queries. |
-| `agents.ingest.model` | str | (inherits default) | Model ID for the ingest agent override. |
-| `agents.query.provider` | str | (inherits default) | Override provider/model for query answering only. |
-| `agents.query.model` | str | (inherits default) | Model ID for the query agent override. |
-| `agents.lint.provider` | str | (inherits default) | Override provider/model for the lint agent only. |
-| `agents.lint.model` | str | (inherits default) | Model ID for the lint agent override. |
-| `agents.adversarial.provider` | str | (inherits default) | Dedicated LLM provider for adversarial lint review. Falls back to `agents.default` when not set. Cross-model adversarial reduces self-serving bias — a different model family evaluates claims independently. |
-| `agents.adversarial.model` | str | (inherits default) | Model ID for the adversarial reviewer. For maximum independence, choose a model from a different family than the ingest model. |
-| `agents.llm_timeout_seconds` | int | `0` | Per-call LLM timeout in seconds; `0` = no limit. Set to e.g. `90` when using reasoning models (MiniMax-M2.5, DeepSeek-R1) that can exceed their internal generation budget silently. Restart required. |
-| `agents.scaffold_max_tokens` | int | `8192` | Max output tokens for the scaffold (page generation) agent. Increase to `16384`+ when using reasoning models on large wikis where the default budget is exhausted. |
-| `agents.query_max_tokens` | int | `8192` | Max output tokens for the query agent. Increase if reasoning models exhaust their budget before completing the answer. |
-| `lint.adversarial_max_per_page` | int | `3` | Maximum adversarial warnings flagged per page. Must be ≥ `adversarial_gate_threshold` for the gate to fire. Raise to 4–5 for a thorough audit; lower to 1–2 to reduce noise on large wikis. |
-| `lint.check_url_availability` | bool | `false` | When `true`, lint performs an HTTP HEAD check on every URL source and flags unreachable URLs. Adds network calls to each lint run; opt-in only. |
-| `server.host` | str | `"127.0.0.1"` | Bind address. Change to `"0.0.0.0"` to expose the server on all interfaces (e.g. for LAN access). No built-in auth — restrict via firewall when exposing. |
-| `server.port` | int | `7070` | HTTP listen port. Change when running multiple wikis simultaneously. |
-| `ingest.max_pages_per_ingest` | int | `15` | Max pages one ingest job may create or update. |
-| `ingest.chunk_size` | int | `1500` | Text chunk size in characters for BM25 indexing. |
-| `ingest.chunk_overlap` | int | `150` | Overlap between consecutive chunks. |
-| `ingest.fetch_timeout_seconds` | int | `30` | Seconds to wait for a URL response before failing the fetch. |
-| `ingest.staging_policy` | str | `"off"` | Candidate staging gate: `"off"` = commit pages immediately; `"all"` = stage all new pages for review; `"threshold"` = stage only pages below `staging_confidence_min`. |
-| `ingest.staging_confidence_min` | str | `"high"` | Minimum confidence to auto-commit when `staging_policy = "threshold"`. Values: `"high"`, `"medium"`, `"low"`. Pages below this threshold are held as candidates. |
-| `query.gap_score_threshold` | float | `2.0` | BM25 score below which a knowledge gap is detected and `suggested_searches` are returned instead of (or alongside) an answer. Lower = more sensitive gap detection. |
-| `query.context_token_budget` | int | `4000` | Token budget for context pack assembly. Increase for richer context on complex queries; decrease if hitting prompt size limits. |
-| `queue.max_parallel_ingest` | int | `4` | Reserved for future parallel execution. The worker currently processes jobs sequentially; this field has no runtime effect. |
-| `queue.max_retries` | int | `3` | Retries before job → dead |
-| `queue.backoff_base_seconds` | int | `30` | Exponential backoff base; delays are `min(base × 2^(attempt−1), 300)` seconds |
-| `cache.version` | str | `"4"` | Bump to invalidate all cached LLM responses without touching source code |
-| `cost.soft_warn_usd` | float | `0.50` | Emit `logger.warning` in server log when per-job ingest cost exceeds this threshold; job continues normally |
-| `cost.hard_gate_usd` | float | `2.00` | Permanently fail the ingest job (DEAD) and record a `cost_gate_exceeded` audit event when per-job cost exceeds this threshold |
-| `cost.auto_resolve_confidence_threshold` | float | `0.85` | Auto-apply lint resolutions above this score |
-| `chat.conversation_history_turns` | int | `5` | Number of prior conversation turns injected into each query prompt for multi-turn context. Set to `0` to disable conversation history (each query answered independently). |
-| `chat.session_retention_days` | int | `30` | Days to retain chat session history in `audit.db`. Sessions older than this are pruned automatically. |
-| `audit.lifecycle_retention_days` | int | `0` | Days to retain lifecycle events in `audit.db`. `0` = keep forever. When set, events older than this threshold are pruned at the end of each lint run. |
-| `audit.url_staleness_days` | int | `0` | Days after which URL-sourced pages are automatically marked `stale` if the source URL has not been re-ingested. `0` = disabled. |
-| `logs.level` | str | `"INFO"` | Console log level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `logs.max_file_mb` | int | `5` | Rotate `synthadoc.log` at this size (MB) |
-| `logs.backup_count` | int | `5` | Rotated log files to keep; total disk ≈ `max_file_mb × (backup_count + 1)` |
-| `web_search.provider` | str | `"tavily"` | Web search provider (currently only `tavily` supported) |
-| `web_search.max_results` | int | `20` | Maximum results fetched per web search query |
-| `search.vector` | bool | `false` | Enable semantic re-ranking; downloads `BAAI/bge-small-en-v1.5` (~130 MB) once on first enable |
-| `search.vector_top_candidates` | int | `20` | BM25 candidate pool size when vector re-ranking is active |
-| `ingest.max_source_chars` | int | `32000` | Character limit applied to each source before the LLM call. Sources exceeding this limit are truncated; the page's `sources:` frontmatter entry gets `truncated: true` and lint emits a warning. Override per-run with `--max-source-chars N`. _(v1.0.0)_ |
-| `ingest.citation_source_lines` | int | `400` | Number of source lines the LLM sees during Pass 4 (citation annotation). Increase if lint reports `out_of_range` on long sources such as transcripts or PDFs. Raise `citation_max_tokens` in proportion when increasing this value. |
-| `ingest.citation_max_tokens` | int | `8192` | Output token budget for the annotated section returned by Pass 4. Increase when `citation_source_lines` is raised or wiki sections are long, to avoid truncated annotations. |
-| `query.context_wiki_pct` | float | `0.60` | Fraction of the model context window reserved for wiki source pages. _(v1.0.0)_ |
-| `query.context_history_pct` | float | `0.20` | Fraction reserved for conversation history. _(v1.0.0)_ |
-| `query.context_system_pct` | float | `0.15` | Fraction reserved for system prompt and instructions. Parsed and validated but not yet enforced as a hard cap in v1.0.0. _(v1.0.0)_ |
-| `query.context_index_pct` | float | `0.05` | Fraction reserved for the wiki index preamble. Parsed and validated but not yet enforced as a hard cap in v1.0.0. _(v1.0.0)_ |
-| `query.context_window` | int | _(auto)_ | Override the built-in context window lookup for the configured model. Use when running a local or custom model whose window size is not in the built-in table. _(v1.0.0)_ |
+
+| Key                                      | Type  | Default              | Description                                                                                                                                                                                                                                                                |
+| ---------------------------------------- | ----- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wiki.domain`                            | str   | `"General"`          | Topic scope of the wiki. Used in prompts to keep ingest focused. Example:`"Machine Learning"` or `"Quantum Computing"`.                                                                                                                                                    |
+| `agents.default.provider`                | str   | `"gemini"`           | LLM provider:`anthropic`, `openai`, `gemini`, `groq`, `minimax`, `deepseek`, `qwen`, `ollama`                                                                                                                                                                              |
+| `agents.default.model`                   | str   | `"gemini-2.5-flash"` | Model ID passed to the provider API                                                                                                                                                                                                                                        |
+| `agents.default.base_url`                | str   | `""`                 | Override the provider's API endpoint. Use this to point any OpenAI-compatible provider at a custom URL (e.g. a local proxy or a private deployment).                                                                                                                       |
+| `agents.default.thinking`                | str   | `""`                 | Reasoning mode:`"disabled"` turns off chain-of-thought (faster, cheaper on MiniMax M3 and Qwen); `"enabled"` or `"adaptive"` turns it on. Empty string uses the provider's default. Applies to `minimax`, `qwen` (DashScope), and `deepseek` providers; ignored by others. |
+| `agents.ingest.provider`                 | str   | (inherits default)   | Override provider/model for the ingest agent only. Useful to use a cheap fast model for ingest while keeping a high-quality model for queries.                                                                                                                             |
+| `agents.ingest.model`                    | str   | (inherits default)   | Model ID for the ingest agent override.                                                                                                                                                                                                                                    |
+| `agents.query.provider`                  | str   | (inherits default)   | Override provider/model for query answering only.                                                                                                                                                                                                                          |
+| `agents.query.model`                     | str   | (inherits default)   | Model ID for the query agent override.                                                                                                                                                                                                                                     |
+| `agents.lint.provider`                   | str   | (inherits default)   | Override provider/model for the lint agent only.                                                                                                                                                                                                                           |
+| `agents.lint.model`                      | str   | (inherits default)   | Model ID for the lint agent override.                                                                                                                                                                                                                                      |
+| `agents.adversarial.provider`            | str   | (inherits default)   | Dedicated LLM provider for adversarial lint review. Falls back to`agents.default` when not set. Cross-model adversarial reduces self-serving bias — a different model family evaluates claims independently.                                                              |
+| `agents.adversarial.model`               | str   | (inherits default)   | Model ID for the adversarial reviewer. For maximum independence, choose a model from a different family than the ingest model.                                                                                                                                             |
+| `agents.llm_timeout_seconds`             | int   | `0`                  | Per-call LLM timeout in seconds;`0` = no limit. Set to e.g. `90` when using reasoning models (MiniMax-M2.5, DeepSeek-R1) that can exceed their internal generation budget silently. Restart required.                                                                      |
+| `agents.scaffold_max_tokens`             | int   | `8192`               | Max output tokens for the scaffold (page generation) agent. Increase to`16384`+ when using reasoning models on large wikis where the default budget is exhausted.                                                                                                          |
+| `agents.query_max_tokens`                | int   | `8192`               | Max output tokens for the query agent. Increase if reasoning models exhaust their budget before completing the answer.                                                                                                                                                     |
+| `lint.adversarial_max_per_page`          | int   | `3`                  | Maximum adversarial warnings flagged per page. Must be ≥`adversarial_gate_threshold` for the gate to fire. Raise to 4–5 for a thorough audit; lower to 1–2 to reduce noise on large wikis.                                                                              |
+| `lint.check_url_availability`            | bool  | `false`              | When`true`, lint performs an HTTP HEAD check on every URL source and flags unreachable URLs. Adds network calls to each lint run; opt-in only.                                                                                                                             |
+| `server.host`                            | str   | `"127.0.0.1"`        | Bind address. Change to`"0.0.0.0"` to expose the server on all interfaces (e.g. for LAN access). No built-in auth — restrict via firewall when exposing.                                                                                                                  |
+| `server.port`                            | int   | `7070`               | HTTP listen port. Change when running multiple wikis simultaneously.                                                                                                                                                                                                       |
+| `ingest.max_pages_per_ingest`            | int   | `15`                 | Max pages one ingest job may create or update.                                                                                                                                                                                                                             |
+| `ingest.chunk_size`                      | int   | `1500`               | Text chunk size in characters for BM25 indexing.                                                                                                                                                                                                                           |
+| `ingest.chunk_overlap`                   | int   | `150`                | Overlap between consecutive chunks.                                                                                                                                                                                                                                        |
+| `ingest.fetch_timeout_seconds`           | int   | `30`                 | Seconds to wait for a URL response before failing the fetch.                                                                                                                                                                                                               |
+| `ingest.staging_policy`                  | str   | `"off"`              | Candidate staging gate:`"off"` = commit pages immediately; `"all"` = stage all new pages for review; `"threshold"` = stage only pages below `staging_confidence_min`.                                                                                                      |
+| `ingest.staging_confidence_min`          | str   | `"high"`             | Minimum confidence to auto-commit when`staging_policy = "threshold"`. Values: `"high"`, `"medium"`, `"low"`. Pages below this threshold are held as candidates.                                                                                                            |
+| `query.gap_score_threshold`              | float | `2.0`                | BM25 score below which a knowledge gap is detected and`suggested_searches` are returned instead of (or alongside) an answer. Lower = more sensitive gap detection.                                                                                                         |
+| `query.context_token_budget`             | int   | `4000`               | Token budget for context pack assembly. Increase for richer context on complex queries; decrease if hitting prompt size limits.                                                                                                                                            |
+| `queue.max_parallel_ingest`              | int   | `4`                  | Reserved for future parallel execution. The worker currently processes jobs sequentially; this field has no runtime effect.                                                                                                                                                |
+| `queue.max_retries`                      | int   | `3`                  | Retries before job → dead                                                                                                                                                                                                                                                 |
+| `queue.backoff_base_seconds`             | int   | `30`                 | Exponential backoff base; delays are`min(base × 2^(attempt−1), 300)` seconds                                                                                                                                                                                             |
+| `cache.version`                          | str   | `"4"`                | Bump to invalidate all cached LLM responses without touching source code                                                                                                                                                                                                   |
+| `cost.soft_warn_usd`                     | float | `0.50`               | Emit`logger.warning` in server log when per-job ingest cost exceeds this threshold; job continues normally                                                                                                                                                                 |
+| `cost.hard_gate_usd`                     | float | `2.00`               | Permanently fail the ingest job (DEAD) and record a`cost_gate_exceeded` audit event when per-job cost exceeds this threshold                                                                                                                                               |
+| `cost.auto_resolve_confidence_threshold` | float | `0.85`               | Auto-apply lint resolutions above this score                                                                                                                                                                                                                               |
+| `chat.conversation_history_turns`        | int   | `5`                  | Number of prior conversation turns injected into each query prompt for multi-turn context. Set to`0` to disable conversation history (each query answered independently).                                                                                                  |
+| `chat.session_retention_days`            | int   | `30`                 | Days to retain chat session history in`audit.db`. Sessions older than this are pruned automatically.                                                                                                                                                                       |
+| `audit.lifecycle_retention_days`         | int   | `0`                  | Days to retain lifecycle events in`audit.db`. `0` = keep forever. When set, events older than this threshold are pruned at the end of each lint run.                                                                                                                       |
+| `audit.url_staleness_days`               | int   | `0`                  | Days after which URL-sourced pages are automatically marked`stale` if the source URL has not been re-ingested. `0` = disabled.                                                                                                                                             |
+| `logs.level`                             | str   | `"INFO"`             | Console log level:`DEBUG`, `INFO`, `WARNING`, `ERROR`                                                                                                                                                                                                                      |
+| `logs.max_file_mb`                       | int   | `5`                  | Rotate`synthadoc.log` at this size (MB)                                                                                                                                                                                                                                    |
+| `logs.backup_count`                      | int   | `5`                  | Rotated log files to keep; total disk ≈`max_file_mb × (backup_count + 1)`                                                                                                                                                                                                |
+| `web_search.provider`                    | str   | `"tavily"`           | Web search provider (currently only`tavily` supported)                                                                                                                                                                                                                     |
+| `web_search.max_results`                 | int   | `20`                 | Maximum results fetched per web search query                                                                                                                                                                                                                               |
+| `search.vector`                          | bool  | `false`              | Enable semantic re-ranking; downloads`BAAI/bge-small-en-v1.5` (~130 MB) once on first enable                                                                                                                                                                               |
+| `search.vector_top_candidates`           | int   | `20`                 | BM25 candidate pool size when vector re-ranking is active                                                                                                                                                                                                                  |
+| `ingest.max_source_chars`                | int   | `32000`              | Character limit applied to each source before the LLM call. Sources exceeding this limit are truncated; the page's`sources:` frontmatter entry gets `truncated: true` and lint emits a warning. Override per-run with `--max-source-chars N`. _(v1.0.0)_                   |
+| `ingest.citation_source_lines`           | int   | `400`                | Number of source lines the LLM sees during Pass 4 (citation annotation). Increase if lint reports`out_of_range` on long sources such as transcripts or PDFs. Raise `citation_max_tokens` in proportion when increasing this value.                                         |
+| `ingest.citation_max_tokens`             | int   | `8192`               | Output token budget for the annotated section returned by Pass 4. Increase when`citation_source_lines` is raised or wiki sections are long, to avoid truncated annotations.                                                                                                |
+| `query.context_wiki_pct`                 | float | `0.60`               | Fraction of the model context window reserved for wiki source pages._(v1.0.0)_                                                                                                                                                                                             |
+| `query.context_history_pct`              | float | `0.20`               | Fraction reserved for conversation history._(v1.0.0)_                                                                                                                                                                                                                      |
+| `query.context_system_pct`               | float | `0.15`               | Fraction reserved for system prompt and instructions. Parsed and validated but not yet enforced as a hard cap in v1.0.0._(v1.0.0)_                                                                                                                                         |
+| `query.context_index_pct`                | float | `0.05`               | Fraction reserved for the wiki index preamble. Parsed and validated but not yet enforced as a hard cap in v1.0.0._(v1.0.0)_                                                                                                                                                |
+| `query.context_window`                   | int   | _(auto)_             | Override the built-in context window lookup for the configured model. Use when running a local or custom model whose window size is not in the built-in table._(v1.0.0)_                                                                                                   |
 
 ---
 
@@ -1405,14 +1437,16 @@ on_lint_complete   = { cmd = "python hooks/notify.py", blocking = true }   # blo
 
 Two events are fired in v0.1:
 
-| Event | Fires when | Context fields |
-|-------|-----------|----------------|
+
+| Event                | Fires when                        | Context fields                                                                                          |
+| -------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `on_ingest_complete` | A source is successfully ingested | `event`, `wiki`, `source`, `pages_created`, `pages_updated`, `pages_flagged`, `tokens_used`, `cost_usd` |
-| `on_lint_complete` | A lint run finishes | `event`, `wiki`, `contradictions_found`, `orphans` |
+| `on_lint_complete`   | A lint run finishes               | `event`, `wiki`, `contradictions_found`, `orphans`                                                      |
 
 ### Context JSON examples
 
 **on_ingest_complete**
+
 ```json
 {
   "event": "on_ingest_complete",
@@ -1427,6 +1461,7 @@ Two events are fired in v0.1:
 ```
 
 **on_lint_complete**
+
 ```json
 {
   "event": "on_lint_complete",
@@ -1488,12 +1523,13 @@ The default (`"4"`) is defined in `synthadoc/core/cache.py`. Custom skill author
 
 **Invalidation triggers:**
 
-| Trigger | Behavior |
-|---------|----------|
-| Source content changes | New SHA-256 → cache miss → fresh LLM call |
-| `[cache] version` bumped in config | All old entries bypassed |
-| `ingest --force` | `bust_cache=True` → skips `cache.get()`, repopulates |
-| `cache clear` | Deletes all rows from `cache.db` |
+
+| Trigger                            | Behavior                                              |
+| ---------------------------------- | ----------------------------------------------------- |
+| Source content changes             | New SHA-256 → cache miss → fresh LLM call           |
+| `[cache] version` bumped in config | All old entries bypassed                              |
+| `ingest --force`                   | `bust_cache=True` → skips `cache.get()`, repopulates |
+| `cache clear`                      | Deletes all rows from`cache.db`                       |
 
 ### Layer 3 — Query result cache (`cache.db` — `query_cache` table)
 
@@ -1510,11 +1546,12 @@ def make_query_cache_key(question: str, epoch: int, model: str = "") -> str:
 
 **Invalidation triggers:**
 
-| Trigger | Behavior |
-|---------|----------|
-| Any `ingest` or lifecycle change | `wiki_epoch` incremented → all query cache entries for prior epoch bypassed |
-| `--no-cache` flag on query | Cache lookup skipped; fresh LLM call; result repopulated |
-| `cache clear` | Deletes all rows from both `response_cache` and `query_cache` tables |
+
+| Trigger                         | Behavior                                                                     |
+| ------------------------------- | ---------------------------------------------------------------------------- |
+| Any`ingest` or lifecycle change | `wiki_epoch` incremented → all query cache entries for prior epoch bypassed |
+| `--no-cache` flag on query      | Cache lookup skipped; fresh LLM call; result repopulated                     |
+| `cache clear`                   | Deletes all rows from both`response_cache` and `query_cache` tables          |
 
 ### Layer 4 — Provider prompt cache
 
@@ -1532,10 +1569,11 @@ Cost tracking is live: `estimate_cost()` is called after each ingest and query o
 
 ### Thresholds
 
-| Threshold | Default | Behaviour |
-|-----------|---------|-----------|
-| `soft_warn_usd` | $0.50 | `logger.warning` in server log; job continues normally |
-| `hard_gate_usd` | $2.00 | Server/ingest path: records `cost_gate_exceeded` audit event + permanently fails job (DEAD). Interactive CLI: prompts `Proceed? [y/N]` |
+
+| Threshold       | Default | Behaviour                                                                                                                             |
+| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `soft_warn_usd` | $0.50   | `logger.warning` in server log; job continues normally                                                                                |
+| `hard_gate_usd` | $2.00   | Server/ingest path: records`cost_gate_exceeded` audit event + permanently fails job (DEAD). Interactive CLI: prompts `Proceed? [y/N]` |
 
 ### Cost Tracking and Pricing
 
@@ -1556,18 +1594,20 @@ LLM call → CompletionResponse(input_tokens, output_tokens)
 A static Python dict maps model name → `(input_usd_per_token, output_usd_per_token)`.
 Separate input and output rates reflect real-world API pricing (output tokens cost 3–5× more than input tokens for most models).
 
-| Provider | Example model | Input (per token) | Output (per token) |
-|---|---|---|---|
-| Anthropic | claude-haiku-4-5-20251001 | $0.000001 | $0.000005 |
-| Anthropic | claude-sonnet-4-6 | $0.000003 | $0.000015 |
-| Anthropic | claude-opus-4-7 | $0.000005 | $0.000025 |
-| OpenAI | gpt-4o-mini | $0.00000015 | $0.0000006 |
-| Gemini | gemini-2.5-flash | $0.0000003 | $0.0000025 |
-| Groq | llama-3.3-70b-versatile | $0.00000059 | $0.00000079 |
-| MiniMax | MiniMax-M2.5 | $0.00000015 | $0.0000012 |
-| MiniMax | MiniMax-M2.7 | $0.0000003 | $0.0000012 |
+
+| Provider  | Example model             | Input (per token) | Output (per token) |
+| --------- | ------------------------- | ----------------- | ------------------ |
+| Anthropic | claude-haiku-4-5-20251001 | $0.000001         | $0.000005          |
+| Anthropic | claude-sonnet-4-6         | $0.000003         | $0.000015          |
+| Anthropic | claude-opus-4-7           | $0.000005         | $0.000025          |
+| OpenAI    | gpt-4o-mini               | $0.00000015       | $0.0000006         |
+| Gemini    | gemini-2.5-flash          | $0.0000003        | $0.0000025         |
+| Groq      | llama-3.3-70b-versatile   | $0.00000059       | $0.00000079        |
+| MiniMax   | MiniMax-M2.5              | $0.00000015       | $0.0000012         |
+| MiniMax   | MiniMax-M2.7              | $0.0000003        | $0.0000012         |
 
 **Special cases:**
+
 - **Ollama (local inference):** Always `$0.00` regardless of token count — `is_local=True` short-circuits the calculation.
 - **Unknown models:** Use a conservative fallback rate (`$0.000003` per token for both input and output) rather than crashing or silently reporting `$0.00`.
 
@@ -1603,7 +1643,7 @@ The HTTP server always passes `auto_confirm=True` (no interactive terminal avail
 
 ## 14. Job Queue
 
-**File:** `synthadoc/core/queue.py`  
+**File:** `synthadoc/core/queue.py`
 **Storage:** `<wiki-root>/.synthadoc/jobs.db` (SQLite)
 
 ### State transitions
@@ -1619,14 +1659,15 @@ in_progress → dead         (retryable error; retries == max_retries)
 in_progress → skipped      (system-initiated skip; e.g. auto-blocked domain)
 ```
 
-| Status | Meaning | Action |
-|--------|---------|--------|
-| `failed` | Non-retryable error (e.g. stub skill, bad source) | Inspect error; fix source; enqueue again |
-| `dead` | Retryable error exhausted max retries | `synthadoc jobs retry <id>` to reset to pending |
-| `skipped` | System-initiated permanent skip (e.g. domain auto-blocked after repeated 403s) | No action needed; remove domain from blocked list to re-enable |
-| `cancelled` | Pending job cancelled by user via `synthadoc jobs cancel` | Re-enqueue manually if cancelled in error |
 
-**Backoff formula:** `min(backoff_base_seconds × 2^(attempt − 1), 300)`  
+| Status      | Meaning                                                                        | Action                                                         |
+| ----------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| `failed`    | Non-retryable error (e.g. stub skill, bad source)                              | Inspect error; fix source; enqueue again                       |
+| `dead`      | Retryable error exhausted max retries                                          | `synthadoc jobs retry <id>` to reset to pending                |
+| `skipped`   | System-initiated permanent skip (e.g. domain auto-blocked after repeated 403s) | No action needed; remove domain from blocked list to re-enable |
+| `cancelled` | Pending job cancelled by user via`synthadoc jobs cancel`                       | Re-enqueue manually if cancelled in error                      |
+
+**Backoff formula:** `min(backoff_base_seconds × 2^(attempt − 1), 300)`
 With the default base of 30 s: attempt 1 waits 30 s, attempt 2 waits 60 s, attempt 3 waits 120 s (all capped at 300 s). The `retry_after` timestamp is stored in the jobs table; `dequeue()` skips any job whose `retry_after` is still in the future. Applied only to transient errors (network timeouts, connection failures, 5xx responses).
 
 **Persistence:** Jobs survive server restarts. `in_progress` jobs at shutdown are reset to `pending` on startup.
@@ -1660,16 +1701,17 @@ Suppressed to WARNING: `httpx`, `httpcore`, `uvicorn.access`, `anthropic`, `open
 
 ### Log record fields
 
-| Field | Always present | Source |
-|-------|---------------|--------|
-| `ts` | Yes | `record.created` |
-| `level` | Yes | `record.levelname` |
-| `logger` | Yes | `record.name` |
-| `msg` | Yes | `record.getMessage()` |
-| `job_id` | Job context only | `LoggerAdapter.extra` |
+
+| Field       | Always present   | Source                |
+| ----------- | ---------------- | --------------------- |
+| `ts`        | Yes              | `record.created`      |
+| `level`     | Yes              | `record.levelname`    |
+| `logger`    | Yes              | `record.name`         |
+| `msg`       | Yes              | `record.getMessage()` |
+| `job_id`    | Job context only | `LoggerAdapter.extra` |
 | `operation` | Job context only | `LoggerAdapter.extra` |
-| `wiki` | Job context only | `LoggerAdapter.extra` |
-| `trace_id` | When OTel active | OTel span context |
+| `wiki`      | Job context only | `LoggerAdapter.extra` |
+| `trace_id`  | When OTel active | OTel span context     |
 
 ### Job-scoped logging
 
@@ -1705,13 +1747,14 @@ Spans cover: full operation tree (orchestrator → agent → LLM calls → stora
 
 ### Log level guidance
 
-| Level | When to use |
-|-------|------------|
-| `DEBUG` | LLM prompt bodies, cache key details, BM25 scores, entity extraction details |
-| `INFO` | Job lifecycle, page created/updated, server started, lint summary |
-| `WARNING` | Soft failures (network unreachable), suspicious patterns |
-| `ERROR` | Job failed, API error, file write failed |
-| `CRITICAL` | Server cannot start |
+
+| Level      | When to use                                                                  |
+| ---------- | ---------------------------------------------------------------------------- |
+| `DEBUG`    | LLM prompt bodies, cache key details, BM25 scores, entity extraction details |
+| `INFO`     | Job lifecycle, page created/updated, server started, lint summary            |
+| `WARNING`  | Soft failures (network unreachable), suspicious patterns                     |
+| `ERROR`    | Job failed, API error, file write failed                                     |
+| `CRITICAL` | Server cannot start                                                          |
 
 ---
 
@@ -1759,6 +1802,7 @@ This section is for developers building custom skills or LLM providers.
 4. Implement `extract(source: str) -> ExtractedContent`.
 
 **Folder layout:**
+
 ```
 slack_export/
   SKILL.md
@@ -1770,6 +1814,7 @@ slack_export/
 ```
 
 **`SKILL.md`:**
+
 ```yaml
 ---
 name: slack_export
@@ -1788,6 +1833,7 @@ Loads all JSON channel files from a Slack export ZIP and returns the message tex
 ```
 
 **`scripts/main.py`:**
+
 ```python
 # SPDX-License-Identifier: MIT
 from synthadoc.skills.base import BaseSkill, ExtractedContent
@@ -1857,10 +1903,11 @@ Hooks fire after key operations. They can be in any language; the process receiv
 
 **Available events:**
 
-| Event | Fired after | JSON context fields |
-|---|---|---|
+
+| Event                | Fired after                | JSON context fields                                                                                     |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `on_ingest_complete` | Every completed ingest job | `event`, `wiki`, `source`, `pages_created`, `pages_updated`, `pages_flagged`, `tokens_used`, `cost_usd` |
-| `on_lint_complete` | Every completed lint run | `event`, `wiki`, `contradictions_found`, `orphans` |
+| `on_lint_complete`   | Every completed lint run   | `event`, `wiki`, `contradictions_found`, `orphans`                                                      |
 
 **Register hooks in `.synthadoc/config.toml`:**
 
@@ -1928,11 +1975,12 @@ Pages may carry an `aliases:` list in YAML frontmatter. `QueryAgent._expand_alia
 
 ### CLI commands
 
-| Command | Description |
-|---|---|
-| `synthadoc routing init` | Generate ROUTING.md from current index.md branch structure |
-| `synthadoc routing validate` | Report dangling slugs and unassigned slugs (dry run) |
-| `synthadoc routing clean` | Remove dangling slugs from ROUTING.md |
+
+| Command                      | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `synthadoc routing init`     | Generate ROUTING.md from current index.md branch structure |
+| `synthadoc routing validate` | Report dangling slugs and unassigned slugs (dry run)       |
+| `synthadoc routing clean`    | Remove dangling slugs from ROUTING.md                      |
 
 All commands accept `-w <wiki>` / `--wiki <wiki>` to target a specific wiki.
 
@@ -1940,10 +1988,11 @@ All commands accept `-w <wiki>` / `--wiki <wiki>` to target a specific wiki.
 
 The `Routing: manage ROUTING.md...` command opens a `RoutingModal`. On open it calls `GET /routing/status` and enables or disables the three buttons accordingly:
 
-| State | Init | Validate | Clean |
-|---|---|---|---|
-| ROUTING.md absent | enabled | disabled | disabled |
-| ROUTING.md present | disabled | enabled | enabled |
+
+| State              | Init     | Validate | Clean    |
+| ------------------ | -------- | -------- | -------- |
+| ROUTING.md absent  | enabled  | disabled | disabled |
+| ROUTING.md present | disabled | enabled  | enabled  |
 | Server unreachable | disabled | disabled | disabled |
 
 After each action the result appears in an inline result area with per-entry `[Branch] [[slug]]` detail rows. The ROUTING.md preview box (max-height 120 px, scrollable) is shown/refreshed by Init and Clean operations.
@@ -1956,11 +2005,12 @@ After each action the result appears in an inline result area with per-entry `[B
 
 New pages can be routed to `wiki/candidates/` instead of `wiki/` based on the `[ingest] staging_policy` setting:
 
-| Value | Behaviour |
-|---|---|
-| `off` | All new pages go directly to `wiki/` (default) |
-| `all` | All new pages go to `wiki/candidates/` |
-| `threshold` | Pages below `staging_confidence_min` go to `wiki/candidates/` |
+
+| Value       | Behaviour                                                    |
+| ----------- | ------------------------------------------------------------ |
+| `off`       | All new pages go directly to`wiki/` (default)                |
+| `all`       | All new pages go to`wiki/candidates/`                        |
+| `threshold` | Pages below`staging_confidence_min` go to `wiki/candidates/` |
 
 `staging_confidence_min` values: `high` (default), `medium`, `low`. Confidence ordering: `high > medium > low`.
 
@@ -1970,29 +2020,31 @@ New pages can be routed to `wiki/candidates/` instead of `wiki/` based on the `[
 
 ### CLI commands
 
-| Command | Description |
-|---|---|
-| `synthadoc staging policy [off\|all\|threshold]` | Show or set the staging policy |
-| `synthadoc staging policy --min-confidence <level>` | Set minimum confidence threshold |
-| `synthadoc candidates list` | List all candidate pages with confidence and date |
-| `synthadoc candidates promote <slug>` | Move a candidate to `wiki/` |
-| `synthadoc candidates promote --all` | Promote all candidates |
-| `synthadoc candidates discard <slug>` | Delete a candidate |
-| `synthadoc candidates discard --all` | Delete all candidates |
+
+| Command                                             | Description                                       |
+| --------------------------------------------------- | ------------------------------------------------- |
+| `synthadoc staging policy [off|all|threshold]`      | Show or set the staging policy                    |
+| `synthadoc staging policy --min-confidence <level>` | Set minimum confidence threshold                  |
+| `synthadoc candidates list`                         | List all candidate pages with confidence and date |
+| `synthadoc candidates promote <slug>`               | Move a candidate to`wiki/`                        |
+| `synthadoc candidates promote --all`                | Promote all candidates                            |
+| `synthadoc candidates discard <slug>`               | Delete a candidate                                |
+| `synthadoc candidates discard --all`                | Delete all candidates                             |
 
 Policy changes take effect on the next ingest job — no server restart needed.
 
 ### HTTP API
 
-| Method | Path | Request | Response |
-|--------|------|---------|----------|
-| `GET` | `/staging/policy` | — | `{policy: str, confidence_min: str\|null}` |
-| `POST` | `/staging/policy` | `{policy: str, confidence_min?: str}` | `{policy: str, confidence_min: str\|null}` |
-| `GET` | `/candidates` | — | `[{slug: str, title: str, confidence: str, ingested_at: str}]` |
-| `POST` | `/candidates/promote-all` | — | `{promoted: int, updated: int}` |
-| `POST` | `/candidates/discard-all` | — | `{discarded: int}` |
-| `POST` | `/candidates/{slug}/promote` | — | `{promoted: slug, new: bool, updated: bool}` |
-| `POST` | `/candidates/{slug}/discard` | — | `{discarded: slug}` |
+
+| Method | Path                         | Request                               | Response                                                       |
+| ------ | ---------------------------- | ------------------------------------- | -------------------------------------------------------------- |
+| `GET`  | `/staging/policy`            | —                                    | `{policy: str, confidence_min: str|null}`                      |
+| `POST` | `/staging/policy`            | `{policy: str, confidence_min?: str}` | `{policy: str, confidence_min: str|null}`                      |
+| `GET`  | `/candidates`                | —                                    | `[{slug: str, title: str, confidence: str, ingested_at: str}]` |
+| `POST` | `/candidates/promote-all`    | —                                    | `{promoted: int, updated: int}`                                |
+| `POST` | `/candidates/discard-all`    | —                                    | `{discarded: int}`                                             |
+| `POST` | `/candidates/{slug}/promote` | —                                    | `{promoted: slug, new: bool, updated: bool}`                   |
+| `POST` | `/candidates/{slug}/discard` | —                                    | `{discarded: slug}`                                            |
 
 Promote moves the file from `wiki/candidates/<slug>.md` to `wiki/<slug>.md`. If a page with the same slug already exists in `wiki/` (a staged update to an existing page), the existing file is overwritten. Only newly created pages (not overwrites) are indexed into BM25.
 
@@ -2034,13 +2086,14 @@ Method: `await agent.build(goal, token_budget=None) → ContextPack`
 
 ### ContextPack
 
-| Field | Type | Description |
-|---|---|---|
-| `goal` | `str` | The input goal string |
-| `token_budget` | `int` | Effective budget used |
-| `tokens_used` | `int` | Tokens consumed by included pages |
-| `pages` | `list[ContextPage]` | Included pages, ranked by relevance |
-| `omitted` | `list[ContextPage]` | Pages excluded due to budget |
+
+| Field          | Type                | Description                         |
+| -------------- | ------------------- | ----------------------------------- |
+| `goal`         | `str`               | The input goal string               |
+| `token_budget` | `int`               | Effective budget used               |
+| `tokens_used`  | `int`               | Tokens consumed by included pages   |
+| `pages`        | `list[ContextPage]` | Included pages, ranked by relevance |
+| `omitted`      | `list[ContextPage]` | Pages excluded due to budget        |
 
 `ContextPack.to_markdown()` renders a human-readable evidence pack. `ContextPack.to_dict()` returns a JSON-serialisable dict for the REST API.
 
@@ -2124,11 +2177,12 @@ adversarial_max_per_page = 3   # must be >= adversarial_gate_threshold; raise to
 
 ### CLI commands
 
-| Command | Description |
-|---|---|
-| `synthadoc lint run` | Full lint pass including adversarial review |
-| `synthadoc lint run --no-adversarial` | Structural-only lint; clears existing `lint_warnings` |
-| `synthadoc lint report` | Show warnings — CLI output has a dedicated Adversarial section |
+
+| Command                               | Description                                                     |
+| ------------------------------------- | --------------------------------------------------------------- |
+| `synthadoc lint run`                  | Full lint pass including adversarial review                     |
+| `synthadoc lint run --no-adversarial` | Structural-only lint; clears existing`lint_warnings`            |
+| `synthadoc lint report`               | Show warnings — CLI output has a dedicated Adversarial section |
 
 ### HTTP API
 
@@ -2177,10 +2231,11 @@ Results are cached by section SHA-256 so re-ingest of unchanged sections does no
 
 To support the Source Viewer in Obsidian, `_write_sidecar()` writes two files to `.synthadoc/extracted/` for every locally ingested source:
 
-| File | Contents | Source types |
-|------|----------|-------------|
-| `<basename>.txt` | Plain UTF-8 extracted text with line numbers preserved | All local file types |
-| `<basename>.pagemap.json` | JSON array mapping line numbers to PDF page numbers | PDF only |
+
+| File                      | Contents                                               | Source types         |
+| ------------------------- | ------------------------------------------------------ | -------------------- |
+| `<basename>.txt`          | Plain UTF-8 extracted text with line numbers preserved | All local file types |
+| `<basename>.pagemap.json` | JSON array mapping line numbers to PDF page numbers    | PDF only             |
 
 The pagemap enables the "Open PDF at page N →" button in the Source Viewer to resolve a line range to the correct PDF page without re-parsing the document. Web and YouTube sources do not produce sidecars (no stable local path to key on).
 
@@ -2188,15 +2243,16 @@ The pagemap enables the "Open PDF at page N →" button in the Source Viewer to 
 
 Stored in `audit.db`. Written by `AuditDB.record_claim_citations()` after each annotated page section is saved.
 
-| Column | Type | Notes |
-|--------|------|-------|
-| `id` | INTEGER PK | |
-| `page_slug` | TEXT | Wiki page the citation belongs to |
-| `source_file` | TEXT | Basename of the raw source file |
-| `line_start` | INTEGER | First line of the supporting passage |
-| `line_end` | INTEGER | Last line of the supporting passage |
-| `claim_excerpt` | TEXT | First ~100 chars of the annotated paragraph |
-| `ingested_at` | TEXT | UTC ISO-8601 |
+
+| Column          | Type       | Notes                                       |
+| --------------- | ---------- | ------------------------------------------- |
+| `id`            | INTEGER PK |                                             |
+| `page_slug`     | TEXT       | Wiki page the citation belongs to           |
+| `source_file`   | TEXT       | Basename of the raw source file             |
+| `line_start`    | INTEGER    | First line of the supporting passage        |
+| `line_end`      | INTEGER    | Last line of the supporting passage         |
+| `claim_excerpt` | TEXT       | First ~100 chars of the annotated paragraph |
+| `ingested_at`   | TEXT       | UTC ISO-8601                                |
 
 ### HTTP API
 
@@ -2215,11 +2271,12 @@ Response: `{total: int, citations: [CitationRow]}`
 
 ### CLI commands
 
-| Command | Description |
-|---|---|
-| `synthadoc audit citations -w <wiki>` | Last 50 citations across the whole wiki |
-| `synthadoc audit citations -w <wiki> --page <slug>` | All citations for one page |
-| `synthadoc audit citations -w <wiki> --broken` | Citations that failed line-range validation |
+
+| Command                                             | Description                                 |
+| --------------------------------------------------- | ------------------------------------------- |
+| `synthadoc audit citations -w <wiki>`               | Last 50 citations across the whole wiki     |
+| `synthadoc audit citations -w <wiki> --page <slug>` | All citations for one page                  |
+| `synthadoc audit citations -w <wiki> --broken`      | Citations that failed line-range validation |
 
 ### Obsidian plugin
 
@@ -2237,7 +2294,6 @@ For PDF sources, if the pagemap sidecar exists and the target page is > 1, a **"
 
 ---
 
-
 ## 23. Lifecycle Machine
 
 ### Concept
@@ -2246,33 +2302,35 @@ Every wiki page moves through a defined set of states that reflect its review st
 
 ### States
 
-| State | Meaning | How to reach it |
-|---|---|---|
-| `draft` | Newly compiled, not yet lint-reviewed | Automatic on ingest |
-| `active` | Lint-reviewed, current, trusted | Lint auto-promotes from `draft` |
-| `contradicted` | Conflict detected | Lint detects contradiction between sources |
-| `stale` | Source file changed since last ingest | Lint detects SHA-256 hash mismatch |
-| `archived` | Source removed or explicitly retired | Lint auto-archives on missing source; or manual |
+
+| State          | Meaning                               | How to reach it                                 |
+| -------------- | ------------------------------------- | ----------------------------------------------- |
+| `draft`        | Newly compiled, not yet lint-reviewed | Automatic on ingest                             |
+| `active`       | Lint-reviewed, current, trusted       | Lint auto-promotes from`draft`                  |
+| `contradicted` | Conflict detected                     | Lint detects contradiction between sources      |
+| `stale`        | Source file changed since last ingest | Lint detects SHA-256 hash mismatch              |
+| `archived`     | Source removed or explicitly retired  | Lint auto-archives on missing source; or manual |
 
 ### Transition rules
 
 Automated transitions (lint, ingest) write state directly and are not subject to the graph. User-driven transitions (CLI, HTTP API, MCP) are validated against `ALLOWED_LIFECYCLE_TRANSITIONS` in `synthadoc/storage/wiki.py`; invalid paths are rejected with HTTP 422 or an MCP error dict.
 
-| From | To | Trigger | Notes |
-|---|---|---|---|
-| _(none)_ | `draft` | ingest | New page created by ingest |
-| `draft` | `active` | lint, cli/api/mcp | Lint auto-promotes when all checks pass; or manual activate |
-| `draft` | `archived` | cli/api/mcp | Abandon a draft without publishing |
-| `active` | `contradicted` | lint, cli/api/mcp | Lint detects conflict automatically; or user manually flags |
-| `active` | `stale` | lint | Local source: SHA-256 hash mismatch; URL source older than `url_staleness_days` |
-| `active` | `archived` | lint, cli/api/mcp | Lint: local source missing or URL 404/410; or manual retire |
-| `stale` | `draft` | cli/api/mcp | Revise stale content — puts page back in review queue |
-| `stale` | `active` | cli/api/mcp | Re-validate without revision — user confirms content still accurate |
-| `stale` | `archived` | lint, cli/api/mcp | Lint: source gone; or manual archive |
-| `contradicted` | `draft` | cli/api/mcp | Revise contradicted content — resets to review queue |
-| `contradicted` | `active` | cli/api/mcp | Resolve contradiction and re-activate directly |
-| `contradicted` | `archived` | cli/api/mcp | Archive after reviewing the conflict |
-| `archived` | `draft` | cli/api/mcp | Restore for revision — places page back in review queue |
+
+| From           | To             | Trigger           | Notes                                                                          |
+| -------------- | -------------- | ----------------- | ------------------------------------------------------------------------------ |
+| _(none)_       | `draft`        | ingest            | New page created by ingest                                                     |
+| `draft`        | `active`       | lint, cli/api/mcp | Lint auto-promotes when all checks pass; or manual activate                    |
+| `draft`        | `archived`     | cli/api/mcp       | Abandon a draft without publishing                                             |
+| `active`       | `contradicted` | lint, cli/api/mcp | Lint detects conflict automatically; or user manually flags                    |
+| `active`       | `stale`        | lint              | Local source: SHA-256 hash mismatch; URL source older than`url_staleness_days` |
+| `active`       | `archived`     | lint, cli/api/mcp | Lint: local source missing or URL 404/410; or manual retire                    |
+| `stale`        | `draft`        | cli/api/mcp       | Revise stale content — puts page back in review queue                         |
+| `stale`        | `active`       | cli/api/mcp       | Re-validate without revision — user confirms content still accurate           |
+| `stale`        | `archived`     | lint, cli/api/mcp | Lint: source gone; or manual archive                                           |
+| `contradicted` | `draft`        | cli/api/mcp       | Revise contradicted content — resets to review queue                          |
+| `contradicted` | `active`       | cli/api/mcp       | Resolve contradiction and re-activate directly                                 |
+| `contradicted` | `archived`     | cli/api/mcp       | Archive after reviewing the conflict                                           |
+| `archived`     | `draft`        | cli/api/mcp       | Restore for revision — places page back in review queue                       |
 
 Transitions not in this table are rejected. Notable blocked paths: `stale ↔ contradicted` (different issue types that should not be crossed directly), `archived → active/stale/contradicted` (must go through `draft` for re-review first), `draft → stale/contradicted` (unpublished pages cannot be in those states).
 
@@ -2417,11 +2475,12 @@ synthadoc audit lifecycle purge -w <wiki> --keep-latest <n>
 
 ### HTTP API
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/lifecycle/status` | Current state counts from `page_states` |
-| `GET` | `/lifecycle/events` | Paginated event log (`slug`, `to_state`, `limit`, `offset` query params) |
-| `POST` | `/lifecycle/transition` | Body: `{slug, to_state, reason?}` — validates allowed transition, writes both tables |
+
+| Method | Path                    | Description                                                                          |
+| ------ | ----------------------- | ------------------------------------------------------------------------------------ |
+| `GET`  | `/lifecycle/status`     | Current state counts from`page_states`                                               |
+| `GET`  | `/lifecycle/events`     | Paginated event log (`slug`, `to_state`, `limit`, `offset` query params)             |
+| `POST` | `/lifecycle/transition` | Body:`{slug, to_state, reason?}` — validates allowed transition, writes both tables |
 
 ### Obsidian plugin
 
@@ -2450,11 +2509,12 @@ A content snapshot is a copy of the page body (`WikiPage.content`) stored in the
 `content_snapshot` column of a `lifecycle_events` row. Three distinct triggers produce
 snapshots; ingest-agent transitions never do (ingest does not change existing content):
 
-| Trigger | When it fires | Dedup? |
-|---------|--------------|--------|
-| **Manual lifecycle transition** | User calls `lifecycle activate`, `lifecycle archive`, `lifecycle restore` via CLI, the Obsidian Lifecycle modal, the REST API, or the MCP tool | No — always records |
-| **Lint-driven state change** | `LintAgent._transition()` fires: draft → active (promotion), active → stale (hash mismatch), active → archived (source gone), contradicted → active (auto-resolve) | No — always records; for auto-resolve, captures the post-resolution body that was just written |
-| **Manual file edit in Obsidian** | The Obsidian plugin's `vault.on("modify")` handler fires after a 2-second debounce on any `.md` file at the vault root | Yes — `AuditLog.snapshot_if_changed()` compares incoming content to the last stored snapshot and only writes a new row when content differs |
+
+| Trigger                          | When it fires                                                                                                                                                          | Dedup?                                                                                                                                      |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Manual lifecycle transition**  | User calls`lifecycle activate`, `lifecycle archive`, `lifecycle restore` via CLI, the Obsidian Lifecycle modal, the REST API, or the MCP tool                          | No — always records                                                                                                                        |
+| **Lint-driven state change**     | `LintAgent._transition()` fires: draft → active (promotion), active → stale (hash mismatch), active → archived (source gone), contradicted → active (auto-resolve) | No — always records; for auto-resolve, captures the post-resolution body that was just written                                             |
+| **Manual file edit in Obsidian** | The Obsidian plugin's`vault.on("modify")` handler fires after a 2-second debounce on any `.md` file at the vault root                                                  | Yes —`AuditLog.snapshot_if_changed()` compares incoming content to the last stored snapshot and only writes a new row when content differs |
 
 For the manual-edit trigger the `from_state` and `to_state` columns are both set to the
 current page state (no lifecycle transition occurs — this is a pure content checkpoint).
@@ -2490,35 +2550,38 @@ The `synthadoc export` command serializes the wiki in five machine-readable form
 
 **`graphml`** — Standard GraphML 1.1. Nodes = pages; edges = wikilinks extracted from page bodies. Node attributes:
 
-| Attribute | Type | Description |
-|-----------|------|-------------|
-| `label` | string | Human-readable page title — read by Gephi and Cytoscape as the display label |
-| `title` | string | Same as `label`; retained for backwards compatibility |
-| `status` | string | Lifecycle state (`draft`, `active`, `contradicted`, `stale`, `archived`) |
-| `confidence` | string | Ingest confidence level |
-| `orphan` | boolean | `true` if the page has zero inbound wikilinks |
-| `citation_count` | int | Reserved; always `0` in current release |
-| `inbound_link_count` | int | Number of other pages that link to this page |
-| `routing_branch` | string | Branch name from ROUTING.md membership |
+
+| Attribute            | Type    | Description                                                                   |
+| -------------------- | ------- | ----------------------------------------------------------------------------- |
+| `label`              | string  | Human-readable page title — read by Gephi and Cytoscape as the display label |
+| `title`              | string  | Same as`label`; retained for backwards compatibility                          |
+| `status`             | string  | Lifecycle state (`draft`, `active`, `contradicted`, `stale`, `archived`)      |
+| `confidence`         | string  | Ingest confidence level                                                       |
+| `orphan`             | boolean | `true` if the page has zero inbound wikilinks                                 |
+| `citation_count`     | int     | Reserved; always`0` in current release                                        |
+| `inbound_link_count` | int     | Number of other pages that link to this page                                  |
+| `routing_branch`     | string  | Branch name from ROUTING.md membership                                        |
 
 All edges carry `edge_type="wikilink"`. Self-links are suppressed. The file also embeds a `y:ShapeNode/y:NodeLabel` element (yEd namespace) so node labels render natively when the file is opened in **yEd Graph Editor**. No position data is embedded — run the tool's layout algorithm after import. Tested tools: yEd (Layout → Organic or Hierarchical), Gephi (enable labels via the Aα button in the bottom toolbar; run ForceAtlas2), Cytoscape (File → Import → Network from File).
 
 **`json`** — Agent-ready structured dump. Each page object contains:
 
-| Field | Description |
-|-------|-------------|
-| `claims[]` | Source file, line range, claim excerpt — from the claim provenance audit database |
-| `lifecycle_history[]` | Every state transition with `from`, `to`, `timestamp`, `triggered_by`, `reason` |
-| `ingest_cost_usd` | Cumulative LLM cost (USD) across all source files that contributed to this page |
-| `ingest_tokens` | Cumulative token count across all ingest calls for this page |
-| `sources[]` | Source file metadata: file, hash, size, ingested timestamp |
-| `lint_warnings[]` | Adversarial review findings: `{claim, concern}` pairs |
+
+| Field                 | Description                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| `claims[]`            | Source file, line range, claim excerpt — from the claim provenance audit database |
+| `lifecycle_history[]` | Every state transition with`from`, `to`, `timestamp`, `triggered_by`, `reason`     |
+| `ingest_cost_usd`     | Cumulative LLM cost (USD) across all source files that contributed to this page    |
+| `ingest_tokens`       | Cumulative token count across all ingest calls for this page                       |
+| `sources[]`           | Source file metadata: file, hash, size, ingested timestamp                         |
+| `lint_warnings[]`     | Adversarial review findings:`{claim, concern}` pairs                               |
 
 Wiki-level fields: `total_compilation_cost_usd`, `routing.branch_memberships`, `exported_at`, `page_count`.
 
 **`okf`** — [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle directory. Unlike other formats, `okf` produces a **directory tree** rather than a single file. The bundle is directly consumable by any OKF-aware agent or tool without code changes.
 
 Bundle layout:
+
 ```
 <output-dir>/
   index.md        # OKF index — pages grouped by knowledge type
@@ -2556,18 +2619,20 @@ Outputs to stdout by default; `--output` writes to a file. For `--format okf`, `
 
 Accepts `{ format, status_filter }`. Returns raw content with appropriate `Content-Type`:
 
-| Format | Content-Type |
-|--------|-------------|
-| `llms.txt`, `llms-full.txt` | `text/plain; charset=utf-8` |
-| `graphml` | `application/xml` |
-| `json` | `application/json` |
-| `okf` | `application/json` — a JSON object mapping relative file paths to file contents (`{"index.md": "...", "wiki/alan-turing.md": "..."}`) |
+
+| Format                      | Content-Type                                                                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `llms.txt`, `llms-full.txt` | `text/plain; charset=utf-8`                                                                                                            |
+| `graphml`                   | `application/xml`                                                                                                                      |
+| `json`                      | `application/json`                                                                                                                     |
+| `okf`                       | `application/json` — a JSON object mapping relative file paths to file contents (`{"index.md": "...", "wiki/alan-turing.md": "..."}`) |
 
 Returns 422 for unknown format. No LLM calls.
 
 ### Obsidian
 
 **`Synthadoc: Export Wiki`** opens a modal with:
+
 - A brief description panel explaining each format
 - Format dropdown (json / llms.txt / llms-full.txt / graphml / okf)
 - Output path field (full-width, pre-filled with today's date and correct extension, editable)
@@ -2597,17 +2662,18 @@ data: {"event": "citations", "data": {"citations": ["alan-turing", "enigma"]}}
 data: {"event": "done", "data": {"next_hints": [...], "input_tokens": 1240, "output_tokens": 380, "tokens_used": 1620}}
 ```
 
-| Event | Payload | When |
-|---|---|---|
-| `status` | `{"phase": "retrieving"}` | Phase 1 starts |
-| `status` | `{"phase": "synthesizing", "sources": N}` | Phase 2 starts |
-| `token` | `{"text": "…"}` | Each LLM token |
-| `citations` | `{"citations": […]}` | After last token |
-| `gap` | `{"suggested_searches": […]}` | If knowledge gap detected |
-| `clarify` | `{"prompt": "…", "candidates": ["slug-1", …], "action": "…"}` | Action agent needs disambiguation (e.g. which page to activate) |
-| `notice` | `{"text": "…"}` | System message (e.g. conversation history was compressed) |
-| `done` | `{"next_hints": […], "input_tokens": N, "output_tokens": N, "tokens_used": N}` | Stream complete |
-| `error` | `{"message": "…"}` | On any exception |
+
+| Event       | Payload                                                                         | When                                                            |
+| ----------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `status`    | `{"phase": "retrieving"}`                                                       | Phase 1 starts                                                  |
+| `status`    | `{"phase": "synthesizing", "sources": N}`                                       | Phase 2 starts                                                  |
+| `token`     | `{"text": "…"}`                                                                | Each LLM token                                                  |
+| `citations` | `{"citations": […]}`                                                           | After last token                                                |
+| `gap`       | `{"suggested_searches": […]}`                                                  | If knowledge gap detected                                       |
+| `clarify`   | `{"prompt": "…", "candidates": ["slug-1", …], "action": "…"}`                | Action agent needs disambiguation (e.g. which page to activate) |
+| `notice`    | `{"text": "…"}`                                                                | System message (e.g. conversation history was compressed)       |
+| `done`      | `{"next_hints": […], "input_tokens": N, "output_tokens": N, "tokens_used": N}` | Stream complete                                                 |
+| `error`     | `{"message": "…"}`                                                             | On any exception                                                |
 
 The CLI `synthadoc query` renders tokens as they arrive using ANSI cursor control. Pass `--no-stream` to fall back to the blocking `POST /query` endpoint and print the full answer when complete.
 
@@ -2619,18 +2685,19 @@ Streaming LLM responses do not return token counts in the same way as blocking c
 
 **Provider-side collection** — each `LLMProvider` subclass exposes two instance attributes: `last_stream_input_tokens` and `last_stream_output_tokens`. These default to `0` and are populated from the API-specific usage field when the stream ends:
 
-| Provider | Mechanism | Verified |
-|---|---|---|
-| OpenAI | `stream_options={"include_usage": True}` passed to `chat.completions.create()`; final chunk carries `chunk.usage.prompt_tokens` / `completion_tokens` with empty `choices` | ✅ |
-| Anthropic | `message_start` event → `event.message.usage.input_tokens`; `message_delta` event → `event.usage.output_tokens` | ✅ |
-| Ollama | Final chunk with `done=True` → `prompt_eval_count` / `eval_count` | ✅ |
-| DeepSeek | Same `OpenAIProvider` path as OpenAI; DeepSeek's OpenAI-compatible API supports `stream_options` | ✅ |
-| MiniMax (reasoning: M2.5+) | Detects `<think>` in stream → falls back to blocking `complete()` → captures exact counts from `resp.usage` | ✅ |
-| MiniMax (non-reasoning, e.g. M3 thinking=disabled) | Same `OpenAIProvider` path; MiniMax API silently ignores `stream_options`. Falls back to character-based estimate (÷ 3.5 chars/token) from prompt + answer lengths. Accuracy ±20%. | ✅ estimated |
-| Gemini | Same `OpenAIProvider` path via `generativelanguage.googleapis.com/v1beta/openai/`; Google's compatibility layer honours `stream_options` — verified live (Gemini 2.5 Flash Lite, 50K tokens) | ✅ |
-| Groq | Same `OpenAIProvider` path; Groq's OpenAI-compatible API supports `stream_options` | ✅ |
-| Qwen (DashScope) | Same `OpenAIProvider` path via DashScope; `stream_options` honoured — verified live (qwen-plus, 28K tokens) | ✅ |
-| Qwen (Ollama) | Ollama path → `prompt_eval_count` / `eval_count` | ✅ |
+
+| Provider                                           | Mechanism                                                                                                                                                                                    | Verified     |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| OpenAI                                             | `stream_options={"include_usage": True}` passed to `chat.completions.create()`; final chunk carries `chunk.usage.prompt_tokens` / `completion_tokens` with empty `choices`                   | ✅           |
+| Anthropic                                          | `message_start` event → `event.message.usage.input_tokens`; `message_delta` event → `event.usage.output_tokens`                                                                            | ✅           |
+| Ollama                                             | Final chunk with`done=True` → `prompt_eval_count` / `eval_count`                                                                                                                            | ✅           |
+| DeepSeek                                           | Same`OpenAIProvider` path as OpenAI; DeepSeek's OpenAI-compatible API supports `stream_options`                                                                                              | ✅           |
+| MiniMax (reasoning: M2.5+)                         | Detects`<think>` in stream → falls back to blocking `complete()` → captures exact counts from `resp.usage`                                                                                 | ✅           |
+| MiniMax (non-reasoning, e.g. M3 thinking=disabled) | Same`OpenAIProvider` path; MiniMax API silently ignores `stream_options`. Falls back to character-based estimate (÷ 3.5 chars/token) from prompt + answer lengths. Accuracy ±20%.          | ✅ estimated |
+| Gemini                                             | Same`OpenAIProvider` path via `generativelanguage.googleapis.com/v1beta/openai/`; Google's compatibility layer honours `stream_options` — verified live (Gemini 2.5 Flash Lite, 50K tokens) | ✅           |
+| Groq                                               | Same`OpenAIProvider` path; Groq's OpenAI-compatible API supports `stream_options`                                                                                                            | ✅           |
+| Qwen (DashScope)                                   | Same`OpenAIProvider` path via DashScope; `stream_options` honoured — verified live (qwen-plus, 28K tokens)                                                                                  | ✅           |
+| Qwen (Ollama)                                      | Ollama path →`prompt_eval_count` / `eval_count`                                                                                                                                             | ✅           |
 
 **Forwarding to `done` event** — after `complete_stream()` is exhausted, `QueryAgent.run_stream()` reads the provider attributes and includes them in the final `done` event payload: `input_tokens`, `output_tokens`, `tokens_used`.
 
@@ -2652,11 +2719,12 @@ cache_key = hash(
 
 **Wiki epoch** is an integer stored in `cache.db` that increments on every event that changes wiki content:
 
-| Event | Effect on epoch |
-|-------|----------------|
-| `ingest` completes (pages written) | epoch + 1 |
-| `lifecycle transition` (any state change) | epoch + 1 |
-| `cache clear` | epoch reset to 0 |
+
+| Event                                     | Effect on epoch  |
+| ----------------------------------------- | ---------------- |
+| `ingest` completes (pages written)        | epoch + 1        |
+| `lifecycle transition` (any state change) | epoch + 1        |
+| `cache clear`                             | epoch reset to 0 |
 
 Because the epoch is part of the cache key, any structural change to the wiki automatically invalidates all cached query answers — there is no explicit expiry TTL. Answers cached before an ingest are never served after it.
 
@@ -2684,21 +2752,23 @@ The web chat UI is a React single-page application served at `GET /app` by the S
 
 Each browser session is assigned a `session_id` (UUID) on `POST /sessions`. The server maintains a lightweight in-memory store per session:
 
-| Field | Type | Description |
-|---|---|---|
-| `session_id` | UUID | Unique identifier for this browser session |
-| `mode` | str | Session mode (`NEW_WIKI`, `EXPLORER`, `HEALTH_CHECK`, `POWER_USER`) |
-| `cursor` | int | Current position in the hint pool for windowed rotation |
-| `last_hints` | list[str] | Hints returned in the previous response (used for deduplication) |
+
+| Field        | Type      | Description                                                         |
+| ------------ | --------- | ------------------------------------------------------------------- |
+| `session_id` | UUID      | Unique identifier for this browser session                          |
+| `mode`       | str       | Session mode (`NEW_WIKI`, `EXPLORER`, `HEALTH_CHECK`, `POWER_USER`) |
+| `cursor`     | int       | Current position in the hint pool for windowed rotation             |
+| `last_hints` | list[str] | Hints returned in the previous response (used for deduplication)    |
 
 **Session mode** is derived from the wiki's current state at `POST /sessions`:
 
-| Mode | Condition | Hint behaviour |
-|---|---|---|
-| `NEW_WIKI` | `WikiStorage.count_pages() < 5` | Onboarding chips — guides user through first ingest |
-| `EXPLORER` | ≥5 pages, no prior `chat_sessions` rows | Discovery chips — broad overview questions |
-| `HEALTH_CHECK` | ≥5 pages, prior sessions, ≥1 `stale` page | Lifecycle chips — suggests running lint or reviewing stale pages |
-| `POWER_USER` | ≥5 pages, prior sessions, no stale pages | Context-sensitive follow-up chips |
+
+| Mode           | Condition                                  | Hint behaviour                                                    |
+| -------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| `NEW_WIKI`     | `WikiStorage.count_pages() < 5`            | Onboarding chips — guides user through first ingest              |
+| `EXPLORER`     | ≥5 pages, no prior`chat_sessions` rows    | Discovery chips — broad overview questions                       |
+| `HEALTH_CHECK` | ≥5 pages, prior sessions, ≥1`stale` page | Lifecycle chips — suggests running lint or reviewing stale pages |
+| `POWER_USER`   | ≥5 pages, prior sessions, no stale pages  | Context-sensitive follow-up chips                                 |
 
 The mode is returned by `POST /sessions` and also visible as a badge in the UI header.
 
@@ -2733,6 +2803,7 @@ Each `GET /query/stream` call may include a `session_id` (UUID from `POST /sessi
 The left navigation bar in the web UI is driven by `GET /sessions` (returns up to 20 recent sessions, ordered by `last_active DESC`) rather than `localStorage`, so history is consistent across browser tabs and survives page refreshes.
 
 **2-level collapsible tree:**
+
 - Sessions with a single user turn appear as a flat entry showing the question text and relative timestamp.
 - Sessions with two or more user turns render as a collapsible group: the root row shows the first question plus a turn count badge (e.g. `3 turns`); a **▸** chevron toggles expansion; expanded child rows show each follow-up question with a `↳` indent.
 
@@ -2742,10 +2813,11 @@ The left navigation bar in the web UI is driven by `GET /sessions` (returns up t
 
 **API surface:**
 
-| Endpoint | Description |
-|---|---|
-| `GET /sessions?limit=N` | Returns `[{session_id, mode, created_at, last_active, turns: [str]}]` — `turns` is the list of user message contents in chronological order |
-| `GET /sessions/{session_id}/messages` | Returns `[{role, content}]` for every message in the session, oldest first |
+
+| Endpoint                              | Description                                                                                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /sessions?limit=N`               | Returns`[{session_id, mode, created_at, last_active, turns: [str]}]` — `turns` is the list of user message contents in chronological order |
+| `GET /sessions/{session_id}/messages` | Returns`[{role, content}]` for every message in the session, oldest first                                                                   |
 
 **Configuration:**
 
@@ -2788,11 +2860,12 @@ synthadoc serve -w my-wiki --port 7070
 
 ### Transport options
 
-| Client | Transport | Config mechanism |
-|---|---|---|
-| Claude Desktop | stdio | `command` + `args` in `mcpServers` JSON |
-| Claude Code CLI | SSE (`--transport sse`) | `claude mcp add --transport sse <name> <url>` |
-| n8n, LangGraph, custom agents | HTTP/SSE | Direct HTTP connection to `/mcp/sse` |
+
+| Client                        | Transport               | Config mechanism                              |
+| ----------------------------- | ----------------------- | --------------------------------------------- |
+| Claude Desktop                | stdio                   | `command` + `args` in `mcpServers` JSON       |
+| Claude Code CLI               | SSE (`--transport sse`) | `claude mcp add --transport sse <name> <url>` |
+| n8n, LangGraph, custom agents | HTTP/SSE                | Direct HTTP connection to`/mcp/sse`           |
 
 Claude Desktop does not support `"url"`-based HTTP connections in its `mcpServers` config — stdio is the only supported transport. Claude Code supports both SSE and stdio. The SSE endpoint path is exactly `/mcp/sse` (not `/mcp` or `/mcp/`).
 
@@ -2808,20 +2881,21 @@ For Claude Desktop, `mcpServers` key names must use underscores (e.g. `synthadoc
 
 ### Tool reference
 
-| Tool | Parameters | Returns | LLM cost |
-|---|---|---|---|
-| `synthadoc_search` | `terms: str` | `{results: [{slug, score, title, snippet}]}` | Claude only |
-| `synthadoc_read_page` | `slug: str` | `{slug, title, content, status, type, tags, lint_warnings, sources}` or `{error, slug}` | Claude only |
-| `synthadoc_list_pages` | `status?: str` (default `"all"`) | `{pages: [{slug, title, status, type, has_sources}], total: int}` | Neither |
-| `synthadoc_context` | `goal: str`, `token_budget?: int` (default `10000`) | `{goal, token_budget, tokens_used, pages: [{slug, relevance, excerpt, source, confidence, tags, estimated_tokens}], omitted: [{slug, estimated_tokens}]}` | Neither |
-| `synthadoc_export` | `format?: str` (default `"okf"`), `output_path?: str` (okf defaults to `<wiki>/exports/<name>-okf-<date>/`), `status_filter?: str` (default `"all"`) | okf writes folder to disk → `{format, output_path, files_written, pages}`. Other formats: with `output_path` → `{format, output_path, pages}`; without → `{format, content, pages}`. Formats: `okf`, `llms.txt`, `llms-full.txt`, `json`, `graphml` | Neither |
-| `synthadoc_write_page` | `slug: str`, `content: str`, `title?: str` | `{slug, title, status}` or `{error, slug}` | Neither |
-| `synthadoc_status` | *(none)* | `{pages: int, wiki: str}` | Neither |
-| `synthadoc_jobs` | `status?: str` (default `"all"`) | `{jobs: [{id, operation, status, created, source?, error?}]}` | Neither |
-| `synthadoc_lifecycle` | `slug: str`, `to_state: str`, `reason: str` | `{slug, from_state, to_state, reason, timestamp, cascade_links_removed_from: [str]}` or `{error, cascade_links_removed_from: []}` _(cascade field added v1.0.2)_ | Neither |
-| `synthadoc_lint_report` | *(none)* | `{contradicted: [str], orphans: [str], adversarial_warnings: int, adversarial_pages: [str]}` | Neither |
-| `synthadoc_ingest` | `source: str` | `{job_id, source}` | Synthadoc |
-| `synthadoc_lint` | `scope?: str` (default `"all"`) | `{job_id, scope}` | Synthadoc |
+
+| Tool                    | Parameters                                                                                                                                           | Returns                                                                                                                                                                                                                                               | LLM cost    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `synthadoc_search`      | `terms: str`                                                                                                                                         | `{results: [{slug, score, title, snippet}]}`                                                                                                                                                                                                          | Claude only |
+| `synthadoc_read_page`   | `slug: str`                                                                                                                                          | `{slug, title, content, status, type, tags, lint_warnings, sources}` or `{error, slug}`                                                                                                                                                               | Claude only |
+| `synthadoc_list_pages`  | `status?: str` (default `"all"`)                                                                                                                     | `{pages: [{slug, title, status, type, has_sources}], total: int}`                                                                                                                                                                                     | Neither     |
+| `synthadoc_context`     | `goal: str`, `token_budget?: int` (default `10000`)                                                                                                  | `{goal, token_budget, tokens_used, pages: [{slug, relevance, excerpt, source, confidence, tags, estimated_tokens}], omitted: [{slug, estimated_tokens}]}`                                                                                             | Neither     |
+| `synthadoc_export`      | `format?: str` (default `"okf"`), `output_path?: str` (okf defaults to `<wiki>/exports/<name>-okf-<date>/`), `status_filter?: str` (default `"all"`) | okf writes folder to disk →`{format, output_path, files_written, pages}`. Other formats: with `output_path` → `{format, output_path, pages}`; without → `{format, content, pages}`. Formats: `okf`, `llms.txt`, `llms-full.txt`, `json`, `graphml` | Neither     |
+| `synthadoc_write_page`  | `slug: str`, `content: str`, `title?: str`                                                                                                           | `{slug, title, status}` or `{error, slug}`                                                                                                                                                                                                            | Neither     |
+| `synthadoc_status`      | *(none)*                                                                                                                                             | `{pages: int, wiki: str}`                                                                                                                                                                                                                             | Neither     |
+| `synthadoc_jobs`        | `status?: str` (default `"all"`)                                                                                                                     | `{jobs: [{id, operation, status, created, source?, error?}]}`                                                                                                                                                                                         | Neither     |
+| `synthadoc_lifecycle`   | `slug: str`, `to_state: str`, `reason: str`                                                                                                          | `{slug, from_state, to_state, reason, timestamp, cascade_links_removed_from: [str]}` or `{error, cascade_links_removed_from: []}` _(cascade field added v1.0.2)_                                                                                      | Neither     |
+| `synthadoc_lint_report` | *(none)*                                                                                                                                             | `{contradicted: [str], orphans: [str], adversarial_warnings: int, adversarial_pages: [str]}`                                                                                                                                                          | Neither     |
+| `synthadoc_ingest`      | `source: str`                                                                                                                                        | `{job_id, source}`                                                                                                                                                                                                                                    | Synthadoc   |
+| `synthadoc_lint`        | `scope?: str` (default `"all"`)                                                                                                                      | `{job_id, scope}`                                                                                                                                                                                                                                     | Synthadoc   |
 
 Valid `to_state` values for `synthadoc_lifecycle`: `active`, `draft`, `stale`, `contradicted`, `archived`.
 
@@ -2837,10 +2911,11 @@ Valid `status` values for `synthadoc_jobs` and `synthadoc_list_pages`: `all`, `p
 
 The MCP integration separates reasoning from persistence:
 
-| Layer | Role | What it handles |
-|---|---|---|
-| Claude (Desktop or Code) | **Brain** — reasoning, synthesis, editorial judgment | Tool chaining, cross-domain inference, writing quality |
-| Synthadoc MCP | **Memory** — domain knowledge, lifecycle, audit | BM25 search, page storage, 5-state lifecycle, immutable event log |
+
+| Layer                    | Role                                                  | What it handles                                                   |
+| ------------------------ | ----------------------------------------------------- | ----------------------------------------------------------------- |
+| Claude (Desktop or Code) | **Brain** — reasoning, synthesis, editorial judgment | Tool chaining, cross-domain inference, writing quality            |
+| Synthadoc MCP            | **Memory** — domain knowledge, lifecycle, audit      | BM25 search, page storage, 5-state lifecycle, immutable event log |
 
 Practical consequences:
 
@@ -2869,10 +2944,11 @@ The audit trail records the same fields as a manual CLI transition — the MCP p
 
 ### CLI flags
 
-| Flag | Effect |
-|---|---|
-| `--mcp-only` | Start only the MCP endpoint; suppress HTTP REST API and web UI |
-| `--http-only` | Start only the HTTP server; suppress the MCP mount |
+
+| Flag          | Effect                                                         |
+| ------------- | -------------------------------------------------------------- |
+| `--mcp-only`  | Start only the MCP endpoint; suppress HTTP REST API and web UI |
+| `--http-only` | Start only the HTTP server; suppress the MCP mount             |
 
 Default (no flag): both MCP and HTTP start together on the same port.
 
@@ -2940,13 +3016,14 @@ Every backup contains a `manifest.json` at the zip root:
 
 ### Restore conflict rules
 
-| Situation | Behaviour |
-|---|---|
-| Name not in registry | Register normally |
-| Name in registry, path exists | Hard stop — use `--name` to rename or `synthadoc uninstall` first |
-| Name in registry, path gone (stale) | Proceed with a printed note; stale entry is overwritten |
-| Demo wiki renamed via `--name` | Warn + `y/N` prompt (breaks `demo sync`) |
-| Port taken | System suggests the next available port; user confirms or overrides |
+
+| Situation                           | Behaviour                                                           |
+| ----------------------------------- | ------------------------------------------------------------------- |
+| Name not in registry                | Register normally                                                   |
+| Name in registry, path exists       | Hard stop — use`--name` to rename or `synthadoc uninstall` first   |
+| Name in registry, path gone (stale) | Proceed with a printed note; stale entry is overwritten             |
+| Demo wiki renamed via`--name`       | Warn +`y/N` prompt (breaks `demo sync`)                             |
+| Port taken                          | System suggests the next available port; user confirms or overrides |
 
 ### CLI commands
 
@@ -2964,16 +3041,18 @@ synthadoc restore <backup.zip> [--name <new-name>] [--target <dir>] [--port <por
 
 Every source document passes through a sanitizer immediately after text extraction, before any LLM call. The sanitizer removes six categories of content that could manipulate the LLM or degrade compilation quality:
 
-| Category | Action | Warning logged? |
-|---|---|---|
-| Zero-width characters (U+200B, U+200C, U+200D, U+FEFF) | Removed silently | No |
-| Bidi override characters (U+202A–U+202E, U+2066–U+2069) | Removed | Yes |
-| HTML comments (`<!-- ... -->`) | Removed silently | No |
-| Hidden CSS spans (`display:none`, `visibility:hidden`) | Removed silently | No |
-| Base64 blobs ≥ 200 consecutive characters | Replaced with `[base64 content removed]` | Yes |
-| Instruction-override phrases (8 patterns: "ignore previous instructions", "disregard the above", "override your system prompt", etc.) | Replaced with `[redacted]` | Always |
+
+| Category                                                                                                                              | Action                                  | Warning logged? |
+| ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- | --------------- |
+| Zero-width characters (U+200B, U+200C, U+200D, U+FEFF)                                                                                | Removed silently                        | No              |
+| Bidi override characters (U+202A–U+202E, U+2066–U+2069)                                                                             | Removed                                 | Yes             |
+| HTML comments (`<!-- ... -->`)                                                                                                        | Removed silently                        | No              |
+| Hidden CSS spans (`display:none`, `visibility:hidden`)                                                                                | Removed silently                        | No              |
+| Base64 blobs ≥ 200 consecutive characters                                                                                            | Replaced with`[base64 content removed]` | Yes             |
+| Instruction-override phrases (8 patterns: "ignore previous instructions", "disregard the above", "override your system prompt", etc.) | Replaced with`[redacted]`               | Always          |
 
 When content is removed and a warning is appropriate, the server logs a `WARN` entry:
+
 ```
 [WARN] sanitizer stripped content from 'papers/survey.pdf': bidi overrides, instruction-override phrase
 ```
@@ -3022,12 +3101,13 @@ The same `max_source_chars` field is accepted by the HTTP `POST /jobs/ingest` bo
 
 Query context is allocated proportionally to the configured model's context window, replacing the prior hard cap. The default allocation:
 
-| Slice | Default | Purpose |
-|---|---|---|
-| `context_wiki_pct` | 60% | Wiki page content (ranked by BM25 + vector score) |
-| `context_history_pct` | 20% | Chat turn history (newest-first, oldest dropped when over budget) |
-| `context_system_pct` | 15% | System prompt and purpose document |
-| `context_index_pct` | 5% | `ROUTING.md` and search index |
+
+| Slice                 | Default | Purpose                                                           |
+| --------------------- | ------- | ----------------------------------------------------------------- |
+| `context_wiki_pct`    | 60%     | Wiki page content (ranked by BM25 + vector score)                 |
+| `context_history_pct` | 20%     | Chat turn history (newest-first, oldest dropped when over budget) |
+| `context_system_pct`  | 15%     | System prompt and purpose document                                |
+| `context_index_pct`   | 5%      | `ROUTING.md` and search index                                     |
 
 Percentages must sum to ≤ 100. Configure in `[query]`:
 
@@ -3046,13 +3126,14 @@ context_index_pct     = 5
 
 Synthadoc ships a built-in prefix-matched table:
 
-| Model | Context window |
-|---|---|
+
+| Model                                                   | Context window |
+| ------------------------------------------------------- | -------------- |
 | `claude-opus-4*`, `claude-sonnet-4*`, `claude-haiku-4*` | 200,000 tokens |
-| `gpt-4o*`, `gpt-4-turbo*` | 128,000 tokens |
-| `gpt-4` (exact) | 8,192 tokens |
-| `gpt-3.5-turbo*` | 16,385 tokens |
-| Unknown / fallback | 128,000 tokens |
+| `gpt-4o*`, `gpt-4-turbo*`                               | 128,000 tokens |
+| `gpt-4` (exact)                                         | 8,192 tokens   |
+| `gpt-3.5-turbo*`                                        | 16,385 tokens  |
+| Unknown / fallback                                      | 128,000 tokens |
 
 Set `context_window = N` in config to override the map (useful for local Ollama models with non-standard context sizes).
 
@@ -3082,9 +3163,10 @@ CREATE TABLE graph_edges (
 
 Edge weight is a composite signal from two sources:
 
-| Edge type | Source | Weight contribution |
-|-----------|--------|---------------------|
-| `wikilink` | `[[slug]]` occurrences in page body | +1 per occurrence |
+
+| Edge type   | Source                                                     | Weight contribution  |
+| ----------- | ---------------------------------------------------------- | -------------------- |
+| `wikilink`  | `[[slug]]` occurrences in page body                        | +1 per occurrence    |
 | `co_source` | pages compiled from the same source file (matched by hash) | +2 per shared source |
 
 Most edges are `mixed` (have both types). Pure `co_source` edges surface hidden relationships — pages compiled from the same source document are linked immediately after ingest, before any wikilinks are created. `edge_type` is stored on each edge so the web UI can render co-source edges with a different visual style.
@@ -3129,15 +3211,16 @@ The five structural system pages — `overview`, `index`, `dashboard`, `purpose`
 
 The Obsidian plugin includes a **draggable modal** knowledge graph panel (`Graph: show knowledge graph` command). It fetches from the same `GET /graph` endpoint as the web UI and renders a force-directed Canvas 2D simulation using Verlet integration (no external library). System pages are already excluded from the server response.
 
-| Feature | Obsidian panel | Web UI Graph tab |
-|---------|----------------|-----------------|
-| Engine | Canvas 2D + Verlet | D3.js SVG |
-| Node click | Opens the wiki page in the current pane | Opens the node sidebar with "Ask about this →" |
-| **Best for** | **Navigating to and editing pages** | **Asking questions about a page** |
-| Draggable panel | Yes — drag header to reposition | Fixed tab layout |
-| Node cap | 300 most-connected (see note) | No cap |
-| Cluster legend | Yes | Yes |
-| Type filter | Yes | Yes |
+
+| Feature         | Obsidian panel                          | Web UI Graph tab                                |
+| --------------- | --------------------------------------- | ----------------------------------------------- |
+| Engine          | Canvas 2D + Verlet                      | D3.js SVG                                       |
+| Node click      | Opens the wiki page in the current pane | Opens the node sidebar with "Ask about this →" |
+| **Best for**    | **Navigating to and editing pages**     | **Asking questions about a page**               |
+| Draggable panel | Yes — drag header to reposition        | Fixed tab layout                                |
+| Node cap        | 300 most-connected (see note)           | No cap                                          |
+| Cluster legend  | Yes                                     | Yes                                             |
+| Type filter     | Yes                                     | Yes                                             |
 
 **Rule of thumb:** Use the **web UI** when you want to ask questions about a node. Use the **Obsidian panel** when you want to navigate to and edit a page.
 
@@ -3153,11 +3236,12 @@ The Obsidian plugin includes a **draggable modal** knowledge graph panel (`Graph
 
 `synthadoc init` and `synthadoc scaffold` write three agent skill files at the wiki root:
 
-| File | Format | Read by |
-|------|--------|---------|
-| `AGENTS.md` | OpenAI Agents SDK / Codex / OpenCode | Codex CLI, OpenCode, generic agents |
-| `CLAUDE.md` | Claude Code / Anthropic | Claude Code (loaded automatically when the wiki folder is opened) |
-| `GEMINI.md` | Gemini CLI | Gemini CLI |
+
+| File        | Format                               | Read by                                                           |
+| ----------- | ------------------------------------ | ----------------------------------------------------------------- |
+| `AGENTS.md` | OpenAI Agents SDK / Codex / OpenCode | Codex CLI, OpenCode, generic agents                               |
+| `CLAUDE.md` | Claude Code / Anthropic              | Claude Code (loaded automatically when the wiki folder is opened) |
+| `GEMINI.md` | Gemini CLI                           | Gemini CLI                                                        |
 
 All three files carry **identical content**: a title block, the LLM-generated domain guidelines for the wiki, a quick-reference CLI command table, and an MCP tool table. The only difference is the heading comment. This means any AI coding tool that opens the wiki root gets full Synthadoc guidance without manual setup.
 
@@ -3261,23 +3345,25 @@ Triggered by phrases such as "re-ingest the alan-turing page". A pre-LLM regex f
 
 Both workflows share the same `IngestLintWorkflow` tool set:
 
-| Tool | Description |
-|------|-------------|
-| `find_stale_pages` | Returns `[{slug, source_path}]` for all stale pages with a local text source |
-| `find_page_source` | Looks up any page by slug regardless of lifecycle state; returns `{slug, source_path}` |
-| `ingest_source` | Force-ingests a source file and waits for the job to reach a terminal state; returns `{status, message, job_id}` |
-| `poll_job` | Polls `GET /jobs/{job_id}` with exponential backoff until terminal; returns final status |
-| `run_lint` | Enqueues a full lint run; returns `{job_id}` — caller uses `poll_job` to wait for completion |
-| `confirm` | Sends a `confirm_request` SSE event and blocks until the user responds (Yes/No) |
+
+| Tool               | Description                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `find_stale_pages` | Returns`[{slug, source_path}]` for all stale pages with a local text source                                     |
+| `find_page_source` | Looks up any page by slug regardless of lifecycle state; returns`{slug, source_path}`                           |
+| `ingest_source`    | Force-ingests a source file and waits for the job to reach a terminal state; returns`{status, message, job_id}` |
+| `poll_job`         | Polls`GET /jobs/{job_id}` with exponential backoff until terminal; returns final status                         |
+| `run_lint`         | Enqueues a full lint run; returns`{job_id}` — caller uses `poll_job` to wait for completion                    |
+| `confirm`          | Sends a`confirm_request` SSE event and blocks until the user responds (Yes/No)                                  |
 
 ### Web UI graph sidebar maintenance chips
 
 In the web UI **Graph tab**, the node detail panel includes a **Maintenance** section with two chips that trigger the same workflows without typing:
 
-| Chip | Sent query | Workflow |
-|------|-----------|---------|
-| **⚑ Check this page for issues** | `"Check the {slug} page for issues"` | Lint-style analysis for the selected page |
-| **↻ Re-ingest this page** | `"Re-ingest the {slug} page"` | Triggers the page-by-slug reingest workflow |
+
+| Chip                              | Sent query                           | Workflow                                    |
+| --------------------------------- | ------------------------------------ | ------------------------------------------- |
+| **⚑ Check this page for issues** | `"Check the {slug} page for issues"` | Lint-style analysis for the selected page   |
+| **↻ Re-ingest this page**        | `"Re-ingest the {slug} page"`        | Triggers the page-by-slug reingest workflow |
 
 ### SSE protocol extensions (v1.2.0)
 
@@ -3324,51 +3410,56 @@ Triggered by phrases such as "run scaffold" or "regenerate scaffold". A pre-LLM 
 
 **IngestLintWorkflow** (stale-pages bulk reingest and page-by-slug reingest):
 
-| Tool | Description |
-|------|-------------|
-| `find_stale_pages` | Returns `[{slug, source_path}]` for all stale pages with a local text source |
-| `find_page_source` | Looks up any page by slug regardless of lifecycle state; returns `{slug, source_path}` |
-| `ingest_source` | Force-ingests a source file and waits for the job to reach a terminal state; returns `{status, message, job_id}` |
-| `poll_job` | Polls `GET /jobs/{job_id}` with exponential backoff until terminal; returns final status |
-| `run_lint` | Enqueues a full lint run; returns `{job_id}` — caller uses `poll_job` to wait for completion |
-| `confirm` | Sends a `confirm_request` SSE event and blocks until the user responds (Yes/No) |
-| `get_page_states` | Returns the current lifecycle state for a list of slugs |
+
+| Tool               | Description                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `find_stale_pages` | Returns`[{slug, source_path}]` for all stale pages with a local text source                                     |
+| `find_page_source` | Looks up any page by slug regardless of lifecycle state; returns`{slug, source_path}`                           |
+| `ingest_source`    | Force-ingests a source file and waits for the job to reach a terminal state; returns`{status, message, job_id}` |
+| `poll_job`         | Polls`GET /jobs/{job_id}` with exponential backoff until terminal; returns final status                         |
+| `run_lint`         | Enqueues a full lint run; returns`{job_id}` — caller uses `poll_job` to wait for completion                    |
+| `confirm`          | Sends a`confirm_request` SSE event and blocks until the user responds (Yes/No)                                  |
+| `get_page_states`  | Returns the current lifecycle state for a list of slugs                                                         |
 
 **BrokenWikilinksWorkflow** (broken wikilinks scan and fix):
 
-| Tool | Description |
-|------|-------------|
-| `find_broken_wikilinks` | Scans active pages for `[[slug]]` refs that resolve to no existing page; returns broken refs with fuzzy suggestions |
-| `apply_link_fixes` | Applies `{old_ref → new_ref}` corrections to a single page; `new_ref=null` removes the link |
-| `confirm` | Sends a `confirm_request` SSE event and blocks until the user responds |
-| `run_lint` | Enqueues a lint pass to validate link integrity after fixes |
-| `poll_job` | Polls a job to terminal state |
-| `get_page_states` | Returns the current lifecycle state for a list of slugs |
+
+| Tool                    | Description                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `find_broken_wikilinks` | Scans active pages for`[[slug]]` refs that resolve to no existing page; returns broken refs with fuzzy suggestions |
+| `apply_link_fixes`      | Applies`{old_ref → new_ref}` corrections to a single page; `new_ref=null` removes the link                        |
+| `confirm`               | Sends a`confirm_request` SSE event and blocks until the user responds                                              |
+| `run_lint`              | Enqueues a lint pass to validate link integrity after fixes                                                        |
+| `poll_job`              | Polls a job to terminal state                                                                                      |
+| `get_page_states`       | Returns the current lifecycle state for a list of slugs                                                            |
 
 **LintReportWorkflow** (lint run and full report):
 
-| Tool | Description |
-|------|-------------|
-| `run_lint` | Enqueues a full lint pass; returns `{job_id}` |
-| `poll_job` | Waits for the lint job to reach a terminal state |
+
+| Tool              | Description                                                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `run_lint`        | Enqueues a full lint pass; returns`{job_id}`                                                                                       |
+| `poll_job`        | Waits for the lint job to reach a terminal state                                                                                   |
 | `get_lint_report` | Reads last lint summary from audit DB and per-page frontmatter; returns contradicted pages, adversarial warnings, and orphan slugs |
 
 **ScaffoldWorkflow** (scaffold and report):
 
-| Tool | Description |
-|------|-------------|
-| `get_scaffold_preview` | Reads domain from `WorkflowContext.domain`; returns domain and list of files to overwrite |
-| `confirm` | Sends a `confirm_request` SSE event and blocks until user responds |
-| `run_scaffold` | Enqueues scaffold job, polls to terminal state, reads `job.result` for `categories_updated` and `routing_regenerated` |
+
+| Tool                   | Description                                                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `get_scaffold_preview` | Reads domain from`WorkflowContext.domain`; returns domain and list of files to overwrite                             |
+| `confirm`              | Sends a`confirm_request` SSE event and blocks until user responds                                                    |
+| `run_scaffold`         | Enqueues scaffold job, polls to terminal state, reads`job.result` for `categories_updated` and `routing_regenerated` |
 
 ### Web UI graph sidebar maintenance chips
 
 In the web UI **Graph tab**, the node detail panel includes a **Maintenance** section with two chips that trigger the same workflows without typing:
 
-| Chip | Sent query | Workflow |
-|------|-----------|---------|
-| **⚑ Check this page for issues** | `"Check the {slug} page for issues"` | Lint-style analysis for the selected page |
-| **↻ Re-ingest this page** | `"Re-ingest the {slug} page"` | Triggers the page-by-slug reingest workflow |
+
+| Chip                              | Sent query                           | Workflow                                    |
+| --------------------------------- | ------------------------------------ | ------------------------------------------- |
+| **⚑ Check this page for issues** | `"Check the {slug} page for issues"` | Lint-style analysis for the selected page   |
+| **↻ Re-ingest this page**        | `"Re-ingest the {slug} page"`        | Triggers the page-by-slug reingest workflow |
 
 ### SSE protocol extensions (v1.2.0)
 
@@ -3434,11 +3525,12 @@ Three cache layers (embedding, LLM response, provider prompt cache) invalidate a
 
 Every Synthadoc wiki ships three companion files that give AI coding agents a complete, self-contained operating guide for the wiki:
 
-| File | Platform |
-|---|---|
-| `AGENTS.md` | Codex CLI, OpenCode, and any agent that reads the AGENTS.md convention |
+
+| File        | Platform                                                                                       |
+| ----------- | ---------------------------------------------------------------------------------------------- |
+| `AGENTS.md` | Codex CLI, OpenCode, and any agent that reads the AGENTS.md convention                         |
 | `CLAUDE.md` | Claude Code (this session's tool) — highest-priority instruction source in Claude's hierarchy |
-| `GEMINI.md` | Gemini CLI — relevant because Synthadoc's default LLM provider is `gemini-2.5-flash-lite` |
+| `GEMINI.md` | Gemini CLI — relevant because Synthadoc's default LLM provider is`gemini-2.5-flash-lite`      |
 
 All three files share identical body content generated from the same template; they differ only in their H1 heading so each agent recognises its own file first. The body covers:
 
@@ -3512,13 +3604,14 @@ any point.
 
 ### Strategy menu
 
-| Strategy | When it runs |
-|---|---|
-| Content rewrite | Always the first attempt — rewrites the page to remove unsupported claims or reconcile conflicting sources with explicit hedging |
-| Web ingest for better grounding | After a failed first attempt when the agent judges the page lacks authoritative sourcing — proposes fetching a specific URL |
-| Force source re-ingest | Source file exists but may be outdated — proposes re-ingesting with a force flag |
-| Cross-page resolution | The conflict stems from a related page's reference — proposes modifying the referring page |
-| Escalate | Cap reached (3 attempts) — detailed diagnosis and concrete next steps, page remains *contradicted* |
+
+| Strategy                        | When it runs                                                                                                                      |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| Content rewrite                 | Always the first attempt — rewrites the page to remove unsupported claims or reconcile conflicting sources with explicit hedging |
+| Web ingest for better grounding | After a failed first attempt when the agent judges the page lacks authoritative sourcing — proposes fetching a specific URL      |
+| Force source re-ingest          | Source file exists but may be outdated — proposes re-ingesting with a force flag                                                 |
+| Cross-page resolution           | The conflict stems from a related page's reference — proposes modifying the referring page                                       |
+| Escalate                        | Cap reached (3 attempts) — detailed diagnosis and concrete next steps, page remains*contradicted*                                |
 
 ### Final confirmation
 
@@ -3553,6 +3646,7 @@ being needed first:
   and "List contradicted pages" as follow-up chips below the response.
 
 **CLI:**
+
 ```bash
 synthadoc workflow run --name contradiction-resolver              # all contradicted pages
 synthadoc workflow run --name contradiction-resolver --slug alan-turing   # one page
@@ -3591,9 +3685,10 @@ escalation).
 `tool_transition_lifecycle_state` writes to two separate DB tables when it
 promotes a page back to *active*:
 
-| Call | Table | Read by |
-|---|---|---|
-| `set_page_state(slug, to_state, "workflow")` | `page_states` | `GET /lifecycle/pages` (current lifecycle state) |
+
+| Call                                                                     | Table              | Read by                                               |
+| ------------------------------------------------------------------------ | ------------------ | ----------------------------------------------------- |
+| `set_page_state(slug, to_state, "workflow")`                             | `page_states`      | `GET /lifecycle/pages` (current lifecycle state)      |
 | `record_lifecycle_event(slug, from_state, to_state, reason, "workflow")` | `lifecycle_events` | `GET /lifecycle/events?slug=…` (immutable audit log) |
 
 Each call is wrapped in an independent `try/except` block — a DB failure in
@@ -3718,6 +3813,7 @@ either does not abort the workflow. The page file is written first via
 - **OKF `type:` field** — IngestAgent now writes a `type:` frontmatter field on every compiled page (values: `concept`, `person`, `organization`, `technology`, `event`, `location`, `product`). The field is required by OKF v0.1 and enables type-grouped `index.md` in the export bundle. Pages ingested before v0.9.0 can be backfilled via `synthadoc demo sync` (demo wikis) or re-running `synthadoc ingest` (custom wikis).
 - **`synthadoc demo sync` — optional wiki name** — running `synthadoc demo sync` without a wiki name argument syncs all registered demo wikis in one pass. The sync step also backfills `type:` on existing pages that were compiled before v0.9.0 without the field.
 - **SSE shutdown stability** — a log filter installed on `uvicorn.error` at startup suppresses three benign error classes that appear when the server exits while SSE connections are open: `asyncio.CancelledError`, `KeyboardInterrupt`, and the `RuntimeError("Expected ASGI message 'http.response.body'…")` that Starlette's error middleware raises after cancellation. Actual errors during normal operation are unaffected.
+
 ### v0.8.0 (Community Edition)
 
 - **Multi-turn conversation** — the web chat UI maintains conversation history across turns within a session. History is stored in `audit.db` per session and loaded server-side on each request (up to `conversation_history_turns` turns, default 5). Follow-up questions are rewritten into standalone form by a dedicated rewrite component before BM25 retrieval, so context-dependent phrases ("What came after that?") resolve correctly. When the session exceeds the turn limit, a summarization component compresses the oldest turns into a `[Session summary]` entry; a `notice` SSE event is emitted the first time compression occurs.
@@ -3754,13 +3850,13 @@ either does not abort the workflow. The page file is written first via
 - **Lifecycle Obsidian plugin** — `Synthadoc: Manage Page Lifecycle` command opens `LifecycleModal`: sortable, filterable, paginated table of all pages with current state and last transition; valid transition action buttons per row; `ReasonModal` prompts for reason before committing; draft/stale badge links on lint modal and jobs panel open the table pre-filtered
 - **Export formats** — `synthadoc export --format <fmt>` serializes the wiki in four formats assembled server-side with zero LLM calls: `llms.txt` (navigation index per llmstxt.org spec — active pages in `## Pages`, contradicted/stale in `## Needs Review`, archived omitted); `llms-full.txt` (flat content dump with `---` separators, provenance footnotes preserved verbatim, no size limit); `graphml` (standard GraphML 1.1 — node attributes include `label`/`title`, `status`, `confidence`, `orphan`, `inbound_link_count`, `routing_branch`; edges=wikilinks; dual-label support: `label` key for Gephi/Cytoscape, `y:NodeLabel` for yEd; no position data — run tool layout after import); `json` (agent-ready dump with `claims[]`, `lifecycle_history[]`, per-page `ingest_cost_usd` and `ingest_tokens`, `total_compilation_cost_usd`, `routing.branch_memberships`); all formats accept `--status` filter (`all`/`active`/`draft`/`stale`/`contradicted`/`archived`); `POST /export` endpoint accepts `{format, status_filter}`; Obsidian **Export Wiki** command — format dropdown, full-width output path, status filter, Export button, View Graph inline preview button (graphml only)
 
-
 ### v0.5.0 (Community Edition)
 
 - **Adversarial review** — concurrent independent LLM review of every wiki page after lint runs; flags overstated claims, unsupported assertions, and high-confidence statements the source material does not support; results stored as `lint_warnings: [{claim, concern}]` in page frontmatter; surfaced in redesigned 3-tab `Lint: report` modal (Contradictions / Orphans / Adversarial) and redesigned `synthadoc lint report` CLI output; configured via `[agents].adversarial` and `[lint].adversarial_max_per_page` (default 2) in `config.toml`; skipped with `synthadoc lint run --no-adversarial` (also clears stale warnings); cross-model review — a different model family from the ingest model reduces self-serving bias; concurrent via `asyncio.gather()` — a 100-page wiki completes in the same wall-clock time as one call; per-page rate-limit failures are non-fatal
 - **Claim-level provenance** — during ingest, Pass 4 (`_annotate_citations()`) reads each page section alongside numbered source text and inserts `^[filename:L-L]` inline citation markers at the end of substantive paragraphs; markers map compiled claims to exact source line ranges; stored in the page body, recorded in `audit.db` `claim_citations` table, and validated by lint; local source sidecars written to `.synthadoc/extracted/` (plain-text `.txt` for all file types; pagemap JSON for PDFs to resolve line numbers to PDF page numbers); in Obsidian (Reading View only) markers render as interactive citation chips — one click opens the Source Viewer showing the referenced lines with ±5 lines of context; PDF sources show a page-jump button; `GET /provenance/citations` endpoint powers the **View Page Provenance** modal (sortable, paginated citation table); `synthadoc audit citations` CLI queries the same table with `--page` and `--broken` filters
 - **Routing Obsidian plugin** — `Synthadoc: Routing: manage ROUTING.md...` command palette entry opens a modal panel with three buttons: **Init** creates ROUTING.md from the current index.md branch structure (enabled only when ROUTING.md does not exist), **Validate** reports dangling slugs, **Clean** removes dangling slugs from ROUTING.md; after each action results appear inline
 - **Candidates Staging Obsidian plugin** — `Synthadoc: Staging: manage staging policy...` and `Synthadoc: Candidates: review candidate pages...` command palette entries; Staging modal shows policy state with segmented controls; Candidates modal shows a paginated table with promote/discard bulk and per-row actions
+
 ### v0.4.0 (Community Edition)
 
 - **Routing layer** — `ROUTING.md` groups wiki pages into named topic branches; `QueryAgent` picks 1–2 branches via a lightweight LLM call and restricts BM25 to those slugs, reducing noise on large wikis; falls back to full-corpus search when no branch is selected; `IngestAgent` auto-places new pages into the best branch on create
@@ -3835,4 +3931,3 @@ either does not abort the workflow. The page file is written first via
 - **Multi-wiki** — unlimited isolated wikis, each on its own port
 - **OpenTelemetry** — traces, metrics, structured logs; OTLP export optional
 - **Cross-platform** — Windows, Linux, macOS
-

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -1,6 +1,6 @@
 ﻿# Synthadoc User Quick-Start Guide
 
-**Version: v1.2.1 (Community Edition)**
+**Version: v1.3.0 (Community Edition)**
 
 This guide walks you through the **History of Computing** demo wiki — a fully wired
 Synthadoc environment with 13 pre-built pages and six raw source files that cover every
@@ -208,15 +208,15 @@ history-of-computing/
 **Open these files in Obsidian now:**
 
 
-| File                  | What to look at                                                   |
-| --------------------- | ----------------------------------------------------------------- |
-| `wiki/index.md`       | Pre-generated category structure with`[[wikilinks]]` to each page |
-| `wiki/dashboard.md`   | Live Dataview tables — contradictions, orphans, recently added / updated / archived |
-| `wiki/alan-turing.md` | YAML frontmatter:`status`, `confidence`, `tags`, `sources[]`      |
-| `AGENTS.md`           | Domain-specific guidelines for Codex/OpenCode agents — LLM reads this on every ingest |
-| `CLAUDE.md`           | Same guidelines in Claude Code format — loaded automatically when you open this folder in Claude Code |
-| `GEMINI.md`           | Same guidelines in Gemini CLI format |
-| `wiki/purpose.md`     | Scope definition for History of Computing — five sections (Overview, What Belongs, Out of Scope, Intended Audience, Primary Use Cases). Each section contains a `<!-- synthadoc:scaffold -->` marker: content you add **above** a marker is preserved when you re-run `synthadoc scaffold`; content below is refreshed by the LLM. |
+| File                  | What to look at                                                                                                                                                                                                                                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wiki/index.md`       | Pre-generated category structure with`[[wikilinks]]` to each page                                                                                                                                                                                                                                                                  |
+| `wiki/dashboard.md`   | Live Dataview tables — contradictions, orphans, recently added / updated / archived                                                                                                                                                                                                                                               |
+| `wiki/alan-turing.md` | YAML frontmatter:`status`, `confidence`, `tags`, `sources[]`                                                                                                                                                                                                                                                                       |
+| `AGENTS.md`           | Domain-specific guidelines for Codex/OpenCode agents — LLM reads this on every ingest                                                                                                                                                                                                                                             |
+| `CLAUDE.md`           | Same guidelines in Claude Code format — loaded automatically when you open this folder in Claude Code                                                                                                                                                                                                                             |
+| `GEMINI.md`           | Same guidelines in Gemini CLI format                                                                                                                                                                                                                                                                                               |
+| `wiki/purpose.md`     | Scope definition for History of Computing — five sections (Overview, What Belongs, Out of Scope, Intended Audience, Primary Use Cases). Each section contains a`<!-- synthadoc:scaffold -->` marker: content you add **above** a marker is preserved when you re-run `synthadoc scaffold`; content below is refreshed by the LLM. |
 
 > **Upgrading an existing wiki?** If your wiki was created before v1.0.2, it will have `AGENTS.md` but not `CLAUDE.md` or `GEMINI.md`. Run `synthadoc scaffold` once to generate all three with LLM-produced guidelines that match your current wiki content.
 
@@ -224,13 +224,14 @@ history-of-computing/
 
 `wiki/dashboard.md` contains four live Dataview tables. Open it in Obsidian (Reading View) after installing the Dataview plugin to see them update automatically as you work through this guide.
 
-| Section | What it shows | Powered by |
-|---------|--------------|------------|
-| **Contradicted pages** | Pages whose sources conflict — need manual resolution | `status = "contradicted"` |
-| **Orphan pages** | Pages with no inbound `[[wikilinks]]` — run lint first to populate | `orphan = true` (set by lint) |
-| **Recently added** | The 10 most recently created pages, newest first | `created` frontmatter field |
-| **Recently updated** | Pages that have been re-ingested with new source material since their initial creation | `updated` frontmatter field — only present after a re-ingest |
-| **Recently archived** | Pages currently in `archived` state — retired from active use | `status = "archived"` |
+
+| Section                | What it shows                                                                          | Powered by                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **Contradicted pages** | Pages whose sources conflict — need manual resolution                                 | `status = "contradicted"`                                     |
+| **Orphan pages**       | Pages with no inbound`[[wikilinks]]` — run lint first to populate                     | `orphan = true` (set by lint)                                 |
+| **Recently added**     | The 10 most recently created pages, newest first                                       | `created` frontmatter field                                   |
+| **Recently updated**   | Pages that have been re-ingested with new source material since their initial creation | `updated` frontmatter field — only present after a re-ingest |
+| **Recently archived**  | Pages currently in`archived` state — retired from active use                          | `status = "archived"`                                         |
 
 **Recently added vs. Recently updated** — these are intentionally separate:
 
@@ -367,10 +368,11 @@ an alias and one is a longer substring of the query, the longer one takes preced
 
 Every page compiled by Synthadoc also carries two fields that align with Google's [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):
 
-| Field | What it contains | Set by |
-|-------|-----------------|--------|
-| `type` | Knowledge classifier: `concept`, `person`, `technology`, `event`, `organization`, `location`, or `product` | Ingest — LLM classifies during the analysis pass |
-| `resource` | Primary source URL (only present for URL-sourced pages) | Ingest — auto-populated from the URL |
+
+| Field      | What it contains                                                                                          | Set by                                            |
+| ---------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `type`     | Knowledge classifier:`concept`, `person`, `technology`, `event`, `organization`, `location`, or `product` | Ingest — LLM classifies during the analysis pass |
+| `resource` | Primary source URL (only present for URL-sourced pages)                                                   | Ingest — auto-populated from the URL             |
 
 These fields make Synthadoc wikis directly consumable by any OKF-aware agent without an export step. Pages ingested from local files have no `resource` field.
 
@@ -577,13 +579,13 @@ Most knowledge bases treat every page the same — ingested means trusted. Synth
 ### Lifecycle states
 
 
-| State          | Meaning                                   | How it is reached                               | What to do                                 |
-| -------------- | ----------------------------------------- | ----------------------------------------------- | ------------------------------------------ |
-| `draft`        | Compiled but not yet lint-reviewed        | Automatic on ingest                             | Run lint to auto-promote clean pages       |
-| `active`       | Lint-reviewed, current, trusted           | Lint auto-promotes from`draft`                  | No action needed                           |
+| State          | Meaning                                     | How it is reached                                               | What to do                                           |
+| -------------- | ------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------- |
+| `draft`        | Compiled but not yet lint-reviewed          | Automatic on ingest                                             | Run lint to auto-promote clean pages                 |
+| `active`       | Lint-reviewed, current, trusted             | Lint auto-promotes from`draft`                                  | No action needed                                     |
 | `contradicted` | Sources conflict, or adversarial gate fired | Lint detects contradiction or ≥ threshold adversarial warnings | Resolve conflict or fix flagged claims, then re-lint |
-| `stale`        | Source file has changed since last ingest | Lint detects SHA-256 hash mismatch              | Re-ingest the updated source with`--force` |
-| `archived`     | Source removed or explicitly retired      | Lint auto-archives on missing source; or manual | Restore to`draft` if source returns        |
+| `stale`        | Source file has changed since last ingest   | Lint detects SHA-256 hash mismatch                              | Re-ingest the updated source with`--force`           |
+| `archived`     | Source removed or explicitly retired        | Lint auto-archives on missing source; or manual                 | Restore to`draft` if source returns                  |
 
 ### Check lifecycle status (CLI)
 
@@ -732,11 +734,12 @@ konrad-zuse   draft   active  lint    2026-05-28T18:31:23  lint passed
 Synthadoc automatically captures a **content snapshot** — a frozen copy of the page body
 — every time anything meaningful happens to a page. Three situations trigger a snapshot:
 
-| Trigger | What causes it | Example |
-|---------|---------------|---------|
-| **Manual lifecycle transition** | You activate, archive, or restore a page via the CLI, Obsidian plugin, API, or the MCP `synthadoc_lifecycle` tool | `synthadoc lifecycle activate konrad-zuse` |
-| **Lint-driven state change** | Lint promotes a page, marks it stale, archives it for a missing source, or auto-resolves a contradiction | `synthadoc lint run --auto-resolve` |
-| **Manual file edit in Obsidian** | You edit a wiki page directly in Obsidian; the plugin detects the save and sends the content to the server (2-second debounce, only records when content actually changed) | Edit `wiki/orphan-page.md` in Obsidian and save |
+
+| Trigger                          | What causes it                                                                                                                                                             | Example                                        |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **Manual lifecycle transition**  | You activate, archive, or restore a page via the CLI, Obsidian plugin, API, or the MCP`synthadoc_lifecycle` tool                                                           | `synthadoc lifecycle activate konrad-zuse`     |
+| **Lint-driven state change**     | Lint promotes a page, marks it stale, archives it for a missing source, or auto-resolves a contradiction                                                                   | `synthadoc lint run --auto-resolve`            |
+| **Manual file edit in Obsidian** | You edit a wiki page directly in Obsidian; the plugin detects the save and sends the content to the server (2-second debounce, only records when content actually changed) | Edit`wiki/orphan-page.md` in Obsidian and save |
 
 Snapshots are listed **newest-first**. Index 1 is always the most recent snapshot; older
 snapshots carry higher index numbers.
@@ -850,6 +853,7 @@ rollback is always undoable. Roll back to index 1 to get the edited body back.
 ---
 
 **Common use cases:**
+
 - Undo an accidental edit made directly in Obsidian
 - Recover content overwritten by a failed re-ingest
 - Audit exactly what a page said when it first went live
@@ -861,12 +865,14 @@ The **Content Snapshots** tab in the **Manage Page Lifecycle** modal is the Obsi
 surface for everything above.
 
 **What the tab shows:**
+
 - All snapshots across all pages, sorted by slug then by index when unfiltered
 - Snapshot index (1 = newest per slug), the state transition that triggered it, who
   triggered it (`lint`, `cli`, `api`, `MANUAL_EDIT`), the timestamp, and the content size
 - A **Filter by slug…** input with a × clear button to narrow the list to one page
 
 **Actions:**
+
 - **Click any row** — opens the corresponding wiki page in the main Obsidian panel
 - **View** — opens the inline diff described in Step 2 above
 - **Rollback** — executes the rollback described in Step 3 above; the current body is
@@ -2068,21 +2074,23 @@ Synthadoc exports your wiki in five machine-readable formats — all assembled s
 
 ### What each format contains
 
-| Format          | What it exports                                                                                                                                                                                                                                   | Best used for                                                    |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `llms.txt`      | Page titles + one-line summaries, structured per the [llmstxt.org](https://llmstxt.org) spec. Contradicted/stale pages appear in a **Needs Review** section; archived pages are omitted.                                                          | Feeding AI assistants a compact, navigable wiki index            |
-| `llms-full.txt` | Full page content for all pages, separated by `---` dividers, with status and confidence headers. Provenance footnotes (`^[source.txt:42-58]`) are preserved verbatim. No size limit.                                                             | Large-context LLM prompts, RAG pipelines, offline reading        |
-| `graphml`       | Directed wikilink graph — one node per page, one edge per `[[wikilink]]`. Each node carries the page title, lifecycle state, confidence level, orphan flag, inbound link count, and routing branch. Compatible with yEd, Gephi, and Cytoscape.   | Visualising knowledge structure, detecting hub pages and orphans |
-| `json`          | Full structured dump per page: content, tags, sources, claims with source line ranges, lifecycle transition history, routing branch, and per-page ingest cost and token usage. Wiki-level: total compilation cost and routing branch memberships. | Agent pipelines, programmatic processing, compliance audits      |
-| `okf`           | [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle directory — one Markdown file per page with conformant YAML frontmatter, an `index.md` grouped by knowledge type, and a `log.md` change log. `[[wikilinks]]` are rewritten to OKF relative paths. Default includes **active + contradicted** pages only; contradicted pages carry a `> **Contradiction:** …` blockquote in the body. | Any OKF-aware agent or tool — **zero code changes needed**       |
+
+| Format          | What it exports                                                                                                                                                                                                                                                                                                                                                                                                                          | Best used for                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `llms.txt`      | Page titles + one-line summaries, structured per the[llmstxt.org](https://llmstxt.org) spec. Contradicted/stale pages appear in a **Needs Review** section; archived pages are omitted.                                                                                                                                                                                                                                                  | Feeding AI assistants a compact, navigable wiki index            |
+| `llms-full.txt` | Full page content for all pages, separated by`---` dividers, with status and confidence headers. Provenance footnotes (`^[source.txt:42-58]`) are preserved verbatim. No size limit.                                                                                                                                                                                                                                                     | Large-context LLM prompts, RAG pipelines, offline reading        |
+| `graphml`       | Directed wikilink graph — one node per page, one edge per`[[wikilink]]`. Each node carries the page title, lifecycle state, confidence level, orphan flag, inbound link count, and routing branch. Compatible with yEd, Gephi, and Cytoscape.                                                                                                                                                                                           | Visualising knowledge structure, detecting hub pages and orphans |
+| `json`          | Full structured dump per page: content, tags, sources, claims with source line ranges, lifecycle transition history, routing branch, and per-page ingest cost and token usage. Wiki-level: total compilation cost and routing branch memberships.                                                                                                                                                                                        | Agent pipelines, programmatic processing, compliance audits      |
+| `okf`           | [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle directory — one Markdown file per page with conformant YAML frontmatter, an `index.md` grouped by knowledge type, and a `log.md` change log. `[[wikilinks]]` are rewritten to OKF relative paths. Default includes **active + contradicted** pages only; contradicted pages carry a `> **Contradiction:** …` blockquote in the body. | Any OKF-aware agent or tool —**zero code changes needed**       |
 
 ### Status filter — export only what you trust
 
 The `--status` flag scopes the export to a specific lifecycle state:
 
+
 | Value           | What is included                  | When to use it                                                                    |
 | --------------- | --------------------------------- | --------------------------------------------------------------------------------- |
-| `all` (default) | Every non-archived page¹          | Full snapshot                                                                     |
+| `all` (default) | Every non-archived page¹         | Full snapshot                                                                     |
 | `active`        | Only lint-reviewed, trusted pages | **Recommended for AI consumption** — avoids feeding unreviewed content to an LLM |
 | `draft`         | Pages awaiting first lint pass    | Reviewing what has been ingested but not yet approved                             |
 | `stale`         | Pages whose source has changed    | Identifying content that needs re-ingest                                          |
@@ -2535,12 +2543,13 @@ Click **Ask about this →** to jump to the Chat tab with a pre-filled query abo
 
 Synthadoc provides two knowledge graph views powered by the same `GET /graph` endpoint. Choose based on what you want to do next:
 
-| I want to… | Use |
-|---|---|
-| Ask a question about a page | **Web UI Graph tab** — click a node → "Ask about this →" |
-| Read or edit a page I found in the graph | **Obsidian panel** — click a node to open it in the current pane |
-| Explore graph topology while staying in Obsidian | **Obsidian panel** |
-| See graph and chat side by side | **Web UI** |
+
+| I want to…                                      | Use                                                               |
+| ------------------------------------------------ | ----------------------------------------------------------------- |
+| Ask a question about a page                      | **Web UI Graph tab** — click a node → "Ask about this →"       |
+| Read or edit a page I found in the graph         | **Obsidian panel** — click a node to open it in the current pane |
+| Explore graph topology while staying in Obsidian | **Obsidian panel**                                                |
+| See graph and chat side by side                  | **Web UI**                                                        |
 
 > **Rule of thumb:** Use the **web UI** when you want to ask questions about a node. Use the **Obsidian panel** when you want to navigate to and edit a page.
 
@@ -2551,6 +2560,7 @@ You can explore the same knowledge graph without leaving Obsidian. Open the comm
 The panel shows all wiki pages as force-directed nodes coloured by cluster. Use the **type filter** dropdown to narrow to a specific knowledge type (concept, person, event…). If your wiki has more than 300 pages, the 300 most-connected are shown with an explanatory banner — use the type filter to narrow the view.
 
 **Interactions:**
+
 - **Hover** a node — tooltip shows title, slug, type, state, cluster, and connection count.
 - **Click** a node — opens the wiki page in the current pane; the node is highlighted gold.
 - **Drag** a node — re-pins it to a new position.
@@ -2675,14 +2685,15 @@ synthadoc ingest --file sessions.txt -w my-wiki
 
 ### Limitations and tips
 
-| Concern | Detail |
-|---------|--------|
-| **Long sessions** | Very long sessions are truncated at `max_source_chars` (default 400 000 chars). Raise the limit with `--max-source-chars 800000` for very active sessions. |
-| **Tool output excluded** | Shell output and file reads are stripped from the wiki page. Re-ingest the original source files separately if you need the file contents indexed. |
-| **Re-ingest is safe** | Synthadoc deduplicates by source hash — re-ingesting the same `.jsonl` file will update the existing page rather than create a duplicate. |
-| **Codex / Cursor sessions** | The same command works for Codex and Cursor `.jsonl` exports — format is detected automatically. |
-| **Private content** | Session files may contain proprietary code. Keep your wiki on a local or private server and review what the page contains before sharing. |
-| **Sanitization** | Extracted turns pass through the standard pre-LLM source sanitizer (zero-width chars, bidi overrides, HTML comments, instruction-override phrases) — the same step applied to every PDF, URL, and DOCX source. |
+
+| Concern                      | Detail                                                                                                                                                                                                             |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Long sessions**            | Very long sessions are truncated at`max_source_chars` (default 400 000 chars). Raise the limit with `--max-source-chars 800000` for very active sessions.                                                          |
+| **Tool output excluded**     | Shell output and file reads are stripped from the wiki page. Re-ingest the original source files separately if you need the file contents indexed.                                                                 |
+| **Re-ingest is safe**        | Synthadoc deduplicates by source hash — re-ingesting the same`.jsonl` file will update the existing page rather than create a duplicate.                                                                          |
+| **Codex / Cursor sessions**  | The same command works for Codex and Cursor`.jsonl` exports — format is detected automatically.                                                                                                                   |
+| **Private content**          | Session files may contain proprietary code. Keep your wiki on a local or private server and review what the page contains before sharing.                                                                          |
+| **Sanitization**             | Extracted turns pass through the standard pre-LLM source sanitizer (zero-width chars, bidi overrides, HTML comments, instruction-override phrases) — the same step applied to every PDF, URL, and DOCX source.    |
 | **Obsidian plugin / web UI** | Neither the Obsidian plugin nor the web UI can ingest session files directly — they do not send local filesystem paths outside the wiki root. Use the CLI (`synthadoc ingest <path>`) for session file ingestion. |
 
 ---
@@ -2696,14 +2707,15 @@ The web chat UI (and the Obsidian plugin query modal) can drive wiki maintenance
 
 Six workflows are available:
 
-| Workflow | Example phrase | Scope |
-|----------|---------------|-------|
-| **Stale-pages bulk reingest** | "re-ingest stale pages" | Finds every stale page, re-ingests each one in sequence, then runs lint |
-| **Page-by-slug reingest** | "re-ingest the alan-turing page" | Re-ingests one named page regardless of state (active, draft, or stale), then runs lint |
-| **Broken wikilinks scan and fix** | "scan for broken wikilinks" | Scans all active pages for `[[slug]]` references that resolve to no existing page; suggests corrections and fixes them after confirmation |
-| **Lint run and full report** | "run lint" | Runs a full lint pass, waits for it to complete, then surfaces the complete report in a single conversational turn |
-| **Scaffold and report** | "run scaffold" | Previews the domain and files to overwrite, asks for confirmation, then regenerates `index.md`, `purpose.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` |
-| **Contradiction resolver** | "run contradiction resolver" | For each contradicted page: reads content and sources, proposes a rewrite, shows the full diff, applies after approval, re-lints the page, and promotes it to *active* if it passes |
+
+| Workflow                          | Example phrase                   | Scope                                                                                                                                                                              |
+| --------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Stale-pages bulk reingest**     | "re-ingest stale pages"          | Finds every stale page, re-ingests each one in sequence, then runs lint                                                                                                            |
+| **Page-by-slug reingest**         | "re-ingest the alan-turing page" | Re-ingests one named page regardless of state (active, draft, or stale), then runs lint                                                                                            |
+| **Broken wikilinks scan and fix** | "scan for broken wikilinks"      | Scans all active pages for`[[slug]]` references that resolve to no existing page; suggests corrections and fixes them after confirmation                                           |
+| **Lint run and full report**      | "run lint"                       | Runs a full lint pass, waits for it to complete, then surfaces the complete report in a single conversational turn                                                                 |
+| **Scaffold and report**           | "run scaffold"                   | Previews the domain and files to overwrite, asks for confirmation, then regenerates`index.md`, `purpose.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`                             |
+| **Contradiction resolver**        | "run contradiction resolver"     | For each contradicted page: reads content and sources, proposes a rewrite, shows the full diff, applies after approval, re-lints the page, and promotes it to*active* if it passes |
 
 ### Demo — re-ingest all stale pages
 
@@ -2777,10 +2789,11 @@ When done, the workflow writes a plain-text summary showing the re-ingest outcom
 
 In the web UI **Graph tab**, click any node to open the node detail panel. A **Maintenance** section appears at the bottom of the panel with two chips:
 
-| Chip | What happens |
-|------|-------------|
-| **⚑ Check this page for issues** | Sends "Check the [slug] page for issues" to the chat |
-| **↻ Re-ingest this page** | Sends "Re-ingest the [slug] page" to the chat, triggering a page-by-slug reingest |
+
+| Chip                              | What happens                                                                      |
+| --------------------------------- | --------------------------------------------------------------------------------- |
+| **⚑ Check this page for issues** | Sends "Check the [slug] page for issues" to the chat                              |
+| **↻ Re-ingest this page**        | Sends "Re-ingest the [slug] page" to the chat, triggering a page-by-slug reingest |
 
 Clicking either chip routes the request through the normal confirmation flow — the agent confirms before doing anything.
 
@@ -2790,11 +2803,12 @@ Clicking either chip routes the request through the normal confirmation flow —
 
 Open these three files in Obsidian (Edit view or any text editor) and convert the bare slug references to wikilinks, then save each file:
 
-| File | Change |
-|------|--------|
-| `wiki/eniac.md` | Change `john-mauchly` to `[[john-mauchly]]` in the Designers section |
-| `wiki/history-of-computing.md` | Change `ada-lovelace` to `[[ada-lovelace]]` in the 1843 milestone entry |
-| `wiki/grace-hopper.md` | Change `harvard-mark-i` to `[[harvard-mark-i]]` in the first paragraph |
+
+| File                           | Change                                                                 |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `wiki/eniac.md`                | Change`john-mauchly` to `[[john-mauchly]]` in the Designers section    |
+| `wiki/history-of-computing.md` | Change`ada-lovelace` to `[[ada-lovelace]]` in the 1843 milestone entry |
+| `wiki/grace-hopper.md`         | Change`harvard-mark-i` to `[[harvard-mark-i]]` in the first paragraph  |
 
 None of these slugs have a corresponding `.md` page in the wiki — `john-mauchly`, `ada-lovelace`, and `harvard-mark-i` are referenced but uncompiled, making them broken wikilinks.
 
@@ -2834,7 +2848,7 @@ Open the web chat UI. You have three entry points:
 - **Pre-filled suggestion:** After any response that mentions contradicted pages, a pre-filled prompt appears below the reply — click it directly:
 
   > *1 page marked contradicted — run the contradiction resolver to fix them interactively?*
-
+  >
 - **Free text:** Type **"run contradiction resolver"** at any time.
 
 **Step 1 — Cost estimate and approval**
@@ -2987,6 +3001,7 @@ Scaffold running... (8s)
 ```
 
 The final report shows:
+
 - Domain scaffolded
 - Files written
 - Number of pages updated with category labels (`categories_updated`)
@@ -3005,13 +3020,14 @@ Each workflow runs as an agentic tool-call loop that streams inline progress aft
 
 **Key behaviours by workflow:**
 
-| Workflow | Confirmation | Key behaviour |
-|----------|-------------|---------------|
-| **Stale bulk** | ✓ required | Re-ingests pages one at a time; a single failure does not abort the run — remaining pages continue |
-| **By slug** | ✓ required | Force-re-ingests regardless of current lifecycle state |
-| **Broken wikilinks** | ✓ required (if any found) | If the wiki is already clean, the workflow stops after scanning — no card appears |
-| **Lint report** | none | Lint is read-only; runs and reports autonomously |
-| **Scaffold** | ✓ required | User-written content above `<!-- synthadoc:scaffold -->` markers is always preserved |
+
+| Workflow                   | Confirmation                       | Key behaviour                                                                                                             |
+| -------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Stale bulk**             | ✓ required                        | Re-ingests pages one at a time; a single failure does not abort the run — remaining pages continue                       |
+| **By slug**                | ✓ required                        | Force-re-ingests regardless of current lifecycle state                                                                    |
+| **Broken wikilinks**       | ✓ required (if any found)         | If the wiki is already clean, the workflow stops after scanning — no card appears                                        |
+| **Lint report**            | none                               | Lint is read-only; runs and reports autonomously                                                                          |
+| **Scaffold**               | ✓ required                        | User-written content above`<!-- synthadoc:scaffold -->` markers is always preserved                                       |
 | **Contradiction resolver** | ✓ required ×2 (cost + each diff) | Shows full diff before every write; re-lints only the changed page; promotes on pass or escalates after 3 failed attempts |
 
 For tool-level detail — per-workflow tool sets, SSE extensions (`tool_progress`, `confirm_request`, `done.pre_prompt`), routing architecture, loop constraints, pre-prompt mechanics, and audit trail — see [§35 Contradiction Resolver Workflow](design.md#35-contradiction-resolver-workflow) in the design doc.
@@ -3049,9 +3065,8 @@ To promote a page to active: `synthadoc lifecycle activate <slug>`
 
 After upgrading Synthadoc, sync your demo wikis to pick up new content:
 
-    synthadoc demo sync --force   # overwrite existing wiki pages from the latest template (picks up citation markers and other page updates)
-    synthadoc demo sync           # additive only — copies new raw_sources and new wiki pages; existing wiki pages are not overwritten
-
+synthadoc demo sync --force   # overwrite existing wiki pages from the latest template (picks up citation markers and other page updates)
+synthadoc demo sync           # additive only — copies new raw_sources and new wiki pages; existing wiki pages are not overwritten
 ---
 
 ## Uninstall a wiki
@@ -3067,7 +3082,6 @@ To uninstall:
 ```bash
 synthadoc uninstall history-of-computing
 ```
-
 The command asks for two confirmations — a yes/no prompt and then requires you to type the wiki name — before anything is deleted. This applies to both demo wikis and your own wikis.
 
 ---
@@ -3132,16 +3146,16 @@ All commands are accessible via the Command Palette (`Ctrl/Cmd+P` → type `Synt
 ### Wiki
 
 
-| Command                                   | What it does                                                                                                                   |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `Synthadoc: Wiki: regenerate scaffold...` | Rewrites `index.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `purpose.md` using the LLM. Polls job status live. All existing wiki pages are preserved. |
+| Command                                   | What it does                                                                                                                                             |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Synthadoc: Wiki: regenerate scaffold...` | Rewrites`index.md`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and `purpose.md` using the LLM. Polls job status live. All existing wiki pages are preserved. |
 
 ### Lifecycle
 
 
-| Command                            | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Synthadoc: Manage Page Lifecycle` | Two-tab modal. **Current States tab** — sortable, filterable, paginated table of all wiki pages with their current lifecycle state (`draft`, `active`, `contradicted`, `stale`, `archived`) and last transition timestamp. State filter checkboxes narrow the table. Click column headers to sort. Each row shows valid transition action buttons — click to trigger a transition; a reason dialog appears before committing. Draft and stale badge links on the lint modal and jobs panel open this table pre-filtered to that state. **Audit Log tab** — full history of every lifecycle state transition across all pages; searchable by slug, filterable by target state, sortable by any column, with pagination. Each row shows slug, From state, To state, triggered-by (`ingest`, `lint`, `cli`, `api`), timestamp, and reason. |
+| Command                            | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Synthadoc: Manage Page Lifecycle` | Two-tab modal.**Current States tab** — sortable, filterable, paginated table of all wiki pages with their current lifecycle state (`draft`, `active`, `contradicted`, `stale`, `archived`) and last transition timestamp. State filter checkboxes narrow the table. Click column headers to sort. Each row shows valid transition action buttons — click to trigger a transition; a reason dialog appears before committing. Draft and stale badge links on the lint modal and jobs panel open this table pre-filtered to that state. **Audit Log tab** — full history of every lifecycle state transition across all pages; searchable by slug, filterable by target state, sortable by any column, with pagination. Each row shows slug, From state, To state, triggered-by (`ingest`, `lint`, `cli`, `api`), timestamp, and reason. |
 
 ### Audit
 
@@ -3175,8 +3189,8 @@ All commands are accessible via the Command Palette (`Ctrl/Cmd+P` → type `Synt
 ### Export
 
 
-| Command                  | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Command                  | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Synthadoc: Export Wiki` | Modal with a format dropdown (`okf`, `json`, `llms.txt`, `llms-full.txt`, `graphml`), a full-width output path field pre-filled with today's date and the correct extension, and a status filter selector. A brief description at the top explains what each format contains. Click **Export** to write the file to your vault's `exports/` folder; the file opens automatically. For GraphML format, a **View Graph** button also appears for an inline Cytoscape.js preview — nodes are coloured by lifecycle state (active=green, draft=yellow, stale=orange, contradicted=red, archived=grey) and edges represent wikilinks. To load the graph in a dedicated tool, export to file and open in **yEd**, **Gephi**, or **Cytoscape**. |
 
 > **UX note:** All modals are draggable and support full text selection and copy-paste.
@@ -3204,20 +3218,17 @@ git init
 git add .
 git commit -m "init: initial wiki snapshot"
 ```
-
 **2. Copy the hook script:**
 
 ```bash
 cp /path/to/synthadoc-repo/hooks/git-auto-commit.py .
 ```
-
 **3. Add to `.synthadoc/config.toml`:**
 
 ```toml
 [hooks]
 on_ingest_complete = "python git-auto-commit.py"
 ```
-
 **4. Restart the server** to pick up the config change.
 
 ### Verify
@@ -3227,12 +3238,10 @@ After the next ingest:
 ```bash
 git log --oneline -3
 ```
-
 ```
 a3f1b2c wiki: ingest konrad-zuse-z3-computer.md → created konrad-zuse
 d9e4c81 wiki: ingest turing-enigma-decryption.pdf → updated alan-turing
 ```
-
 > **More hooks:** see [`hooks/README.md`](../hooks/README.md) for the full library and
 > contribution guidelines. Available events: `on_ingest_complete`, `on_lint_complete`.
 
@@ -3280,7 +3289,6 @@ default = { provider = "gemini",    model = "gemini-2.5-flash" }                
 # default = { provider = "claude-code" }                                             # Claude Code CLI (no API key)
 # default = { provider = "opencode", model = "opencode/big-pickle" }                # Opencode Zen (free; connect first: opencode → /connect → select Zen)
 ```
-
 Restart `synthadoc serve`. The startup banner confirms `LLM: <provider>/<model>`.
 
 > **Rate limit tips:**
@@ -3312,7 +3320,6 @@ set TAVILY_API_KEY=tvly-your-key-here
 # Windows (cmd.exe — permanent)
 setx TAVILY_API_KEY tvly-your-key-here
 ```
-
 If this key is absent, the server starts normally but web search jobs fail with
 `[ERR-SKILL-004]`. All other features work without it.
 
@@ -3333,7 +3340,6 @@ Settings are resolved in three layers — later layers win:
 2. ~/.synthadoc/config.toml   (global — your preferences across all wikis)
 3. <wiki-root>/.synthadoc/config.toml   (per-project — overrides for one wiki)
 ```
-
 Neither file is required. If both are absent, the built-in defaults take effect.
 
 ### Global config — `~/.synthadoc/config.toml`
@@ -3349,7 +3355,6 @@ lint    = { provider = "groq",   model = "llama-3.3-70b-versatile" }  # cheaper 
 research = "~/wikis/research"
 work     = "~/wikis/work"
 ```
-
 Common reason to edit: switching from the Anthropic default to Gemini Flash (free tier) so all wikis use it without touching each project config.
 
 ### Per-project config — `<wiki-root>/.synthadoc/config.toml`
@@ -3379,7 +3384,6 @@ max_results = 20
 [hooks]
 on_ingest_complete = "python git-auto-commit.py"
 ```
-
 Common reason to edit: each wiki needs its own port when running multiple wikis at the same time.
 
 Full config reference including all keys, defaults, and multi-wiki setup: [docs/design.md — Configuration](design.md#configuration).
@@ -3397,7 +3401,6 @@ synthadoc install my-research --target ~/wikis --domain "My research domain"
 synthadoc use my-research
 synthadoc status
 ```
-
 `--domain` is a free-text description of the subject area — the LLM uses it to generate
 domain-aware starter files: `wiki/index.md`, `wiki/purpose.md`, `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`.
 
@@ -3406,7 +3409,6 @@ domain-aware starter files: `wiki/index.md`, `wiki/purpose.md`, `AGENTS.md`, `CL
 ```bash
 synthadoc serve -w my-research
 ```
-
 ### 3. Scaffold
 
 Before ingesting any content, run scaffold once to build a clean, domain-aware index:
@@ -3414,7 +3416,6 @@ Before ingesting any content, run scaffold once to build a clean, domain-aware i
 ```bash
 synthadoc scaffold
 ```
-
 ### 4. Ingest sources
 
 ```bash
@@ -3423,20 +3424,17 @@ synthadoc ingest "https://example.com/article"
 synthadoc ingest "search for: <your domain topic>"
 synthadoc jobs list
 ```
-
 ### 5. Query
 
 ```bash
 synthadoc query "What are the key themes?"
 ```
-
 ### 6. Lint
 
 ```bash
 synthadoc lint report
 synthadoc lint run --auto-resolve
 ```
-
 ### 7. Open in Obsidian
 
 Open `~/wikis/my-research` as an Obsidian vault.
@@ -3449,7 +3447,6 @@ synthadoc status               # checks finance-wiki
 synthadoc status -w legal-wiki # one-off check without switching
 synthadoc use                  # confirm which wiki is active
 ```
-
 
 | Method                         | Scope                               |
 | ------------------------------ | ----------------------------------- |
@@ -3472,7 +3469,6 @@ Open `.synthadoc/config.toml` in your wiki root, comment out the active `default
 # default = { provider = "claude-code" }                                       # no API key — uses your Claude Code subscription
 # default = { provider = "opencode", model = "opencode/big-pickle" }          # free via Opencode Zen — connect first: opencode → /connect → select Zen
 ```
-
 For Claude Code, `model` is optional — omit it to use Claude Code's own configured default. For Opencode, specify `model = "opencode/big-pickle"` to use the free Zen tier. Restart the server after saving.
 
 Ensure the tool is installed and authenticated in your terminal before starting the server. No environment variables are required.
@@ -3492,7 +3488,6 @@ synthadoc serve -w my-wiki
 synthadoc ingest "https://example.com/article" -w my-wiki
 synthadoc query "What does the article cover?" -w my-wiki
 ```
-
 The output is identical to a direct API provider. The only difference is that each LLM call is handled by Claude Code or Opencode running as a subprocess.
 
 > **Performance note:** CLI providers add subprocess startup overhead per LLM call. For high-volume batch ingest, a direct API provider (`anthropic`, `gemini`, etc.) is faster.
@@ -3504,7 +3499,6 @@ If your coding tool quota is exhausted and you need to continue ingesting, overr
 ```bash
 synthadoc serve -w my-wiki --provider anthropic
 ```
-
 This uses `ANTHROPIC_API_KEY` (or whichever provider you specify) for that session only. When quota resets, restart without `--provider` to return to the CLI provider.
 
 ### Troubleshooting
@@ -3576,10 +3570,11 @@ Synthadoc exposes an MCP server so Claude Desktop, Claude Code, or any MCP-compa
 
 ### Transport options
 
-| | Claude Desktop | Claude Code CLI | Custom agents (n8n, LangGraph…) |
-|---|---|---|---|
-| **stdio** (`--mcp-only`) | Yes — only option | Yes | No |
-| **HTTP/SSE** (`url`) | No — not supported | Yes | Yes |
+
+|                          | Claude Desktop      | Claude Code CLI | Custom agents (n8n, LangGraph…) |
+| ------------------------ | ------------------- | --------------- | -------------------------------- |
+| **stdio** (`--mcp-only`) | Yes — only option  | Yes             | No                               |
+| **HTTP/SSE** (`url`)     | No — not supported | Yes             | Yes                              |
 
 Claude Desktop only supports stdio — it spawns Synthadoc as a subprocess and manages the process lifecycle. HTTP/SSE is available for Claude Code and any custom MCP client.
 
@@ -3618,14 +3613,12 @@ Register each wiki as a separate entry. Synthadoc prefixes every tool descriptio
   }
 }
 ```
-
 **Claude Code / custom agents (HTTP/SSE):**
 
 ```powershell
 synthadoc serve -w "C:\wikis\history-of-computing"   # port 7070
 synthadoc serve -w "C:\wikis\ai-research"             # port 7071
 ```
-
 ```json
 {
   "mcpServers": {
@@ -3634,7 +3627,6 @@ synthadoc serve -w "C:\wikis\ai-research"             # port 7071
   }
 }
 ```
-
 ---
 
 ### Claude Desktop
@@ -3648,7 +3640,6 @@ Claude Desktop uses a restricted PATH and will not find `synthadoc` by name alon
 ```powershell
 (Get-Command synthadoc).Source
 ```
-
 Typical result on Windows: `C:\Users\<you>\AppData\Roaming\Python\Python314\Scripts\synthadoc.exe`
 
 **Step 2 — Add the config entry**
@@ -3663,7 +3654,6 @@ Typical result on Windows: `C:\Users\<you>\AppData\Roaming\Python\Python314\Scri
   }
 }
 ```
-
 Use **absolute paths** for both `synthadoc.exe` and the wiki root. Relative paths and wiki name aliases do not work from Claude Desktop. Key names must use underscores, not hyphens — Claude Desktop rejects hyphenated server names.
 
 **Step 3 — Restart Claude Desktop**
@@ -3683,13 +3673,11 @@ Claude Code supports both SSE (recommended — connects to a running server) and
 ```powershell
 synthadoc serve -w "C:\Users\<you>\wikis\history-of-computing"
 ```
-
 **Step 2 — Register the MCP server**
 
 ```powershell
 claude mcp add --transport sse synthadoc-history-of-computing http://127.0.0.1:7070/mcp/sse
 ```
-
 > Use `--transport sse`, not `--transport http` — FastMCP uses the SSE protocol, not Streamable HTTP.
 
 **Step 3 — Verify**
@@ -3697,7 +3685,6 @@ claude mcp add --transport sse synthadoc-history-of-computing http://127.0.0.1:7
 ```powershell
 claude mcp list
 ```
-
 `synthadoc-history-of-computing` should show `✔ Connected`.
 
 **Step 4 — Test in a Claude Code session**
@@ -3705,7 +3692,6 @@ claude mcp list
 ```powershell
 claude
 ```
-
 Ask: `What's the status of my wiki?` — Claude Code calls `synthadoc_status` directly against the running server.
 
 #### stdio transport
@@ -3715,7 +3701,6 @@ Use this if you don't want to manage a separate server process:
 ```powershell
 claude mcp add synthadoc-history-of-computing "C:\Users\<you>\...\synthadoc.exe" -- serve -w "C:\Users\<you>\wikis\history-of-computing" --mcp-only
 ```
-
 ---
 
 ### HTTP/SSE (n8n, LangGraph, custom agents)
@@ -3725,13 +3710,11 @@ The same endpoint works for any MCP-compatible client:
 ```
 MCP SSE endpoint: http://127.0.0.1:7070/mcp/sse
 ```
-
 No API key required. Verify it is live:
 
 ```
 curl -i http://127.0.0.1:7070/mcp/sse
 ```
-
 You should receive `HTTP/1.1 200 OK` with `content-type: text/event-stream` and the connection will hang open (correct — SSE streams stay open).
 
 ---
@@ -3740,36 +3723,39 @@ You should receive `HTTP/1.1 200 OK` with `content-type: text/event-stream` and 
 
 **Wiki content questions** — Claude fetches raw content and synthesises the answer itself (no LLM call on the Synthadoc side):
 
-| Example prompt | Tool used |
-|---|---|
-| "What's the status of my wiki?" | `synthadoc_status` |
-| "List all pages in the wiki" | `synthadoc_list_pages` |
-| "Show me only the active pages" | `synthadoc_list_pages` (status filter) |
-| "Search for Grace Hopper" | `synthadoc_search` |
-| "Read the grace-hopper page" | `synthadoc_read_page` |
-| "What does my wiki say about quantum error correction?" | `synthadoc_search` + `synthadoc_read_page` |
-| "Show me the adversarial warnings for the early-neural-networks page" | `synthadoc_read_page` |
-| "Which pages have citations? Show me what they are." | `synthadoc_list_pages` + `synthadoc_read_page` |
-| "Build me a context pack on early neural networks" | `synthadoc_context` |
-| "Export my wiki in OKF format" | `synthadoc_export` (okf — writes folder to default path, tells you where) |
-| "Export only active pages as llms.txt" | `synthadoc_export` (format + status_filter, returns content inline) |
+
+| Example prompt                                                        | Tool used                                                                  |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| "What's the status of my wiki?"                                       | `synthadoc_status`                                                         |
+| "List all pages in the wiki"                                          | `synthadoc_list_pages`                                                     |
+| "Show me only the active pages"                                       | `synthadoc_list_pages` (status filter)                                     |
+| "Search for Grace Hopper"                                             | `synthadoc_search`                                                         |
+| "Read the grace-hopper page"                                          | `synthadoc_read_page`                                                      |
+| "What does my wiki say about quantum error correction?"               | `synthadoc_search` + `synthadoc_read_page`                                 |
+| "Show me the adversarial warnings for the early-neural-networks page" | `synthadoc_read_page`                                                      |
+| "Which pages have citations? Show me what they are."                  | `synthadoc_list_pages` + `synthadoc_read_page`                             |
+| "Build me a context pack on early neural networks"                    | `synthadoc_context`                                                        |
+| "Export my wiki in OKF format"                                        | `synthadoc_export` (okf — writes folder to default path, tells you where) |
+| "Export only active pages as llms.txt"                                | `synthadoc_export` (format + status_filter, returns content inline)        |
 
 **Wiki health — zero cost, instant:**
 
-| Example prompt | Tool used |
-|---|---|
+
+| Example prompt                  | Tool used               |
+| ------------------------------- | ----------------------- |
 | "Which pages are contradicted?" | `synthadoc_lint_report` |
-| "Are there any orphan pages?" | `synthadoc_lint_report` |
+| "Are there any orphan pages?"   | `synthadoc_lint_report` |
 | "Give me a wiki health summary" | `synthadoc_lint_report` |
 
 **Synthadoc operations** — Claude manages the wiki on your behalf:
 
-| Example prompt | Tool used |
-|---|---|
-| "List recent jobs" | `synthadoc_jobs` |
-| "Show me any failed or skipped jobs" | `synthadoc_jobs` |
-| "Ingest this URL: https://example.com/paper" | `synthadoc_ingest` |
-| "Run a full lint check on the wiki" | `synthadoc_lint` |
+
+| Example prompt                                        | Tool used             |
+| ----------------------------------------------------- | --------------------- |
+| "List recent jobs"                                    | `synthadoc_jobs`      |
+| "Show me any failed or skipped jobs"                  | `synthadoc_jobs`      |
+| "Ingest this URL: https://example.com/paper"          | `synthadoc_ingest`    |
+| "Run a full lint check on the wiki"                   | `synthadoc_lint`      |
 | "Mark the grace-hopper page as stale — needs review" | `synthadoc_lifecycle` |
 
 ---
@@ -3800,15 +3786,15 @@ Conference (where "artificial intelligence" was coined), and the first AI winter
 computing-history-timeline — Traces from Ada Lovelace (1843) through Turing (1936), von Neumann
 architecture (1945), and includes tags for deep-learning milestones.
 ```
-
 **What the response tells you:**
 
-| Field | Meaning |
-|---|---|
-| `tokens_used / token_budget` | How much of the budget was consumed — pages stop being added once the budget is full |
-| `relevance` | BM25 score — higher means stronger keyword match to your goal |
-| `confidence` | LLM-assigned confidence in the page's coverage of the topic |
-| `omitted` | Pages that were relevant but didn't fit within the budget (none here — only 13% used) |
+
+| Field                        | Meaning                                                                                |
+| ---------------------------- | -------------------------------------------------------------------------------------- |
+| `tokens_used / token_budget` | How much of the budget was consumed — pages stop being added once the budget is full  |
+| `relevance`                  | BM25 score — higher means stronger keyword match to your goal                         |
+| `confidence`                 | LLM-assigned confidence in the page's coverage of the topic                            |
+| `omitted`                    | Pages that were relevant but didn't fit within the budget (none here — only 13% used) |
 
 To request a tighter pack (forces prioritisation and shows omitted pages clearly):
 
@@ -3820,26 +3806,28 @@ To request a tighter pack (forces prioritisation and shows omitted pages clearly
 
 **Claude** = Claude's LLM synthesises the answer (no Synthadoc LLM call). **Synthadoc** = Synthadoc's configured LLM provider runs (tokens billed to your provider account). **Neither** = pure data read or write, no LLM involved.
 
-| Tool | Parameters | What it does | Who calls LLM? |
-|---|---|---|---|
-| `synthadoc_search` | `terms: str` | BM25 keyword search — returns ranked titles, slugs, and snippets | Claude |
-| `synthadoc_read_page` | `slug: str` | Read a page's full content, status, type, tags, adversarial warnings, and source citations | Claude |
-| `synthadoc_list_pages` | `status?: str` (default `"all"`) | List all pages with title, status, type, and `has_sources` flag; filterable by lifecycle state | Neither |
-| `synthadoc_write_page` | `slug: str`, `content: str`, `title?: str` | Update page content (clears contradiction note, bumps epoch) | Neither |
-| `synthadoc_status` | *(none)* | Get wiki page count and path | Neither |
-| `synthadoc_jobs` | `status?: str` (`all`/`pending`/`running`/`completed`/`failed`/`skipped`/`cancelled`/`dead`) | List recent jobs, optionally filtered by status | Neither |
-| `synthadoc_lifecycle` | `slug: str`, `to_state: str`, `reason: str` | Transition a page's lifecycle state; writes an immutable audit record | Neither |
-| `synthadoc_lint_report` | *(none)* | Instant wiki health read — contradicted pages, orphans, adversarial warning counts; **no job, no LLM** | Neither |
-| `synthadoc_context` | `goal: str`, `token_budget?: int` (default `10000`) | Build a token-budgeted context pack — ranked excerpts that fit within the budget; omitted slugs listed separately | Neither |
-| `synthadoc_export` | `format?: str` (default `"okf"`), `output_path?: str` (okf defaults to `<wiki>/exports/<name>-okf-<date>/`), `status_filter?: str` (default `"all"`) | Export the wiki. okf writes a folder to disk and tells you where; other formats return content inline or to a file. Formats: `okf`, `llms.txt`, `llms-full.txt`, `json`, `graphml` | Neither |
-| `synthadoc_ingest` | `source: str` | Enqueue a URL or file for ingest — returns a job ID | Synthadoc |
-| `synthadoc_lint` | `scope?: str` (default `"all"`) | Enqueue a full LLM lint analysis — returns a job ID; use `synthadoc_jobs` to poll | Synthadoc |
+
+| Tool                    | Parameters                                                                                                                                           | What it does                                                                                                                                                                      | Who calls LLM? |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `synthadoc_search`      | `terms: str`                                                                                                                                         | BM25 keyword search — returns ranked titles, slugs, and snippets                                                                                                                 | Claude         |
+| `synthadoc_read_page`   | `slug: str`                                                                                                                                          | Read a page's full content, status, type, tags, adversarial warnings, and source citations                                                                                        | Claude         |
+| `synthadoc_list_pages`  | `status?: str` (default `"all"`)                                                                                                                     | List all pages with title, status, type, and`has_sources` flag; filterable by lifecycle state                                                                                     | Neither        |
+| `synthadoc_write_page`  | `slug: str`, `content: str`, `title?: str`                                                                                                           | Update page content (clears contradiction note, bumps epoch)                                                                                                                      | Neither        |
+| `synthadoc_status`      | *(none)*                                                                                                                                             | Get wiki page count and path                                                                                                                                                      | Neither        |
+| `synthadoc_jobs`        | `status?: str` (`all`/`pending`/`running`/`completed`/`failed`/`skipped`/`cancelled`/`dead`)                                                         | List recent jobs, optionally filtered by status                                                                                                                                   | Neither        |
+| `synthadoc_lifecycle`   | `slug: str`, `to_state: str`, `reason: str`                                                                                                          | Transition a page's lifecycle state; writes an immutable audit record                                                                                                             | Neither        |
+| `synthadoc_lint_report` | *(none)*                                                                                                                                             | Instant wiki health read — contradicted pages, orphans, adversarial warning counts;**no job, no LLM**                                                                            | Neither        |
+| `synthadoc_context`     | `goal: str`, `token_budget?: int` (default `10000`)                                                                                                  | Build a token-budgeted context pack — ranked excerpts that fit within the budget; omitted slugs listed separately                                                                | Neither        |
+| `synthadoc_export`      | `format?: str` (default `"okf"`), `output_path?: str` (okf defaults to `<wiki>/exports/<name>-okf-<date>/`), `status_filter?: str` (default `"all"`) | Export the wiki. okf writes a folder to disk and tells you where; other formats return content inline or to a file. Formats:`okf`, `llms.txt`, `llms-full.txt`, `json`, `graphml` | Neither        |
+| `synthadoc_ingest`      | `source: str`                                                                                                                                        | Enqueue a URL or file for ingest — returns a job ID                                                                                                                              | Synthadoc      |
+| `synthadoc_lint`        | `scope?: str` (default `"all"`)                                                                                                                      | Enqueue a full LLM lint analysis — returns a job ID; use`synthadoc_jobs` to poll                                                                                                 | Synthadoc      |
 
 Valid `to_state` values for `synthadoc_lifecycle`: `active`, `draft`, `stale`, `contradicted`, `archived`.
 
 > **lint vs. lint_report:** Use `synthadoc_lint_report` to check current wiki health instantly (no tokens spent). Use `synthadoc_lint` when you want to run fresh LLM analysis — it enqueues a background job and returns a job ID.
 
 > **Tuning the context budget:** `synthadoc_context` defaults to 10 000 tokens per pack. Pass `token_budget` in the tool call to override for a single request (e.g. `token_budget: 20000`). To change the project-wide default, add this to `.synthadoc/config.toml`:
+>
 > ```toml
 > [query]
 > context_token_budget = 20000
@@ -3852,15 +3840,18 @@ For architecture details and the brain/memory use case framing, see [docs/design
 ### Troubleshooting
 
 **Server does not appear in the panel**
+
 - Use the full path to `synthadoc.exe`, not the bare command name
 - Use absolute paths for the wiki root — aliases and relative paths are not resolved by Claude Desktop
 - Fully quit Claude Desktop from the system tray before reopening (window close is not a full restart)
 
 **Server appears but shows an error badge**
+
 - Click **View Logs** in the Developer panel to see the startup error
 - Verify the wiki path exists and contains a `.synthadoc/` directory (run `synthadoc serve -w <path> --mcp-only` manually to confirm it starts)
 
 **SSE endpoint returns 404**
+
 - The correct URL is `/mcp/sse`, not `/mcp` or `/mcp/`
 - Verify the server is running with `curl -i http://127.0.0.1:7070/`
 
@@ -3872,70 +3863,71 @@ For architecture details and the brain/memory use case framing, see [docs/design
 
 ### When to use it
 
-| Scenario | Command |
-|---|---|
-| Move wiki to another machine | `backup` on old machine, `restore` on new |
-| Snapshot before a risky operation (routing clean, adversarial lint) | `backup` before running the operation |
-| Development workflow: freeze a good state, do risky dev, restore if needed | `backup` → dev work → `restore` |
-| CI/test fixture: start from a known state before each run | `restore` at test start |
-| Share an exact wiki state with a colleague | Send the zip, they run `restore` |
+
+| Scenario                                                                   | Command                                   |
+| -------------------------------------------------------------------------- | ----------------------------------------- |
+| Move wiki to another machine                                               | `backup` on old machine, `restore` on new |
+| Snapshot before a risky operation (routing clean, adversarial lint)        | `backup` before running the operation     |
+| Development workflow: freeze a good state, do risky dev, restore if needed | `backup` → dev work → `restore`         |
+| CI/test fixture: start from a known state before each run                  | `restore` at test start                   |
+| Share an exact wiki state with a colleague                                 | Send the zip, they run`restore`           |
 
 ### Backup
 
 ```
 synthadoc backup -w <wiki>
 ```
-
 Creates a timestamped compressed zip in the current directory:
+
 ```
 synthadoc-backup-history-of-computing-20260624-103000.zip
 ```
-
 **What's included by default:** wiki pages, candidates, config, audit database, exports, query cache, raw sources, and root-level wiki files (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `ROUTING.md`, `log.md`, and any `*.txt` batch ingest files) when present.
 
 **Flags:**
+
 ```
 --output <dir>       Write zip to this directory (default: current directory)
 --no-sources         Exclude raw_sources/ (reduces size for large crawled wikis)
 --no-exports         Exclude exports/ directory
 --no-cache           Exclude cache.db
 ```
-
 ### Restore
 
 ```
 synthadoc restore <backup.zip>
 ```
-
 Restores to the same directory as the zip file by default. Detects port conflicts and suggests the next free port.
 
 **Flags:**
+
 ```
 --name <name>        Restore under a different wiki name
 --target <dir>       Parent directory for the restored wiki (default: zip's folder)
 --port <N>           Use this port (skips interactive prompt)
 ```
-
 **Post-restore checklist (printed automatically):**
+
 1. Set your LLM API key in your environment
 2. `synthadoc serve -w <wiki-name>`
 3. Open the vault in Obsidian — the Obsidian plugin is reinstalled and pre-enabled automatically; Server URL is updated to match the restored port, no manual steps needed
 
 ### What is and isn't backed up
 
-| Item | Included? | Notes |
-|---|---|---|
-| `wiki/*.md` | ✓ Always | All compiled wiki pages |
-| `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `ROUTING.md`, `log.md` | ✓ Always | Wiki root files |
-| `hooks/` | ✓ Always | User hook scripts |
-| `.synthadoc/config.toml` | ✓ Always | Server config |
-| `.synthadoc/audit.db` | ✓ Always | Full audit trail, lifecycle state, chat history |
-| `.synthadoc/extracted/` | ✓ Always | Text sidecars + PDF pagemaps — required by Source Viewer and Provenance modal |
-| `.synthadoc/cache.db` | ✓ Default | Skip with `--no-cache` |
-| `exports/` | ✓ Default | Skip with `--no-exports` |
-| `raw_sources/` | ✓ Default | Skip with `--no-sources` to reduce zip size |
-| LLM API keys | ✗ Never | Never stored in config; set via environment variable |
-| `jobs.db` | ✗ Never | Stale job queue; job *history* is in `audit.db` |
-| `embeddings.db` | ✗ Never | Rebuilt automatically on next server start |
-| `server.pid` | ✗ Never | Machine-specific process ID |
-| `logs/` | ✗ Never | Server application logs |
+
+| Item                                                          | Included?  | Notes                                                                          |
+| ------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------ |
+| `wiki/*.md`                                                   | ✓ Always  | All compiled wiki pages                                                        |
+| `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `ROUTING.md`, `log.md` | ✓ Always  | Wiki root files                                                                |
+| `hooks/`                                                      | ✓ Always  | User hook scripts                                                              |
+| `.synthadoc/config.toml`                                      | ✓ Always  | Server config                                                                  |
+| `.synthadoc/audit.db`                                         | ✓ Always  | Full audit trail, lifecycle state, chat history                                |
+| `.synthadoc/extracted/`                                       | ✓ Always  | Text sidecars + PDF pagemaps — required by Source Viewer and Provenance modal |
+| `.synthadoc/cache.db`                                         | ✓ Default | Skip with`--no-cache`                                                          |
+| `exports/`                                                    | ✓ Default | Skip with`--no-exports`                                                        |
+| `raw_sources/`                                                | ✓ Default | Skip with`--no-sources` to reduce zip size                                     |
+| LLM API keys                                                  | ✗ Never   | Never stored in config; set via environment variable                           |
+| `jobs.db`                                                     | ✗ Never   | Stale job queue; job*history* is in `audit.db`                                 |
+| `embeddings.db`                                               | ✗ Never   | Rebuilt automatically on next server start                                     |
+| `server.pid`                                                  | ✗ Never   | Machine-specific process ID                                                    |
+| `logs/`                                                       | ✗ Never   | Server application logs                                                        |

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -898,7 +898,7 @@ Contradicted pages (1) - need review:
 
   grace-hopper
     -> Open wiki/grace-hopper.md, resolve the conflict, then set status: active
-    -> Or run: synthadoc workflow run contradiction-resolver
+    -> Or run: synthadoc workflow run --name contradiction-resolver
 ```
 
 **In Obsidian:** open `wiki/dashboard.md` — `grace-hopper` appears in the
@@ -958,16 +958,16 @@ The resolver will:
 
 ```bash
 # Resolve all contradicted pages
-synthadoc workflow run contradiction-resolver
+synthadoc workflow run --name contradiction-resolver
 
 # Resolve only the grace-hopper page
-synthadoc workflow run contradiction-resolver --slug grace-hopper
+synthadoc workflow run --name contradiction-resolver --slug grace-hopper
 
 # Resolve only adversarial-gate demotions
-synthadoc workflow run contradiction-resolver --type adversarial
+synthadoc workflow run --name contradiction-resolver --type adversarial
 
 # Resolve only source-conflict demotions
-synthadoc workflow run contradiction-resolver --type source-conflict
+synthadoc workflow run --name contradiction-resolver --type source-conflict
 ```
 
 The CLI renders the same approval prompts and diff previews as the web UI.
@@ -2903,10 +2903,10 @@ The contradicted count reaches zero — no further action needed.
 **Scoping the resolver**
 
 ```bash
-synthadoc workflow run contradiction-resolver                           # all contradicted pages
-synthadoc workflow run contradiction-resolver --slug grace-hopper       # one page
-synthadoc workflow run contradiction-resolver --type adversarial        # adversarial-gate demotions only
-synthadoc workflow run contradiction-resolver --type source-conflict    # source-conflict demotions only
+synthadoc workflow run --name contradiction-resolver                             # all contradicted pages
+synthadoc workflow run --name contradiction-resolver --slug grace-hopper         # one page
+synthadoc workflow run --name contradiction-resolver --type adversarial          # adversarial-gate demotions only
+synthadoc workflow run --name contradiction-resolver --type source-conflict      # source-conflict demotions only
 ```
 
 ---

--- a/obsidian-plugin/manifest.json
+++ b/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "synthadoc",
   "name": "Synthadoc",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "minAppVersion": "1.4.0",
   "description": "Connect your Obsidian vault to synthadoc.",
   "author": "synthadoc",

--- a/obsidian-plugin/package.json
+++ b/obsidian-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synthadoc-obsidian",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "scripts": {
     "build": "node esbuild.config.mjs production",
     "dev": "node esbuild.config.mjs",

--- a/synthadoc/agents/workflows/_base.py
+++ b/synthadoc/agents/workflows/_base.py
@@ -41,6 +41,16 @@ class AgenticWorkflow(ABC):
 
     MATCH_RE: re.Pattern | None = None
 
+    # Set on subclasses that register with the CLI registry.
+    # ``NAME`` is the ``--name`` value for ``synthadoc workflow run``.
+    # ``DESCRIPTION`` is shown by ``synthadoc workflow list``.
+    # ``CLI_ARGS`` is a compact one-line summary of workflow-specific extra
+    # arguments forwarded after ``--name NAME`` (e.g. ``[--slug SLUG]``).
+    # Leave None for workflows that take no extra arguments.
+    NAME: str | None = None
+    DESCRIPTION: str | None = None
+    CLI_ARGS: str | None = None
+
     @abstractmethod
     async def build_system_prompt(self) -> str:
         """Return the system prompt for the LLM."""

--- a/synthadoc/agents/workflows/_registry.py
+++ b/synthadoc/agents/workflows/_registry.py
@@ -5,11 +5,14 @@
 To add a new workflow with fast-path routing:
   1. Implement AgenticWorkflow in a new module under synthadoc/agents/workflows/.
   2. Set MATCH_RE = re.compile(r"...", re.IGNORECASE) on the class.
-  3. Add one import line and one entry in ROUTED_WORKFLOWS below.
+  3. Set NAME and DESCRIPTION on the class to expose it via the CLI.
+  4. Add one import line and one entry in ROUTED_WORKFLOWS below.
 
 No other file needs to change.  ActionAgent reads ROUTED_WORKFLOWS at startup,
 derives _ACTION_RE coverage automatically from each workflow's MATCH_RE, and
 routes directly to the first matching workflow — no LLM extraction required.
+CLI_REGISTRY is derived automatically from ROUTED_WORKFLOWS.NAME entries and
+drives ``synthadoc workflow list`` and ``synthadoc workflow run --name``.
 """
 from __future__ import annotations
 
@@ -26,6 +29,14 @@ ROUTED_WORKFLOWS: list[type[AgenticWorkflow]] = [
     LintReportWorkflow,
     BrokenWikilinksWorkflow,
     ScaffoldWorkflow,
-    ContradictionResolverWorkflow,   # NEW — more specific than IngestLintWorkflow
+    ContradictionResolverWorkflow,   # more specific than IngestLintWorkflow
     IngestLintWorkflow,
 ]
+
+# Workflows available via ``synthadoc workflow run --name <name>``.
+# Populated automatically from ROUTED_WORKFLOWS entries that have NAME set.
+CLI_REGISTRY: dict[str, type[AgenticWorkflow]] = {
+    wf.NAME: wf
+    for wf in ROUTED_WORKFLOWS
+    if wf.NAME is not None
+}

--- a/synthadoc/agents/workflows/broken_wikilinks.py
+++ b/synthadoc/agents/workflows/broken_wikilinks.py
@@ -114,6 +114,9 @@ When you have no more tool calls to make, produce a plain-text summary (no JSON)
 class BrokenWikilinksWorkflow(AgenticWorkflow):
     """Scan active wiki pages for broken [[wikilinks]] and fix them interactively."""
 
+    NAME = "broken-wikilinks"
+    DESCRIPTION = "Scan all pages for broken [[wikilinks]] and fix them interactively."
+
     MATCH_RE = re.compile(
         r"\bbroken\b.{0,40}\b(?:wiki\s*links?|links?)\b"
         r"|\b(?:wiki\s*links?|links?)\b.{0,40}\bbroken\b"

--- a/synthadoc/agents/workflows/contradiction_resolver.py
+++ b/synthadoc/agents/workflows/contradiction_resolver.py
@@ -44,7 +44,10 @@ marked 'contradicted'. A contradicted page may be:
   • Source-conflict: ingest detected that a new source contradicts the existing content.
     Signal: contradiction_note frontmatter field.
   • Both: both signals present.
-  • Unknown: contradicted state with no clear signal — skip with a plain-text note.
+  • Unknown: contradicted state with no lint_warnings and no contradiction_note —
+    run a fresh lint to determine whether the contradicted state is stale metadata
+    (lint passes → auto-transition to active) or a real issue (lint fails → treat
+    as gate-demoted with the fresh warnings).
 
 ━━━ TOOL-CALL WIRE FORMAT ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Emit EXACTLY this JSON object (no markdown fences, no XML, no prose) to call a tool:
@@ -102,7 +105,17 @@ STEP 4 — Per-page resolution loop
   For each page from step 1:
 
     4a. Detect type (gate / conflict / both / unknown from tool result).
-        Unknown → skip, note in final summary.
+
+        Unknown — status is contradicted but no lint_warnings and no contradiction_note:
+          i.  Call tool_run_scoped_lint(slug) to get a fresh lint result.
+          ii. If lint PASS → the contradicted state is stale metadata; transition:
+                call tool_transition_lifecycle_state(slug, to_state="active",
+                  reason="resolved: clean lint with no contradiction signals — contradicted state was stale")
+              Add slug to the "fixed" list and continue to step 4j.
+          iii.If lint FAIL → the page has real issues; treat as gate-demoted using
+              the fresh lint_warnings from this lint result and proceed from step 4c
+              with Strategy 1.
+          Do NOT skip unknown pages without first running tool_run_scoped_lint.
 
     4b. Read page: call tool_read_page_content(slug).
         If conflict or both: also call tool_read_source_content(slug).

--- a/synthadoc/agents/workflows/contradiction_resolver.py
+++ b/synthadoc/agents/workflows/contradiction_resolver.py
@@ -133,12 +133,26 @@ STEP 4 — Per-page resolution loop
         continue to step 4j (next page) or step 5 (final summary) if last page.
         Do NOT output any plain text here — text output ends the entire workflow.
 
-    4h. If lint FAIL (attempt < 3): diagnose why, select a DIFFERENT strategy:
-          Attempt 2: if source is missing/outdated → Strategy 2 (web ingest) or
-                     Strategy 3 (force re-ingest); otherwise Strategy 1 with a
-                     different rewrite angle.
-          Attempt 3: Strategy 4 (cross-page) if applicable, otherwise another
-                     Strategy 1 variant with explicit hedging language.
+    4h. If lint FAIL (attempt < 3): diagnose the failure, then escalate to the next
+        strategy — NEVER use Strategy 1 again after the first attempt fails.
+
+          Attempt 2 — always Strategy 2 or 3 (never Strategy 1):
+            • Strategy 2 (Web ingest) — search for current authoritative sources
+              to support, replace, or provide grounding for the disputed claims.
+              Use this for gate-demoted pages (lint_warnings) where the claims
+              need better citation, and for source-conflict pages where a newer
+              web source may supersede the contradiction.
+            • Strategy 3 (Force re-ingest) — force-reingest the page's source_path
+              if source_path is available and the source itself may have updated.
+            Choose whichever fits the failure diagnosis; prefer Strategy 2 for
+            gate-demoted pages, Strategy 3 for source-conflict pages.
+
+          Attempt 3 — must be a strategy not yet tried:
+            • Strategy 4 (Cross-page resolution) — if linked wiki pages contain
+              information that can resolve or corroborate the disputed content.
+            • The other of Strategy 2 / Strategy 3 if it wasn't used in attempt 2.
+            Never return to Strategy 1.
+
         Repeat from 4c.
 
     4i. If cap reached (3 failed attempts): Strategy 5 — Escalate.
@@ -171,7 +185,9 @@ STEP 6 — Ground-truth confirmation
 • ALWAYS call tool_transition_lifecycle_state AS A TOOL CALL (not in text) when scoped lint passes.
   This call MUST happen before any plain-text output — even a one-line summary ends the workflow.
 • NEVER transition to active before scoped lint passes.
-• NEVER repeat the same strategy on the same page.
+• NEVER use Strategy 1 more than once per page. After Strategy 1 fails, always
+  escalate to Strategy 2, 3, or 4 — never return to Strategy 1 with "a different
+  angle". A different angle is still Strategy 1 and is still forbidden.
 • Cap is HARD at 3 attempts per page — escalate on the 4th failure.
 • Do NOT call tool_propose_and_apply and tool_confirm in the same tool-call batch.
 """

--- a/synthadoc/agents/workflows/contradiction_resolver.py
+++ b/synthadoc/agents/workflows/contradiction_resolver.py
@@ -180,6 +180,10 @@ STEP 6 — Ground-truth confirmation
 class ContradictionResolverWorkflow(AgenticWorkflow):
     """Closed-loop agentic remediation for contradicted wiki pages."""
 
+    NAME = "contradiction-resolver"
+    DESCRIPTION = "Interactively resolve pages in 'contradicted' state (diff-before-write approval)."
+    CLI_ARGS = "[--slug SLUG]  [--type adversarial|source-conflict]"
+
     MATCH_RE: re.Pattern = re.compile(
         r"\bcontradiction.{0,30}\bresolv"
         r"|\bresolv.{0,30}\bcontradict"
@@ -198,16 +202,27 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
     async def build_system_prompt(self) -> str:
         return _SYSTEM_PROMPT
 
+    # Map user-facing --type names to internal scope tokens.
+    _TYPE_REMAP: dict[str, str] = {
+        "adversarial": "gate",
+        "source-conflict": "conflict",
+    }
+
     def build_initial_message(
         self,
         user_input: str,
         **_kwargs,
     ) -> str:
         slug_match = re.search(r"--slug\s+(\S+)", user_input, re.IGNORECASE)
-        type_match = re.search(r"--type\s+(gate|conflict|all)", user_input, re.IGNORECASE)
+        type_match = re.search(
+            r"--type\s+(gate|adversarial|conflict|source-conflict|all)",
+            user_input,
+            re.IGNORECASE,
+        )
 
         slug = slug_match.group(1) if slug_match else None
-        scope = type_match.group(1) if type_match else "all"
+        raw_type = type_match.group(1).lower() if type_match else "all"
+        scope = self._TYPE_REMAP.get(raw_type, raw_type)
 
         msg_parts = ["Run the contradiction resolver workflow."]
         msg_parts.append(f"Scope: {scope}")

--- a/synthadoc/agents/workflows/ingest_lint.py
+++ b/synthadoc/agents/workflows/ingest_lint.py
@@ -93,10 +93,11 @@ When you have a final message for the user, respond with plain text only (no too
 
 
 class IngestLintWorkflow(AgenticWorkflow):
-    """Re-ingest stale pages and run lint in an interactive agentic loop."""
+    """Re-ingest stale pages (bulk) or any specific page by slug, then run lint."""
 
     NAME = "ingest-lint"
-    DESCRIPTION = "Re-ingest stale pages then run lint in an interactive loop."
+    DESCRIPTION = "Re-ingest stale pages (bulk) or any page by slug, then run lint."
+    CLI_ARGS = "[--slug SLUG]  (omit to re-ingest all stale pages)"
 
     MATCH_RE = re.compile(
         r"\bstale\s+pages?\b"

--- a/synthadoc/agents/workflows/ingest_lint.py
+++ b/synthadoc/agents/workflows/ingest_lint.py
@@ -93,6 +93,11 @@ When you have a final message for the user, respond with plain text only (no too
 
 
 class IngestLintWorkflow(AgenticWorkflow):
+    """Re-ingest stale pages and run lint in an interactive agentic loop."""
+
+    NAME = "ingest-lint"
+    DESCRIPTION = "Re-ingest stale pages then run lint in an interactive loop."
+
     MATCH_RE = re.compile(
         r"\bstale\s+pages?\b"
         r"|\borchestrat"

--- a/synthadoc/agents/workflows/lint_report.py
+++ b/synthadoc/agents/workflows/lint_report.py
@@ -90,6 +90,9 @@ intermediate steps must be tool calls, not prose.
 class LintReportWorkflow(AgenticWorkflow):
     """Run a full lint pass then surface the complete report in one shot."""
 
+    NAME = "lint-report"
+    DESCRIPTION = "Run a full lint pass and surface the complete report."
+
     MATCH_RE = re.compile(
         r"^(please\s+)?\brun\b.{0,20}\blint\b"
         r"|^(can|could|would)\s+(you\s+)?(please\s+)?\brun\b.{0,20}\blint\b",

--- a/synthadoc/agents/workflows/scaffold.py
+++ b/synthadoc/agents/workflows/scaffold.py
@@ -93,6 +93,9 @@ When you have no more tool calls to make, produce a plain-text summary (no JSON)
 class ScaffoldWorkflow(AgenticWorkflow):
     """Regenerate core wiki scaffold files with a confirm gate before running."""
 
+    NAME = "scaffold"
+    DESCRIPTION = "Regenerate core wiki scaffold files (confirm gate before writing)."
+
     MATCH_RE = re.compile(
         r"^(please\s+)?\brun\b.{0,20}\bscaffold\b"
         r"|^(can|could|would)\s+(you\s+)?(please\s+)?\brun\b.{0,20}\bscaffold\b"

--- a/synthadoc/cli/workflow.py
+++ b/synthadoc/cli/workflow.py
@@ -5,21 +5,30 @@
 
 Structure
 ---------
-    synthadoc workflow run <workflow-name> [OPTIONS]
+    synthadoc workflow list
+    synthadoc workflow run --name <name> [WORKFLOW_ARGS...] [-w WIKI] [--timeout N]
 
-Each 'run' subcommand builds a natural-language query string and sends it to
-the /query/stream endpoint.  The existing _stream_query function in query.py
-handles all SSE events including confirm_request (user approval prompts), so
-the full agentic loop works identically via CLI and web UI.
+``synthadoc workflow list`` prints all registered workflows with their
+descriptions.
+
+``synthadoc workflow run`` accepts the workflow name via ``--name`` and
+forwards any remaining options (e.g. ``--slug``, ``--type``) verbatim to
+the workflow's query string so each workflow can parse its own arguments.
+
+The existing _stream_query function in query.py handles all SSE events
+including confirm_request (user approval prompts), so the full agentic
+loop works identically via CLI and web UI.
 
 Adding a new workflow
 ---------------------
-Register a new command under ``run_app``:
-
-    @run_app.command("my-workflow")
-    def my_workflow_cmd(...) -> None:
-        ...
+  1. Implement AgenticWorkflow in a new module under synthadoc/agents/workflows/.
+  2. Set MATCH_RE, NAME, and DESCRIPTION on the class.
+  3. Add one import line and one entry in ROUTED_WORKFLOWS in _registry.py.
+  4. Add one entry to _WORKFLOW_QUERIES below that matches the class MATCH_RE.
+  The workflow is then automatically available via ``synthadoc workflow run --name <name>``.
 """
+from __future__ import annotations
+
 from typing import Optional
 
 import typer
@@ -35,68 +44,102 @@ workflow_app = typer.Typer(
     add_completion=False,
 )
 
-# ── sub-group: synthadoc workflow run ─────────────────────────────────────────
-
-run_app = typer.Typer(
-    name="run",
-    help="Run an agentic workflow interactively.",
-    add_completion=False,
-)
-workflow_app.add_typer(run_app)
-
-# Map user-facing --type values to the internal scope token the agent expects.
-_TYPE_TO_SCOPE: dict[str, str] = {
-    "adversarial": "gate",
-    "source-conflict": "conflict",
+# Query-string templates keyed by workflow NAME.
+# Each value is a phrase that matches the workflow's MATCH_RE, triggering
+# fast-path routing in ActionAgent without an LLM extraction call.
+# Any extra CLI arguments passed by the user are appended verbatim so each
+# workflow's build_initial_message can parse them from the query string.
+_WORKFLOW_QUERIES: dict[str, str] = {
+    "lint-report":             "run lint report",
+    "broken-wikilinks":        "scan for broken wikilinks",
+    "scaffold":                "run scaffold",
+    "contradiction-resolver":  "run contradiction resolver",
+    "ingest-lint":             "re-ingest stale pages",
 }
 
 
-@run_app.command("contradiction-resolver")
-def contradiction_resolver_cmd(
-    slug: Optional[str] = typer.Option(
-        None, "--slug", metavar="SLUG", help="Resolve only this page slug."
-    ),
-    type_: Optional[str] = typer.Option(
-        None, "--type", metavar="TYPE",
+@workflow_app.command("list")
+def list_workflows() -> None:
+    """List all registered agentic workflows available via 'workflow run'."""
+    from synthadoc.agents.workflows._registry import CLI_REGISTRY
+
+    if not CLI_REGISTRY:
+        typer.echo("No workflows registered.")
+        return
+
+    rows = [
+        (name, cls.DESCRIPTION or "", cls.CLI_ARGS or "")
+        for name, cls in sorted(CLI_REGISTRY.items())
+    ]
+    name_w = max(len(name) for name in CLI_REGISTRY) + 2
+    desc_w = max(len(desc) for _, desc, _ in rows) + 2
+    typer.echo(f"{'NAME':<{name_w}}  {'DESCRIPTION':<{desc_w}}  EXTRA ARGS")
+    typer.echo("-" * (name_w + 2 + desc_w + 2 + 45))
+    for name, desc, args in rows:
+        typer.echo(f"{name:<{name_w}}  {desc:<{desc_w}}  {args}")
+
+
+@workflow_app.command(
+    "run",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def run_workflow(
+    ctx: typer.Context,
+    name: str = typer.Option(
+        ...,
+        "--name",
+        "-n",
+        metavar="NAME",
         help=(
-            "Scope by contradiction type: "
-            "adversarial (pages demoted by the adversarial gate) | "
-            "source-conflict (pages with source-level contradictions). "
-            "Omit to resolve all contradicted pages."
+            "Workflow to run.  Use 'synthadoc workflow list' to see all "
+            "available workflows."
         ),
     ),
     wiki: Optional[str] = typer.Option(
-        None, "--wiki", "-w",
-        help="Wiki name (defaults to saved default or SYNTHADOC_WIKI env var)."
+        None,
+        "--wiki",
+        "-w",
+        help="Wiki name (defaults to saved default or SYNTHADOC_WIKI env var).",
     ),
     timeout: int = typer.Option(
-        3600, "--timeout", help="Max seconds to wait for the workflow to complete."
+        3600,
+        "--timeout",
+        help="Max seconds to wait for the workflow to complete.",
     ),
 ) -> None:
-    """Interactively resolve pages in 'contradicted' state.
+    """Run an agentic maintenance workflow by name.
 
     \b
-    The workflow lists contradicted pages, shows a cost estimate, then walks
-    through each page with a diff-based approval step. Every change requires
-    your approval before it is applied.
+    Any options not listed above are forwarded to the workflow verbatim, so
+    each workflow can define its own arguments.
 
     \b
     Examples:
-      synthadoc workflow run contradiction-resolver
-      synthadoc workflow run contradiction-resolver --slug alan-turing
-      synthadoc workflow run contradiction-resolver --type adversarial
-      synthadoc workflow run contradiction-resolver --type source-conflict -w my-wiki
+      synthadoc workflow list
+      synthadoc workflow run --name lint-report
+      synthadoc workflow run --name broken-wikilinks
+      synthadoc workflow run --name scaffold
+      synthadoc workflow run --name contradiction-resolver
+      synthadoc workflow run --name contradiction-resolver --slug alan-turing
+      synthadoc workflow run --name contradiction-resolver --type adversarial
+      synthadoc workflow run --name contradiction-resolver --type source-conflict
+      synthadoc workflow run --name ingest-lint -w my-wiki
     """
+    from synthadoc.agents.workflows._registry import CLI_REGISTRY
+
+    if name not in CLI_REGISTRY:
+        available = ", ".join(sorted(CLI_REGISTRY))
+        typer.echo(
+            f"Error: unknown workflow '{name}'.  "
+            f"Available: {available}",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
     resolved_wiki = _resolve_wiki(wiki)
 
-    # Translate user-facing type name to the internal scope token.
-    scope = _TYPE_TO_SCOPE.get(type_ or "", "all")
-
-    parts = ["run contradiction resolver"]
-    if slug:
-        parts.append(f"--slug {slug}")
-    if scope != "all":
-        parts.append(f"--type {scope}")
-    question = " ".join(parts)
+    base_query = _WORKFLOW_QUERIES.get(name, f"run {name}")
+    extra = " ".join(ctx.args)
+    question = f"{base_query} {extra}".strip() if extra else base_query
 
     _stream_query(resolved_wiki, question, no_cache=True, timeout=timeout)

--- a/synthadoc/data/obsidian-plugin/manifest.json
+++ b/synthadoc/data/obsidian-plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "synthadoc",
   "name": "Synthadoc",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "minAppVersion": "1.4.0",
   "description": "Connect your Obsidian vault to synthadoc.",
   "author": "synthadoc",

--- a/tests/cli/test_schedule_cli.py
+++ b/tests/cli/test_schedule_cli.py
@@ -89,10 +89,16 @@ def test_schedule_run_uses_wiki_root_as_cwd(tmp_path):
         captured["cwd"] = kwargs.get("cwd")
         return MagicMock(returncode=0)
 
-    with patch("subprocess.run", side_effect=fake_run):
-        result = runner.invoke(app, [
-            "schedule", "run", "--op", "lint run", "--wiki", str(wiki),
-        ])
+    with patch("synthadoc.storage.log.AuditDB") as MockDB:
+        instance = MagicMock()
+        instance.init = AsyncMock()
+        instance.record_scheduled_run_start = AsyncMock()
+        instance.record_scheduled_run_finish = AsyncMock()
+        MockDB.return_value = instance
+        with patch("subprocess.run", side_effect=fake_run):
+            result = runner.invoke(app, [
+                "schedule", "run", "--op", "lint run", "--wiki", str(wiki),
+            ])
     assert result.exit_code == 0, result.output
     assert captured["cwd"] == str(wiki)
 

--- a/tests/live/test_contradiction_resolver_live.py
+++ b/tests/live/test_contradiction_resolver_live.py
@@ -248,7 +248,7 @@ def _cli(*args: str, check: bool = True) -> subprocess.CompletedProcess:
 
 def _run_workflow(*args: str, timeout: int = 300, input_text: str = "") -> subprocess.CompletedProcess:
     """Run the contradiction-resolver workflow via CLI, feeding *input_text* to stdin."""
-    cmd = ["synthadoc", "-w", WIKI, "run", "contradiction-resolver", *args]
+    cmd = ["synthadoc", "-w", WIKI, "workflow", "run", "--name", "contradiction-resolver", *args]
     return subprocess.run(
         cmd, capture_output=True, text=True, encoding="utf-8",
         input=input_text, timeout=timeout, check=False,
@@ -423,7 +423,7 @@ def test_case3_multi_page_all_scope():
     """Multiple contradicted pages processed sequentially with scope=all.
 
     Setup: At least 2 pages in contradicted state.
-    Run: synthadoc run contradiction-resolver (no --slug)
+    Run: synthadoc workflow run --name contradiction-resolver (no --slug)
     Expected:
       - Output contains "Fixed" with a count ≥ 1.
     Restores all targeted pages to contradicted in the finally block.
@@ -596,15 +596,14 @@ def test_case5_cli_parity():
 
         # Guard: the workflow must reach a completion marker before we make any
         # meaningful assertion.  A missing marker means the stream was cut off
-        # mid-workflow, or the 'synthadoc run' CLI command is not yet available.
+        # mid-workflow or the server did not respond in time.
         # xfail rather than fail so this does not block CI.
         _COMPLETION_MARKERS = ("Fixed", "Unresolved", "Contradiction Resolver — Complete")
         if not any(m in output for m in _COMPLETION_MARKERS):
             pytest.xfail(
                 f"Case 5: CLI resolver did not produce a completion summary "
                 f"(returncode={result.returncode}, {len(output)} chars). "
-                "Either the 'synthadoc run' command is not yet implemented, "
-                "or the stream was cut off mid-workflow.\n"
+                "The stream may have been cut off mid-workflow.\n"
                 f"Last 400 chars: {output[-400:]}"
             )
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -7,16 +7,14 @@ from __future__ import annotations
 import re
 import pytest
 from typer.testing import CliRunner
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 
 def _strip_ansi(text: str) -> str:
     """Remove ANSI colour/style escape sequences from *text*.
 
-    Older versions of rich (Python 3.11 CI) render option names with colour
-    codes inserted between the two leading dashes, e.g. ``-\\x1b[...]-slug``,
-    which breaks plain substring checks.  Stripping ANSI codes first makes
-    the assertions version-agnostic.
+    Older versions of rich insert colour codes between option-name dashes
+    (``-\\x1b[...]-name``), which breaks plain substring checks.
     """
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
@@ -29,143 +27,310 @@ def test_workflow_command_exists_on_app():
     runner = CliRunner()
     result = runner.invoke(app, ["workflow", "--help"])
     assert result.exit_code == 0
-    assert "run" in result.output.lower()
+    out = result.output.lower()
+    assert "run" in out
+    assert "list" in out
 
 
-def test_workflow_run_subcommand_exists():
-    """synthadoc workflow run lists contradiction-resolver."""
+# ── workflow list ─────────────────────────────────────────────────────────────
+
+def test_workflow_list_exits_ok():
+    """synthadoc workflow list exits 0 and prints a table."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    result = runner.invoke(app, ["workflow", "list"])
+    assert result.exit_code == 0
+    assert "NAME" in result.output
+
+
+def test_workflow_list_shows_all_registered_workflows():
+    """All 5 registered workflows appear in 'workflow list' output."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    result = runner.invoke(app, ["workflow", "list"])
+    assert result.exit_code == 0
+    out = result.output
+    for expected in [
+        "lint-report",
+        "broken-wikilinks",
+        "scaffold",
+        "contradiction-resolver",
+        "ingest-lint",
+    ]:
+        assert expected in out, f"'{expected}' missing from 'workflow list' output"
+
+
+def test_workflow_list_shows_descriptions():
+    """workflow list includes the DESCRIPTION for each workflow."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    result = runner.invoke(app, ["workflow", "list"])
+    assert result.exit_code == 0
+    # Every registered workflow must have a non-empty description
+    from synthadoc.agents.workflows._registry import CLI_REGISTRY
+    for name, cls in CLI_REGISTRY.items():
+        assert cls.DESCRIPTION, f"Workflow '{name}' has no DESCRIPTION"
+
+
+# ── workflow run --help ───────────────────────────────────────────────────────
+
+def test_workflow_run_help_shows_name_option():
+    """synthadoc workflow run --help documents --name."""
     from synthadoc.cli.main import app
     runner = CliRunner()
     result = runner.invoke(app, ["workflow", "run", "--help"])
     assert result.exit_code == 0
-    assert "contradiction-resolver" in result.output.lower()
-
-
-# ── contradiction-resolver help ───────────────────────────────────────────────
-
-def test_workflow_run_contradiction_resolver_help():
-    """contradiction-resolver subcommand shows --slug and --type without error.
-
-    The output is stripped of ANSI escape codes before asserting: older rich
-    versions insert colour codes between the leading dashes of each option name
-    (``-\\x1b[...]-slug``), which breaks a plain ``in`` check.
-    """
-    from synthadoc.cli.main import app
-    runner = CliRunner()
-    result = runner.invoke(
-        app, ["workflow", "run", "contradiction-resolver", "--help"]
-    )
-    assert result.exit_code == 0
     clean = _strip_ansi(result.output)
-    assert "--slug" in clean
-    assert "--type" in clean
-    # New user-facing type names must appear in the help text
-    assert "adversarial" in clean
-    assert "source-conflict" in clean
+    assert "--name" in clean
 
 
-# ── type translation (_TYPE_TO_SCOPE) ─────────────────────────────────────────
-
-def test_type_to_scope_mapping():
-    """_TYPE_TO_SCOPE translates user-facing names to internal agent tokens."""
-    from synthadoc.cli.workflow import _TYPE_TO_SCOPE
-    assert _TYPE_TO_SCOPE["adversarial"] == "gate"
-    assert _TYPE_TO_SCOPE["source-conflict"] == "conflict"
-
-
-def test_workflow_run_contradiction_resolver_calls_stream_query():
-    """contradiction-resolver invocation calls _stream_query with the right question."""
+def test_workflow_run_help_shows_workflow_examples():
+    """workflow run --help mentions the registered workflow names."""
     from synthadoc.cli.main import app
     runner = CliRunner()
+    result = runner.invoke(app, ["workflow", "run", "--help"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "contradiction-resolver" in out
+    assert "lint-report" in out
 
+
+# ── workflow run — dispatch ───────────────────────────────────────────────────
+
+def test_workflow_run_calls_stream_query_for_lint_report():
+    """workflow run --name lint-report calls _stream_query."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
     with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
          patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
-        result = runner.invoke(app, [
-            "workflow", "run", "contradiction-resolver",
+        result = runner.invoke(app, ["workflow", "run", "--name", "lint-report"])
+    assert mock_sq.called
+    question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
+    assert "lint" in question.lower()
+
+
+def test_workflow_run_calls_stream_query_for_broken_wikilinks():
+    """workflow run --name broken-wikilinks calls _stream_query."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
+         patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
+        result = runner.invoke(app, ["workflow", "run", "--name", "broken-wikilinks"])
+    assert mock_sq.called
+    question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
+    assert "wikilink" in question.lower()
+
+
+def test_workflow_run_calls_stream_query_for_scaffold():
+    """workflow run --name scaffold calls _stream_query."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
+         patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
+        result = runner.invoke(app, ["workflow", "run", "--name", "scaffold"])
+    assert mock_sq.called
+    question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
+    assert "scaffold" in question.lower()
+
+
+def test_workflow_run_calls_stream_query_for_contradiction_resolver():
+    """workflow run --name contradiction-resolver calls _stream_query."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
+         patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
+        runner.invoke(app, [
+            "workflow", "run", "--name", "contradiction-resolver",
             "-w", "test-wiki",
         ])
     assert mock_sq.called
-    call_args = mock_sq.call_args
-    question = call_args[0][1] if len(call_args[0]) > 1 else call_args[1].get("question", "")
+    question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
     assert "contradiction" in question.lower()
 
 
-def test_workflow_run_contradiction_resolver_with_slug():
-    """--slug flag is forwarded in the query string."""
+def test_workflow_run_calls_stream_query_for_ingest_lint():
+    """workflow run --name ingest-lint calls _stream_query."""
     from synthadoc.cli.main import app
     runner = CliRunner()
+    with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
+         patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
+        result = runner.invoke(app, ["workflow", "run", "--name", "ingest-lint"])
+    assert mock_sq.called
+    question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
+    assert "stale" in question.lower()
 
+
+# ── workflow run — extra args forwarding ──────────────────────────────────────
+
+def test_workflow_run_forwards_slug_to_query():
+    """--slug extra arg is appended to the query string."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
     with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
          patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
         runner.invoke(app, [
-            "workflow", "run", "contradiction-resolver",
+            "workflow", "run", "--name", "contradiction-resolver",
             "--slug", "alan-turing",
             "-w", "test-wiki",
         ])
-
     assert mock_sq.called
-    call_args = mock_sq.call_args
-    question = call_args[0][1] if len(call_args[0]) > 1 else ""
+    question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
+    assert "--slug" in question
     assert "alan-turing" in question
 
 
-def test_workflow_run_contradiction_resolver_type_adversarial():
-    """--type adversarial translates to 'gate' in the query string."""
+def test_workflow_run_forwards_type_adversarial_to_query():
+    """--type adversarial is forwarded in the query string."""
     from synthadoc.cli.main import app
     runner = CliRunner()
-
     with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
          patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
         runner.invoke(app, [
-            "workflow", "run", "contradiction-resolver",
+            "workflow", "run", "--name", "contradiction-resolver",
             "--type", "adversarial",
             "-w", "test-wiki",
         ])
-
     assert mock_sq.called
     question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
-    assert "--type gate" in question
+    assert "--type" in question
+    assert "adversarial" in question
 
 
-def test_workflow_run_contradiction_resolver_type_source_conflict():
-    """--type source-conflict translates to 'conflict' in the query string."""
+def test_workflow_run_forwards_type_source_conflict_to_query():
+    """--type source-conflict is forwarded in the query string."""
     from synthadoc.cli.main import app
     runner = CliRunner()
-
     with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
          patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
         runner.invoke(app, [
-            "workflow", "run", "contradiction-resolver",
+            "workflow", "run", "--name", "contradiction-resolver",
             "--type", "source-conflict",
             "-w", "test-wiki",
         ])
-
     assert mock_sq.called
     question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
-    assert "--type conflict" in question
+    assert "--type" in question
+    assert "source-conflict" in question
 
 
-def test_workflow_run_contradiction_resolver_no_type_omits_scope():
-    """Omitting --type sends no --type token (defaults to all contradicted pages)."""
+def test_workflow_run_no_extra_args_sends_base_query():
+    """With no extra args, the base query string is sent unmodified."""
     from synthadoc.cli.main import app
+    from synthadoc.cli.workflow import _WORKFLOW_QUERIES
     runner = CliRunner()
-
     with patch("synthadoc.cli.workflow._stream_query") as mock_sq, \
          patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
         runner.invoke(app, [
-            "workflow", "run", "contradiction-resolver",
+            "workflow", "run", "--name", "contradiction-resolver",
             "-w", "test-wiki",
         ])
-
     assert mock_sq.called
     question = mock_sq.call_args[0][1] if len(mock_sq.call_args[0]) > 1 else ""
-    assert "--type" not in question
+    assert question == _WORKFLOW_QUERIES["contradiction-resolver"]
+
+
+# ── workflow run — unknown name ───────────────────────────────────────────────
+
+def test_workflow_run_unknown_name_exits_nonzero():
+    """Passing an unregistered workflow name exits with code 1."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    with patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
+        result = runner.invoke(app, [
+            "workflow", "run", "--name", "nonexistent-workflow",
+        ])
+    assert result.exit_code != 0
+
+
+def test_workflow_run_unknown_name_prints_available_list():
+    """Unknown workflow name error message lists available workflow names."""
+    from synthadoc.cli.main import app
+    runner = CliRunner()
+    with patch("synthadoc.cli.workflow._resolve_wiki", return_value="test-wiki"):
+        result = runner.invoke(app, [
+            "workflow", "run", "--name", "does-not-exist",
+        ])
+    # Error goes to stderr; CliRunner mixes it with stdout by default
+    assert "contradiction-resolver" in result.output or result.exit_code != 0
+
+
+# ── CLI_REGISTRY ──────────────────────────────────────────────────────────────
+
+def test_cli_registry_contains_all_named_workflows():
+    """CLI_REGISTRY contains all 5 workflow classes."""
+    from synthadoc.agents.workflows._registry import CLI_REGISTRY
+    expected = {
+        "lint-report",
+        "broken-wikilinks",
+        "scaffold",
+        "contradiction-resolver",
+        "ingest-lint",
+    }
+    assert expected == set(CLI_REGISTRY.keys())
+
+
+def test_cli_registry_values_are_workflow_classes():
+    """CLI_REGISTRY values are AgenticWorkflow subclasses."""
+    from synthadoc.agents.workflows._registry import CLI_REGISTRY
+    from synthadoc.agents.workflows._base import AgenticWorkflow
+    for name, cls in CLI_REGISTRY.items():
+        assert issubclass(cls, AgenticWorkflow), f"{name} is not an AgenticWorkflow"
+
+
+# ── ContradictionResolverWorkflow.build_initial_message ───────────────────────
+
+def test_build_initial_message_no_args_defaults_all():
+    """build_initial_message with no --slug/--type defaults scope to 'all'."""
+    from synthadoc.agents.workflows.contradiction_resolver import ContradictionResolverWorkflow
+    wf = ContradictionResolverWorkflow()
+    msg = wf.build_initial_message("run contradiction resolver")
+    assert "Scope: all" in msg
+
+
+def test_build_initial_message_slug_forwarded():
+    """build_initial_message extracts --slug from the query string."""
+    from synthadoc.agents.workflows.contradiction_resolver import ContradictionResolverWorkflow
+    wf = ContradictionResolverWorkflow()
+    msg = wf.build_initial_message("run contradiction resolver --slug alan-turing")
+    assert "alan-turing" in msg
+
+
+def test_build_initial_message_type_adversarial_maps_to_gate():
+    """--type adversarial in the query is remapped to internal scope 'gate'."""
+    from synthadoc.agents.workflows.contradiction_resolver import ContradictionResolverWorkflow
+    wf = ContradictionResolverWorkflow()
+    msg = wf.build_initial_message("run contradiction resolver --type adversarial")
+    assert "Scope: gate" in msg
+
+
+def test_build_initial_message_type_source_conflict_maps_to_conflict():
+    """--type source-conflict in the query is remapped to internal scope 'conflict'."""
+    from synthadoc.agents.workflows.contradiction_resolver import ContradictionResolverWorkflow
+    wf = ContradictionResolverWorkflow()
+    msg = wf.build_initial_message("run contradiction resolver --type source-conflict")
+    assert "Scope: conflict" in msg
+
+
+def test_build_initial_message_type_gate_passes_through():
+    """--type gate passes through without remapping."""
+    from synthadoc.agents.workflows.contradiction_resolver import ContradictionResolverWorkflow
+    wf = ContradictionResolverWorkflow()
+    msg = wf.build_initial_message("run contradiction resolver --type gate")
+    assert "Scope: gate" in msg
+
+
+def test_build_initial_message_type_conflict_passes_through():
+    """--type conflict passes through without remapping."""
+    from synthadoc.agents.workflows.contradiction_resolver import ContradictionResolverWorkflow
+    wf = ContradictionResolverWorkflow()
+    msg = wf.build_initial_message("run contradiction resolver --type conflict")
+    assert "Scope: conflict" in msg
 
 
 # ── workflow RE routing ────────────────────────────────────────────────────────
 
 def test_workflow_re_matches_contradiction_resolver():
-    """_WORKFLOW_RE in query.py must route contradiction resolver to long timeout."""
+    """_WORKFLOW_RE in query.py routes contradiction resolver to long timeout."""
     import synthadoc.cli.query as q
     assert q._WORKFLOW_RE.search("run contradiction resolver")
     assert q._WORKFLOW_RE.search("fix contradicted pages")


### PR DESCRIPTION
All 5 registered workflows (lint-report, broken-wikilinks, scaffold, contradiction-resolver, ingest-lint) are now reachable from the CLI automatically via NAME/DESCRIPTION/CLI_ARGS class attributes and CLI_REGISTRY in _registry.py.