### PR TITLE
fix(claude-code-provider): system-prompt flag required to run agentic maintenace workflow using Claudecode CLI provider

### DIFF
--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -251,8 +251,9 @@ class ClaudeCodeCLIProvider(CodingToolCLIProvider):
 
     Fix: pass the system prompt via ``--system-prompt`` (replacing the
     default Claude Code agent context) and send only user messages via stdin.
-    When no system prompt is provided, ``--no-system-prompt`` suppresses the
-    default agent context so responses are predictable.
+    When no system prompt is provided no extra system flags are added — Claude
+    Code uses its default context, which is acceptable for single-call tier-1
+    agents (``--no-system-prompt`` is not supported by all Claude Code versions).
     """
     _tool_binary = "claude"
 
@@ -263,16 +264,24 @@ class ClaudeCodeCLIProvider(CodingToolCLIProvider):
         return cmd
 
     def _build_system_args(self, system: Optional[str]) -> list[str]:
-        """Pass system prompt via ``--system-prompt`` flag; suppress default context."""
+        """Pass system prompt via ``--system-prompt`` flag when one is provided.
+
+        When *system* is ``None`` or empty, no extra flags are added — Claude
+        Code uses its default agent context.  This is acceptable for tier-1
+        single-call agents (ingest, lint, etc.) which do not rely on a precise
+        system boundary.
+
+        ``--no-system-prompt`` is intentionally not used: it is not present in
+        all Claude Code versions and causes an "unknown option" exit-code 1
+        when the flag is absent.
+        """
         if system:
             # Replaces Claude Code's default agent system prompt (including any
             # CLAUDE.md collaboration guidelines that would otherwise instruct
             # the subprocess to "pause and discuss" rather than execute the
             # workflow's JSON tool-call protocol).
             return ["--system-prompt", system]
-        # No system prompt — suppress Claude Code's default agent context so
-        # there are no unexpected behavioural instructions.
-        return ["--no-system-prompt"]
+        return []
 
     def _build_prompt(self, messages: list[Message], system: Optional[str]) -> str:
         """Return user messages only — system is passed via ``--system-prompt`` flag."""

--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -122,7 +122,12 @@ class CodingToolCLIProvider(LLMProvider):
         """Return True if stderr indicates the tool's usage quota is exhausted."""
 
     def _build_prompt(self, messages: list[Message], system: Optional[str]) -> str:
-        """Combine system message and user messages into a single prompt string."""
+        """Combine system message and user messages into a single prompt string.
+
+        Subclasses that pass *system* via a dedicated CLI flag should override
+        this method to exclude system from the stdin prompt (return user messages
+        only) and also override :meth:`_build_system_args` to return the flag.
+        """
         parts = []
         if system:
             parts.append(system)
@@ -131,10 +136,25 @@ class CodingToolCLIProvider(LLMProvider):
             parts.append(content)
         return "\n\n".join(parts)
 
+    def _build_system_args(self, system: Optional[str]) -> list[str]:
+        """Return additional argv items for passing the system prompt to the CLI.
+
+        Default implementation returns an empty list — the system prompt is
+        embedded in stdin by :meth:`_build_prompt`.  Override in subclasses
+        that accept the system prompt as a dedicated command-line flag (e.g.
+        ``--system-prompt``) so the LLM receives it as the actual system
+        context rather than as part of the user turn.
+        """
+        return []
+
     async def complete(self, messages: list[Message], system: Optional[str] = None,
                        temperature: float = 0.0, max_tokens: int = 4096) -> CompletionResponse:
         prompt = self._build_prompt(messages, system)
-        cmd = self._cmd_prefix + self._build_command(self._resolved_binary)
+        cmd = (
+            self._cmd_prefix
+            + self._build_command(self._resolved_binary)
+            + self._build_system_args(system)
+        )
 
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -219,6 +239,20 @@ class ClaudeCodeCLIProvider(CodingToolCLIProvider):
 
     Requires `claude` to be installed and authenticated.
     Usage: set provider = "claude-code" in .synthadoc/config.toml.
+
+    System-prompt handling
+    ----------------------
+    The Claude Code CLI (`claude -p`) treats stdin as the *user* turn and
+    injects its own agent context (CLAUDE.md files, superpowers, memory) as
+    the system.  When Synthadoc passes a workflow system prompt (e.g. the
+    JSON wire-format tool protocol), it must arrive as Claude Code's *actual*
+    system — otherwise Claude Code reads it as user content about a different
+    system and correctly refuses to execute tools it doesn't have registered.
+
+    Fix: pass the system prompt via ``--system-prompt`` (replacing the
+    default Claude Code agent context) and send only user messages via stdin.
+    When no system prompt is provided, ``--no-system-prompt`` suppresses the
+    default agent context so responses are predictable.
     """
     _tool_binary = "claude"
 
@@ -227,6 +261,26 @@ class ClaudeCodeCLIProvider(CodingToolCLIProvider):
         if self._model:
             cmd += ["--model", self._model]
         return cmd
+
+    def _build_system_args(self, system: Optional[str]) -> list[str]:
+        """Pass system prompt via ``--system-prompt`` flag; suppress default context."""
+        if system:
+            # Replaces Claude Code's default agent system prompt (including any
+            # CLAUDE.md collaboration guidelines that would otherwise instruct
+            # the subprocess to "pause and discuss" rather than execute the
+            # workflow's JSON tool-call protocol).
+            return ["--system-prompt", system]
+        # No system prompt — suppress Claude Code's default agent context so
+        # there are no unexpected behavioural instructions.
+        return ["--no-system-prompt"]
+
+    def _build_prompt(self, messages: list[Message], system: Optional[str]) -> str:
+        """Return user messages only — system is passed via ``--system-prompt`` flag."""
+        parts = []
+        for m in messages:
+            content = m.content if isinstance(m.content, str) else str(m.content)
+            parts.append(content)
+        return "\n\n".join(parts)
 
     def _parse_output(self, raw: str) -> CompletionResponse:
         try:

--- a/tests/providers/test_coding_tool_providers.py
+++ b/tests/providers/test_coding_tool_providers.py
@@ -183,10 +183,11 @@ def test_claude_build_system_args_with_system():
 
 
 def test_claude_build_system_args_no_system():
-    """No system prompt → --no-system-prompt to suppress default Claude Code context."""
+    """No system prompt → no extra flags (--no-system-prompt not universally supported)."""
     provider = _make_claude_provider()
     args = provider._build_system_args(None)
-    assert "--no-system-prompt" in args
+    assert args == []
+    assert "--no-system-prompt" not in args
     assert "--system-prompt" not in args
 
 

--- a/tests/providers/test_coding_tool_providers.py
+++ b/tests/providers/test_coding_tool_providers.py
@@ -172,6 +172,87 @@ def test_claude_build_command_with_model():
     assert "claude-sonnet-4-5" in cmd
 
 
+def test_claude_build_system_args_with_system():
+    """System prompt present → --system-prompt flag with value."""
+    provider = _make_claude_provider()
+    args = provider._build_system_args("You are a wiki agent.")
+    assert "--system-prompt" in args
+    idx = args.index("--system-prompt")
+    assert args[idx + 1] == "You are a wiki agent."
+    assert "--no-system-prompt" not in args
+
+
+def test_claude_build_system_args_no_system():
+    """No system prompt → --no-system-prompt to suppress default Claude Code context."""
+    provider = _make_claude_provider()
+    args = provider._build_system_args(None)
+    assert "--no-system-prompt" in args
+    assert "--system-prompt" not in args
+
+
+def test_claude_build_prompt_excludes_system():
+    """_build_prompt must not embed system in stdin for ClaudeCodeCLIProvider."""
+    from synthadoc.providers.base import Message
+    provider = _make_claude_provider()
+    prompt = provider._build_prompt(
+        [Message(role="user", content="Find stale pages")],
+        system="You are a maintenance agent.",
+    )
+    assert "You are a maintenance agent." not in prompt
+    assert "Find stale pages" in prompt
+
+
+def test_claude_build_prompt_no_system():
+    """_build_prompt with system=None returns only user content."""
+    from synthadoc.providers.base import Message
+    provider = _make_claude_provider()
+    prompt = provider._build_prompt(
+        [Message(role="user", content="List orphans")],
+        system=None,
+    )
+    assert "List orphans" in prompt
+
+
+@pytest.mark.asyncio
+async def test_claude_complete_passes_system_via_flag():
+    """complete() with a system prompt must pass --system-prompt to the subprocess,
+    not embed the system text in stdin."""
+    import json
+    from synthadoc.providers.base import Message
+    provider = _make_claude_provider()
+    raw = json.dumps({
+        "result": "tool call response",
+        "total_input_tokens": 20,
+        "total_output_tokens": 10,
+        "is_error": False,
+    })
+    mock_proc = _make_mock_proc(raw.encode(), b"", returncode=0)
+    captured_cmd: list = []
+    captured_stdin: list = []
+
+    async def fake_exec(*args, **kwargs):
+        captured_cmd.extend(args)
+        return mock_proc
+
+    mock_proc.communicate = AsyncMock(
+        side_effect=lambda input=None: (
+            captured_stdin.append(input) or (raw.encode(), b"")
+        )
+    )
+
+    with patch("asyncio.create_subprocess_exec", fake_exec):
+        await provider.complete(
+            [Message(role="user", content="run workflow")],
+            system="You are a JSON tool-call agent.",
+        )
+
+    # --system-prompt must be in the command argv, not in the stdin blob
+    cmd_str = " ".join(str(a) for a in captured_cmd)
+    assert "--system-prompt" in cmd_str
+    assert "You are a JSON tool-call agent." not in (captured_stdin[0] or b"").decode()
+    assert "run workflow" in (captured_stdin[0] or b"").decode()
+
+
 # ── OpencodeProvider ──────────────────────────────────────────────────────────
 
 def _make_opencode_provider():


### PR DESCRIPTION
pass workflow system prompt via --system-prompt flag, otherwise the maintenance workflow wouldn't run when using Claudecode CLI provider.

Root cause: CodingToolCLIProvider._build_prompt concatenated the workflow system prompt into the stdin blob passed to 'claude -p'.