### PR TITLE
fix(workflows): hold page_lock during write in tool_propose_and_apply

### DIFF
--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -774,7 +774,8 @@ async def tool_propose_and_apply(
         # is not None, regardless of content quality.  Applying approved new content
         # is the act of resolving the conflict, so the note must be cleared here.
         page.contradiction_note = None
-        ctx.store.write_page(slug, page)
+        with ctx.store.page_lock(slug):
+            ctx.store.write_page(slug, page)
         await ctx.send_sse_event(
             "tool_progress",
             {"tool": "propose_and_apply", "message": f"✓ Applied {strategy_name} to {slug}"},


### PR DESCRIPTION
Two concurrent agentic workflows targeting the same page could clobber each other's writes because tool_propose_and_apply called write_page without holding the per-slug lock.

Wrap the write in the same pattern used by tool_apply_link_fixes, set_page_categories, and _add_category: acquire page_lock(slug) for the duration of the write_page call.

site: https://github.com/axoviq-ai/synthadoc/issues/331