### PR TITLE
fix: harmonise backoff_base_seconds default to 5 s across all three s…

### DIFF
--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -134,7 +134,7 @@ class QueueConfig:
     # throughput support is a design goal.
     max_parallel_ingest: int = 4
     max_retries: int = 3
-    backoff_base_seconds: int = 30
+    backoff_base_seconds: int = 5
 
 
 @dataclass

--- a/synthadoc/core/queue.py
+++ b/synthadoc/core/queue.py
@@ -50,7 +50,7 @@ _MAX_BACKOFF_SECONDS: int = 300
 
 class JobQueue:
     def __init__(self, db_path: Path, max_retries: int = 3,
-                 backoff_base_seconds: int = 30) -> None:
+                 backoff_base_seconds: int = 5) -> None:
         self._path = Path(db_path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._max_retries = max_retries

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,7 +98,7 @@ def test_queue_defaults():
     cfg = load_config()
     assert cfg.queue.max_parallel_ingest == 4
     assert cfg.queue.max_retries == 3
-    assert cfg.queue.backoff_base_seconds == 30
+    assert cfg.queue.backoff_base_seconds == 5
 
 
 def test_unlimited_wikis(tmp_path):


### PR DESCRIPTION
…ites

Three independent defaults existed with conflicting values:
  - QueueConfig dataclass field:       30 s  (dead when load_config() is given files)
  - _raw_to_config fallback:            5 s  (live for any config-file load)
  - JobQueue.__init__ parameter:       30 s  (live for direct JobQueue construction)

The 5 s value in _raw_to_config was the deliberate operational choice (giving retry delays of 5 s / 10 s / 20 s under the default 3-retry budget, capped at 300 s). The 30 s values in the dataclass and JobQueue were the stale originals that were never updated when _raw_to_config was written.

All three now read 5 s.  test_config.py assertion updated to match.

issue: https://github.com/axoviq-ai/synthadoc/issues/339