### PR TITLE
fix(lint-report): include broken citation count in LintReportWorkflow…

### DIFF
--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -332,11 +332,24 @@ async def tool_get_lint_report(ctx: "WorkflowContext") -> dict:
         warned.sort(key=lambda x: x["count"], reverse=True)
         orphan_slugs.sort()
 
+    # Citation issues — reuse find_broken_citation_refs (same function used by
+    # tool_find_broken_citations in BrokenCitationResolverWorkflow).
+    broken_cite_by_slug: dict[str, list[dict]] = {}
+    if ctx.store and ctx.wiki_root:
+        _extracted_dir = Path(ctx.wiki_root) / ".synthadoc" / "extracted"
+        broken_cite_by_slug = find_broken_citation_refs(ctx.store, _extracted_dir)
+    broken_citation_count = sum(len(v) for v in broken_cite_by_slug.values())
+
     return {
         "last_run": summary or {},
         "contradicted_pages": contradicted,
         "adversarial_warnings": warned,
         "orphan_slugs": orphan_slugs,
+        "broken_citations": broken_citation_count,
+        "broken_citation_pages": [
+            {"slug": slug, "count": len(issues)}
+            for slug, issues in sorted(broken_cite_by_slug.items())
+        ],
     }
 
 

--- a/synthadoc/agents/workflows/lint_report.py
+++ b/synthadoc/agents/workflows/lint_report.py
@@ -38,7 +38,9 @@ Output: {
   },
   "contradicted_pages": [{"slug": str, "since": str}],
   "adversarial_warnings": [{"slug": str, "count": int}],
-  "orphan_slugs": [str]
+  "orphan_slugs": [str],
+  "broken_citations": int,
+  "broken_citation_pages": [{"slug": str, "count": int}]
 }
 
 ## Tool-call wire format
@@ -62,6 +64,7 @@ When you have a final message for the user, respond with plain text only (no JSO
    - Dangling links removed: N  (omit this line if dangling_removed == 0)
    - Orphan pages: N
    - Contradictions: N resolved, N flagged
+   - Broken citations: N  (omit this line if broken_citations == 0)
 
    **Contradicted Pages**
    List each as "- slug  (since YYYY-MM-DD)".
@@ -73,6 +76,10 @@ When you have a final message for the user, respond with plain text only (no JSO
 
    **Orphan Pages**
    List each slug as a bullet.
+   If none: "(none)"
+
+   **Broken Citations**
+   List each as "- [[slug]]  (N broken citation(s))".
    If none: "(none)"
 
 Plain text ends the workflow. Use it ONLY in step 3 or on error. All


### PR DESCRIPTION
… summary

tool_get_lint_report returned orphan, contradiction, and adversarial-warning data but never called find_broken_citation_refs, so the LintReportWorkflow had no citation data to surface. The web UI Lint Report workflow summary was therefore always missing the broken-citation line.

Fix:
- _tools.py: tool_get_lint_report now calls find_broken_citation_refs (already imported for BrokenCitationResolverWorkflow) and adds two new fields to its return value:
    broken_citations: int          — total count across all pages
    broken_citation_pages: list   — [{slug, count}] sorted by slug

- lint_report.py: update get_lint_report output schema in the system prompt, add '- Broken citations: N  (omit if 0)' to the Summary bullet list, and add a 'Broken Citations' section listing each affected page.

No new imports needed: find_broken_citation_refs was already imported at the top of _tools.py for use by tool_find_broken_citations.