### PR TITLE
fix: harden agentic workflow confirm gates and fix OKF YAML parse failure

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -3506,7 +3506,7 @@ In the web UI **Graph tab**, the node detail panel includes a **Maintenance** se
 
 ### Provider compatibility
 
-All seven workflows support both the Anthropic API provider (key-based) and CLI providers (Claude Code, Opencode). The execution model differs between provider types.
+All seven workflows support both standard API providers (Anthropic, OpenAI, Gemini, Groq, Ollama, MiniMax, DeepSeek, Qwen, and any custom endpoint) and CLI providers (Claude Code, Opencode). The execution model differs between provider types.
 
 **Why CLI providers need a separate path:** CLI providers are themselves LLM agents. When they receive Synthadoc's JSON wire-format system prompt (`{"tool_call": ...}` protocol), they correctly identify it as prompt injection and refuse to follow it. Each workflow implements a Python-driven path (`run_for_cli_provider`) that calls the same tool functions directly from code — no wire-format loop involved.
 

--- a/docs/user-quick-start-guide.md
+++ b/docs/user-quick-start-guide.md
@@ -2118,6 +2118,8 @@ The lint report also shows a **Citation Issues** section listing any broken, out
 synthadoc lint report
 ```
 
+→ To fix broken citations automatically, use the **[Broken Citation Resolver workflow](#demo--broken-citation-resolver)** — it fuzzy-matches renamed source files, removes malformed markers, and confirms every fix before writing.
+
 ### Checking citation faithfulness
 
 The structural citation check confirms that each `^[filename:L-L]` marker references a known source file and valid line range. **Citation faithfulness** goes further: it uses an LLM to verify that the claim text preceding each marker is actually supported by those source lines.

--- a/synthadoc/agents/workflows/_loop.py
+++ b/synthadoc/agents/workflows/_loop.py
@@ -182,10 +182,18 @@ async def run_tool_call_loop(
             messages.append(Message(role="assistant", content=text))
             # Single call: return the result dict directly (backward-compatible format).
             # Multiple calls: return the list so the LLM sees all results at once.
+            # Use json.dumps (not str()) so the LLM receives standard JSON instead of
+            # Python repr — double-quoted keys, null/true/false instead of None/True/False.
             if len(combined) == 1:
-                messages.append(Message(role="user", content=str(combined[0]["result"])))
+                messages.append(Message(
+                    role="user",
+                    content=json.dumps(combined[0]["result"], ensure_ascii=False, default=str),
+                ))
             else:
-                messages.append(Message(role="user", content=str(combined)))
+                messages.append(Message(
+                    role="user",
+                    content=json.dumps(combined, ensure_ascii=False, default=str),
+                ))
 
         else:
             # Plain-text response — stream as token chunks, then emit final_text.

--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -571,7 +571,14 @@ async def tool_find_broken_citations(
         msg = f"No broken citations found on {scope_label}"
 
     await ctx.send_sse_event("tool_progress", {"tool": "find_broken_citations", "message": msg})
-    return {"pages": pages_with_issues, "scanned": n_scanned, "total_issues": total_issues}
+    # "clean" is a top-level boolean so the LLM can check a single field rather
+    # than evaluating total_issues == 0, which some model versions misread.
+    return {
+        "clean": total_issues == 0,
+        "total_issues": total_issues,
+        "pages": pages_with_issues,
+        "scanned": n_scanned,
+    }
 
 
 async def tool_apply_citation_fixes(

--- a/synthadoc/agents/workflows/_tools.py
+++ b/synthadoc/agents/workflows/_tools.py
@@ -491,7 +491,12 @@ async def tool_find_broken_wikilinks(
         msg = f"No broken wikilinks found on {scope_label}"
 
     await ctx.send_sse_event("tool_progress", {"tool": "find_broken_wikilinks", "message": msg})
-    result: dict = {"pages": pages_with_issues, "scanned": len(scan_slugs), "total_broken": total_broken}
+    result: dict = {
+        "has_issues": total_broken > 0,
+        "pages": pages_with_issues,
+        "scanned": len(scan_slugs),
+        "total_broken": total_broken,
+    }
     if page_slug is not None:
         result["page_title"] = page_title   # display title for use in single-page summary
     return result

--- a/synthadoc/agents/workflows/broken_citation_resolver.py
+++ b/synthadoc/agents/workflows/broken_citation_resolver.py
@@ -89,7 +89,11 @@ get_wiki_status
 ━━━ SINGLE-PAGE MODE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 When the initial message specifies a page_slug, operate in single-page mode:
 - Call find_broken_citations EXACTLY ONCE with that page_slug.
-- If total_issues == 0: respond "No broken citations found on '<slug>'." STOP.
+- Check the "clean" field in the tool result (true = no issues, false = issues found).
+- If clean == true: respond "No broken citations found on '<slug>'." STOP.
+- If clean == false: proceed to STEP 3 — DO NOT output "No broken citations found".
+  The tool result is the authoritative source. NEVER apply your own judgment.
+  NEVER output "No broken citations found" when clean == false.
 - Do NOT call find_broken_citations without a page_slug in single-page mode.
 - Do NOT scan the whole wiki.
 - STEP 5 summary covers only the specified page.
@@ -101,9 +105,11 @@ STEP 1 — Discover (full-wiki mode only; skip if a page_slug was given)
   Call find_broken_citations (no arguments) for a full-wiki scan.
 
 STEP 2 — Check for work
-  If total_issues == 0: respond with plain text
+  Check the "clean" field in the find_broken_citations result.
+  If clean == true (no issues found): respond with plain text
   "No broken citations found — all ^[file:L-L] markers are valid."
   DO NOT call any more tools.
+  If clean == false (issues found): proceed to STEP 3 immediately.
 
 STEP 3 — Report and confirm
   ⚠ Do NOT output any plain text here. Plain text ends the workflow.

--- a/synthadoc/agents/workflows/broken_wikilinks.py
+++ b/synthadoc/agents/workflows/broken_wikilinks.py
@@ -38,7 +38,8 @@ Scan pages for broken [[slug]] references.  Returns fuzzy suggestions
 (difflib, stdlib) for likely typos.
 Input:  {"page_slug": str}   — scan only that one page (single-page mode)
      OR {}                   — scan all active pages (full-wiki mode)
-Output: {"pages": [{"slug": str, "broken_links": [{"ref": str, "suggestion": str|null}]}],
+Output: {"has_issues": bool,   — TRUE when broken links were found, FALSE when clean
+         "pages": [{"slug": str, "broken_links": [{"ref": str, "suggestion": str|null}]}],
          "scanned": int, "total_broken": int,
          "page_title": str|null}   — display title, present only in single-page mode
 
@@ -75,12 +76,14 @@ When you have no more tool calls to make, produce a plain-text summary (no JSON)
 
 ### Phase 1 — Scan
 1. Call find_broken_wikilinks (no arguments).
-2. Check total_broken in the result:
-   - If total_broken == 0: write the clean-wiki summary below and STOP.
-     Do NOT call any more tools.
-   - If total_broken > 0: your NEXT action MUST be a confirm tool call (step 5).
-     Do NOT write any plain text yet. Plain text ends the workflow — you may only
-     write plain text AFTER completing all of Phase 2 (steps 4–9).
+2. Check the "has_issues" field in the result:
+   - If has_issues == false (no broken links): write the clean-wiki summary below
+     and STOP.  Do NOT call any more tools.
+   - If has_issues == true (broken links found): your NEXT action MUST be a confirm
+     tool call (step 5).  Do NOT write any plain text yet.  Plain text ends the
+     workflow — you may only write plain text AFTER completing all of Phase 2
+     (steps 4–9).
+     NEVER call apply_link_fixes as the next step — confirm MUST come first.
 
 #### Clean-wiki summary template (only when total_broken == 0)
 Single-page mode: "No broken wikilinks found on the <page_title> page."
@@ -128,6 +131,12 @@ When find_broken_wikilinks reports total_broken > 0 and the user confirms:
 You MUST call confirm (step 5) and receive {"confirmed": true} before calling
 apply_link_fixes.  If confirmed is false, write the cancellation message and STOP —
 do NOT call apply_link_fixes, run_lint, or get_page_states.
+
+NEVER call apply_link_fixes immediately after find_broken_wikilinks.
+The mandatory order is: find_broken_wikilinks → confirm → apply_link_fixes.
+If you call apply_link_fixes before confirm, you have made an error.
+The tool result's "has_issues" field is the authoritative signal — check it, then
+call confirm, then and only then proceed to apply_link_fixes.
 
 ### Never exit to plain text while broken links remain unfixed
 When find_broken_wikilinks returns total_broken > 0, producing a plain-text response

--- a/synthadoc/core/export.py
+++ b/synthadoc/core/export.py
@@ -451,9 +451,15 @@ class ExportAgent:
 _CITATION_RE = re.compile(r"\^\[[^\]]*\]")
 
 
+_HR_PATTERNS = frozenset({"---", "***", "___", "- - -", "* * *", "_ _ _"})
+
+
 def _first_sentence(text: str) -> str:
     text = text.strip()
-    lines = [ln for ln in text.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+    lines = [
+        ln for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#") and ln.strip() not in _HR_PATTERNS
+    ]
     flat = " ".join(lines[:3])
     flat = _CITATION_RE.sub("", flat)          # strip ^[...] citation markers
     flat = _WIKILINK_RE.sub(                   # strip [[wikilinks]] → display text only

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -333,9 +333,12 @@ def _okf_validate(bundle: dict) -> None:
         warn("POST /export (okf) spec-check", "PyYAML not available — skipping content validation")
         return
 
+    import re as _re_fm
+    _FM_SEP = _re_fm.compile(r"^---\s*$", _re_fm.MULTILINE)
+
     def _fm(text: str) -> dict:
         if text.startswith("---"):
-            parts = text.split("---", 2)
+            parts = _FM_SEP.split(text, 2)
             if len(parts) >= 3:
                 return _yaml.safe_load(parts[1]) or {}
         return {}
@@ -369,7 +372,7 @@ def _okf_validate(bundle: dict) -> None:
         desc = fm.get("description", "")
         if desc and "\n" in desc:
             newline_desc.append(path)
-        body = bundle[path].split("---", 2)[-1] if "---" in bundle[path] else bundle[path]
+        body = _FM_SEP.split(bundle[path], 2)[-1] if "---" in bundle[path] else bundle[path]
         if _WIKILINK_PAT.search(body):
             has_wikilinks.append(path)
 

--- a/tests/live/test_agentic_ingest_lint_live.py
+++ b/tests/live/test_agentic_ingest_lint_live.py
@@ -651,6 +651,7 @@ def test_query_done_pre_prompt_present_when_stale_pages_exist():
 
 
 @pytest.mark.live
+@pytest.mark.timeout(120)
 def test_query_done_pre_prompt_absent_when_no_stale_pages():
     """
     When no actionable pages exist (no stale, no contradicted), the done SSE

--- a/tests/live/test_scaffold_workflow_live.py
+++ b/tests/live/test_scaffold_workflow_live.py
@@ -340,7 +340,7 @@ def test_scaffold_progress_label_says_scaffold_not_ingest():
 # ══════════════════════════════════════════════════════════════════════════════
 
 @pytest.mark.live
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(360)
 def test_two_phrasings_both_trigger_workflow():
     """
     Both canonical trigger phrasings must route to ScaffoldWorkflow
@@ -352,7 +352,7 @@ def test_two_phrasings_both_trigger_workflow():
         "regenerate scaffold",
     ]
     for phrase in phrasings:
-        events = _stream_with_confirm_response(phrase, accept=False, timeout=90)
+        events = _stream_with_confirm_response(phrase, accept=False, timeout=150)
         _assert_stream_complete(events)
 
         tool_names = _tool_names(events)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -381,10 +381,15 @@ def _write_okf_page(store, slug, title, status, content="", type_=None,
     store.write_page(slug, page)
 
 
+import re as _re_export_test
+
+_FM_SEP = _re_export_test.compile(r"^---\s*$", _re_export_test.MULTILINE)
+
+
 def _parse_frontmatter(text: str) -> dict:
     import yaml
     if text.startswith("---"):
-        parts = text.split("---", 2)
+        parts = _FM_SEP.split(text, 2)
         if len(parts) >= 3:
             return yaml.safe_load(parts[1]) or {}
     return {}
@@ -530,7 +535,7 @@ async def test_okf_wikilinks_rewritten_to_relative_paths(tmp_path):
                     content="Compiler pioneer.", type_="person")
     agent = _agent(tmp_path, store)
     result = await agent.run(ExportOptions(format="okf"))
-    body = result["wiki/alan-turing.md"].split("---", 2)[2]
+    body = _FM_SEP.split(result["wiki/alan-turing.md"], 2)[2]
     assert "[[grace-hopper]]" not in body
     assert "[Grace Hopper](grace-hopper.md)" in body
 
@@ -609,7 +614,7 @@ async def test_okf_contradiction_note_appended_to_body(tmp_path):
     store.write_page("conflict-page", page)
     agent = _agent(tmp_path, store)
     result = await agent.run(ExportOptions(format="okf"))
-    body = result["wiki/conflict-page.md"].split("---", 2)[2]
+    body = _FM_SEP.split(result["wiki/conflict-page.md"], 2)[2]
     assert "Source B says the opposite." in body
     assert "> **Contradiction:**" in body
 
@@ -630,7 +635,7 @@ async def test_okf_wikilinks_in_contradiction_note_are_rewritten(tmp_path):
                     content="Correct claim.")
     agent = _agent(tmp_path, store)
     result = await agent.run(ExportOptions(format="okf"))
-    body = result["wiki/conflict-page.md"].split("---", 2)[2]
+    body = _FM_SEP.split(result["wiki/conflict-page.md"], 2)[2]
     assert "[[other-page]]" not in body, "wikilink in contradiction_note was not rewritten"
     assert "[Other Page](other-page.md)" in body
 
@@ -681,6 +686,30 @@ def test_first_sentence_strips_piped_wikilinks():
     result = _first_sentence("Developed by [[grace-hopper|Grace Hopper]]. More follows.")
     assert "[[" not in result
     assert "Grace Hopper" in result
+
+
+def test_first_sentence_skips_horizontal_rules():
+    """Markdown horizontal rules (--- / *** / ___) are skipped so they never
+    appear in the OKF description field (and thus never cause YAML quoting of
+    '---' that would break naive frontmatter splitting)."""
+    assert _first_sentence("---\nThe real content here. More follows.") == "The real content here."
+    assert _first_sentence("***\nStars rule skipped. More follows.") == "Stars rule skipped."
+    assert _first_sentence("___\nUnderscore rule skipped. More follows.") == "Underscore rule skipped."
+
+
+@pytest.mark.asyncio
+async def test_okf_description_survives_horizontal_rule_content(tmp_path):
+    """OKF export of a page whose content opens with '---' must produce
+    valid YAML frontmatter (i.e. description must not contain '---')."""
+    store = _make_store(tmp_path)
+    _write_okf_page(store, "hr-page", "HR Page", LifecycleState.ACTIVE,
+                    content="---\nActual description sentence. More detail follows.", type_="concept")
+    agent = _agent(tmp_path, store)
+    result = await agent.run(ExportOptions(format="okf"))
+    fm = _parse_frontmatter(result["wiki/hr-page.md"])
+    assert fm.get("description") == "Actual description sentence."
+    # description must not carry the Markdown horizontal rule
+    assert "---" not in fm.get("description", "")
 
 
 def test_rewrite_wikilinks_piped_form():
@@ -803,6 +832,6 @@ async def test_okf_spec_wikilinks_resolved_to_markdown(tmp_path):
                     content="Designed the Difference Engine.", type_="person")
     agent = _agent(tmp_path, store)
     result = await agent.run(ExportOptions(format="okf"))
-    body = result["wiki/ada.md"].split("---", 2)[2]
+    body = _FM_SEP.split(result["wiki/ada.md"], 2)[2]
     assert "[[" not in body, "wikilinks must be rewritten to markdown links"
     assert "[Charles Babbage](babbage.md)" in body


### PR DESCRIPTION
Three bug fixes identified from live test runs after v1.3.2.

### Fix 1 — OKF YAML parse failure when page content starts with `---`

**Symptom:** `yaml.scanner.ScannerError` in the live plugin test when parsing OKF bundle frontmatter.

**Root cause (two bugs compounding):**
- `_first_sentence()` included Markdown horizontal-rule lines (`---`, `***`,  `___`) in the description text it returned.
- PyYAML single-quoted strings containing `---` (a YAML document separator),  producing `description: '---'`.
- The naive `text.split("---", 2)` in the test helpers then split at the embedded `---` inside the quoted scalar, truncating the YAML mid-value.

**Fix (`3813f81`):**
- `_first_sentence()` now filters out `_HR_PATTERNS` lines before extracting the first sentence.
- All frontmatter parsers (export tests, live plugin test) use a `re.compile(r"^---\s*$", re.MULTILINE).split()` regex that only matches
  `---` at the start of a line, safely ignoring embedded occurrences.

---

### Fix 2 — BCR: LLM outputs "No broken citations found" despite `total_issues=1`

**Symptom:** `test_fixes_broken_ref` — tool finds 1 broken citation; LLM reports none.

**Root cause (two compounding issues):**
- `_loop.py` serialised tool results with `str()` (Python repr — single-quoted keys, `None`/`True`/`False`), a non-standard format the LLM misread.
- The system prompt condition `total_issues == 0` is numeric; the LLM pattern-matched the response template rather than evaluating the value.

**Fix (`d15a1f8`):**
- `_loop.py` now uses `json.dumps()` for all tool results (double-quoted keys, `null`/`true`/`false`).
- `tool_find_broken_citations` now returns `"clean": bool`.
- BCR system prompt updated to check `clean == true/false` with an explicit guard: _"NEVER output 'No broken citations found' when clean == false."_

Also in the same commit: raised `test_two_phrasings_both_trigger_workflow` pytest timeout 180 → 360 s and per-phrase server timeout 90 → 150 s (API latency under test load), and added `@pytest.mark.timeout(120)` to `test_query_done_pre_prompt_absent_when_no_stale_pages` (previously defaulted to the pyproject.toml 60 s floor).

---

### Fix 3 — Broken Wikilinks: LLM skips `confirm` and calls `apply_link_fixes` directly

**Symptom:** `test_declined_workflow_makes_no_changes` — `apply_link_fixes` appears in tool events despite confirmation being declined.

**Root cause:** The LLM would occasionally call `apply_link_fixes` immediately after `find_broken_wikilinks` without calling `confirm` first. The GATED_TOOLS fallback prevented the actual write, but `_loop.py` emits `tool_progress` before the gate function runs, so the tool appeared in events and the assertion fired.

**Fix (`edd92cd`):**
- `tool_find_broken_wikilinks` now returns `"has_issues": bool` — an explicit boolean the LLM can check without numeric reasoning.
- System prompt updated to use `has_issues == true/false` throughout.
- Added explicit NEVER directive and mandatory ordering statement: `find_broken_wikilinks → confirm → apply_link_fixes`.

---

### Tests

2930 non-live tests pass. All three fixes address live test failures observed against a running server.