### PR TITLE
fix(workflows): enforce lifecycle state-machine graph in tool_transit…

### DIFF
--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -796,9 +796,10 @@ async def tool_transition_lifecycle_state(
 ) -> dict:
     """Transition a page to a new lifecycle state and record an audit event.
 
-    Validates the target state string before writing.  Any workflow that
-    moves pages between states should use this tool so the audit trail is
-    always complete.
+    Validates both the target state name and the transition graph before
+    writing — the same rules enforced by the HTTP endpoint and MCP server.
+    Any workflow that moves pages between states should use this tool so the
+    audit trail is always complete.
 
     LifecycleState in this codebase uses plain string constants (not an enum).
     Assigning page.status = to_state is correct; do NOT call LifecycleState(to_state).
@@ -808,6 +809,8 @@ async def tool_transition_lifecycle_state(
         {"success": True, "from_state": str, "to_state": str}
         {"success": False, "error": str}
     """
+    from synthadoc.storage.wiki import validate_lifecycle_transition
+
     if to_state not in _VALID_STATES:
         return {
             "success": False,
@@ -819,6 +822,15 @@ async def tool_transition_lifecycle_state(
         return {"success": False, "error": f"Page not found: {slug!r}"}
 
     from_state = page.status if page.status else "unknown"
+
+    # Enforce the lifecycle state-machine graph — same rules as the HTTP endpoint
+    # and MCP server.  Lint and ingest bypass this check intentionally (they write
+    # via write_page() directly); this tool is user-driven and must not be more
+    # permissive than the other user-facing surfaces.
+    err = validate_lifecycle_transition(from_state, to_state)
+    if err:
+        return {"success": False, "error": err}
+
     page.status = to_state  # LifecycleState constants are plain strings
 
     if to_state == "active":

--- a/tests/test_workflow_tools_ext.py
+++ b/tests/test_workflow_tools_ext.py
@@ -454,6 +454,84 @@ async def test_transition_hooks_none_safe(tmp_path):
     assert result["success"] is True  # must not raise
 
 
+# ── tool_transition_lifecycle_state — state-machine graph enforcement ─────────
+
+@pytest.mark.asyncio
+async def test_transition_rejects_forbidden_path_archived_to_active(tmp_path):
+    """archived → active is not in ALLOWED_LIFECYCLE_TRANSITIONS; must be rejected."""
+    store = _make_store(tmp_path, {
+        "alan-turing": _page(status=LifecycleState.ARCHIVED),
+    })
+    ctx = _ctx(tmp_path, store)
+
+    from synthadoc.agents.workflows._tools import tool_transition_lifecycle_state
+    result = await tool_transition_lifecycle_state(
+        ctx, slug="alan-turing", to_state="active",
+        reason="trying a forbidden path",
+    )
+
+    assert result["success"] is False
+    assert "not permitted" in result["error"]
+    # Verify the page was NOT written.
+    page = store.read_page("alan-turing")
+    assert page.status == LifecycleState.ARCHIVED
+
+
+@pytest.mark.asyncio
+async def test_transition_rejects_same_state(tmp_path):
+    """active → active must be rejected (same-state is never a valid transition)."""
+    store = _make_store(tmp_path, {
+        "ada-lovelace": _page(status=LifecycleState.ACTIVE),
+    })
+    ctx = _ctx(tmp_path, store)
+
+    from synthadoc.agents.workflows._tools import tool_transition_lifecycle_state
+    result = await tool_transition_lifecycle_state(
+        ctx, slug="ada-lovelace", to_state="active",
+        reason="no-op same-state",
+    )
+
+    assert result["success"] is False
+    assert "already in state" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_transition_rejects_draft_to_stale(tmp_path):
+    """draft → stale is not in ALLOWED_LIFECYCLE_TRANSITIONS; must be rejected."""
+    store = _make_store(tmp_path, {
+        "eniac": _page(status=LifecycleState.DRAFT),
+    })
+    ctx = _ctx(tmp_path, store)
+
+    from synthadoc.agents.workflows._tools import tool_transition_lifecycle_state
+    result = await tool_transition_lifecycle_state(
+        ctx, slug="eniac", to_state="stale",
+        reason="trying another forbidden path",
+    )
+
+    assert result["success"] is False
+    assert "not permitted" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_transition_allows_contradicted_to_active(tmp_path):
+    """contradicted → active is the resolver's valid path; must succeed."""
+    store = _make_store(tmp_path, {
+        "grace-hopper": _page(status=LifecycleState.CONTRADICTED),
+    })
+    ctx = _ctx(tmp_path, store)
+
+    from synthadoc.agents.workflows._tools import tool_transition_lifecycle_state
+    result = await tool_transition_lifecycle_state(
+        ctx, slug="grace-hopper", to_state="active",
+        reason="resolved by contradiction-resolver — strategy: Content rewrite, attempt 1",
+    )
+
+    assert result["success"] is True
+    assert result["from_state"] == "contradicted"
+    assert result["to_state"] == "active"
+
+
 # ── tool_get_wiki_status ──────────────────────────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
…ion_lifecycle_state

The tool validated that to_state is a known state string but never called validate_lifecycle_transition(from_state, to_state), allowing any transition between known states regardless of the state-machine graph. This created a double standard: the same operation rejected by the HTTP endpoint (e.g. archived → active) was silently accepted by the workflow tool.

Fix: import and call validate_lifecycle_transition after reading from_state and before writing page.status.  The lint/ingest bypass of this check is intentional and unaffected — they write via write_page() directly.

The contradiction resolver is unaffected: contradicted → active is an explicit entry in ALLOWED_LIFECYCLE_TRANSITIONS.

Tests added:
  - archived → active rejected (forbidden path, page not written)
  - active → active rejected (same-state)
  - draft → stale rejected (forbidden path)
  - contradicted → active allowed (resolver valid path)

issue:  https://github.com/axoviq-ai/synthadoc/issues/332