### PR TITLE
fix(providers): auto-retry opencode on silent stdout; add new event l…

### DIFF
--- a/synthadoc/providers/coding_tool.py
+++ b/synthadoc/providers/coding_tool.py
@@ -327,11 +327,49 @@ class OpencodeProvider(CodingToolCLIProvider):
     """
     _tool_binary = "opencode"
 
+    # Seconds to wait before the single automatic retry on silent-output failures.
+    _SILENT_RETRY_DELAY = 2.0
+
     def _build_command(self, binary: str) -> list[str]:
         cmd = [binary, "run", "--format", "json"]
         if self._model:
             cmd += ["--model", self._model]
         return cmd
+
+    async def complete(
+        self,
+        messages: list[Message],
+        system: Optional[str] = None,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+    ) -> CompletionResponse:
+        """Complete with a single automatic retry on silent-output failures.
+
+        opencode occasionally exits cleanly (returncode 0, reason=stop) but emits
+        no text events to stdout even though the model generated tokens — the text
+        is flushed to its session database instead.  One transparent retry covers
+        this transient case without cascading into a permanent failure for the whole
+        batch-ingest job.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, 3):
+            try:
+                return await super().complete(
+                    messages, system=system,
+                    temperature=temperature, max_tokens=max_tokens,
+                )
+            except ValueError as exc:
+                last_exc = exc
+                if attempt < 2 and "no text content" in str(exc):
+                    _logger.warning(
+                        "opencode: no text in JSONL output on attempt %d/2 — "
+                        "retrying in %.1fs (transient stdout-flush issue).",
+                        attempt, self._SILENT_RETRY_DELAY,
+                    )
+                    await asyncio.sleep(self._SILENT_RETRY_DELAY)
+                    continue
+                raise
+        raise last_exc  # type: ignore[misc]  # unreachable, but satisfies type-checker
 
     def _parse_output(self, raw: str) -> CompletionResponse:
         _logger.debug("opencode raw output (%d bytes):\n%s", len(raw), raw[:4000])
@@ -340,6 +378,7 @@ class OpencodeProvider(CodingToolCLIProvider):
         input_tokens = 0
         output_tokens = 0
         seen_types: list[str] = []
+        session_id: str | None = None
 
         for line in raw.splitlines():
             line = line.strip()
@@ -353,6 +392,13 @@ class OpencodeProvider(CodingToolCLIProvider):
             etype = event.get("type", "")
             if etype:
                 seen_types.append(etype)
+
+            # Capture session ID from any event for diagnostics.
+            if not session_id:
+                session_id = (
+                    event.get("sessionID")
+                    or (event.get("part") or {}).get("sessionID")
+                )
 
             # --- text content ---
             # Layout A: {"type":"text","data":"..."}
@@ -383,6 +429,28 @@ class OpencodeProvider(CodingToolCLIProvider):
                         if chunk:
                             text_parts.append(chunk)
 
+            # Layout E: streaming text delta (content_block_delta / text_delta).
+            # Seen in newer opencode versions that proxy OpenAI-compatible streaming.
+            elif etype in ("content_block_delta", "text_delta"):
+                delta = event.get("delta") or event
+                chunk = delta.get("text") or delta.get("data") or ""
+                if chunk:
+                    text_parts.append(chunk)
+
+            # Layout F: message-level wrappers carrying assistant content.
+            elif etype in ("message", "message_start", "message_delta"):
+                msg = event.get("message") or event.get("data") or event
+                if isinstance(msg, dict):
+                    content = msg.get("content") or ""
+                    if isinstance(content, str) and content:
+                        text_parts.append(content)
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                chunk = block.get("text") or ""
+                                if chunk:
+                                    text_parts.append(chunk)
+
             elif etype == "error":
                 err = event.get("error") or {}
                 msg = (err.get("data") or {}).get("message") or err.get("name") or "unknown error"
@@ -397,9 +465,17 @@ class OpencodeProvider(CodingToolCLIProvider):
             elif etype == "step_finish":
                 if event.get("reason") == "error":
                     raise RuntimeError("opencode: step finished with error")
-                tokens = event.get("tokens") or {}
-                input_tokens = int(tokens.get("input", 0))
-                output_tokens = int(tokens.get("output", 0))
+                # Tokens may be on the outer event or inside the part sub-object.
+                tokens = (
+                    event.get("tokens")
+                    or (event.get("part") or {}).get("tokens")
+                    or {}
+                )
+                _in = int(tokens.get("input", 0))
+                _out = int(tokens.get("output", 0))
+                if _in or _out:
+                    input_tokens = _in
+                    output_tokens = _out
 
             elif etype in ("message_finish", "session_end"):
                 info = event.get("info") or event.get("properties") or {}
@@ -408,16 +484,29 @@ class OpencodeProvider(CodingToolCLIProvider):
                     input_tokens = int(usage.get("input", 0) or usage.get("input_tokens", 0))
                     output_tokens = int(usage.get("output", 0) or usage.get("output_tokens", 0))
 
+            else:
+                # Layout G (catch-all for future opencode versions): if an event
+                # carries a part sub-object whose type is "text", extract the text
+                # rather than silently dropping it.
+                part = event.get("part") or {}
+                if isinstance(part, dict) and part.get("type") == "text":
+                    chunk = part.get("text") or part.get("data") or ""
+                    if chunk:
+                        text_parts.append(chunk)
+
         if not text_parts:
             _logger.warning(
-                "opencode: no text content extracted. Event types seen: %s\n"
+                "opencode: no text content extracted. Event types seen: %s%s\n"
                 "Raw output (first 2000 chars):\n%s",
-                sorted(set(seen_types)), raw[:2000],
+                sorted(set(seen_types)),
+                f" | session_id={session_id}" if session_id else "",
+                raw[:2000],
             )
             raise ValueError(
                 f"opencode: no text content in JSONL output. "
                 f"Event types seen: {sorted(set(seen_types))}. "
-                f"Check DEBUG logs for the full raw output."
+                + (f"session_id={session_id} — use 'opencode session show {session_id}' to inspect. " if session_id else "")
+                + "Check DEBUG logs for the full raw output."
             )
 
         return CompletionResponse(

--- a/tests/providers/test_coding_tool_providers.py
+++ b/tests/providers/test_coding_tool_providers.py
@@ -435,3 +435,173 @@ def test_opencode_parse_output_benchmark():
     elapsed_ms = (time.perf_counter() - start) * 1000
     assert len(resp.text) > 0
     assert elapsed_ms < 50, f"_parse_output took {elapsed_ms:.1f}ms (limit: 50ms)"
+
+
+# ── OpencodeProvider: new event layouts (post-refactor) ───────────────────────
+
+def test_opencode_parse_output_content_block_delta():
+    """Layout E: content_block_delta events with nested delta.text."""
+    import json
+    provider = _make_opencode_provider()
+    lines = [
+        json.dumps({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Hello "}}),
+        json.dumps({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "world"}}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 10, "output": 5}}),
+    ]
+    resp = provider._parse_output("\n".join(lines))
+    assert resp.text == "Hello world"
+    assert resp.input_tokens == 10
+
+
+def test_opencode_parse_output_text_delta_event():
+    """Layout E: top-level text_delta event type."""
+    import json
+    provider = _make_opencode_provider()
+    lines = [
+        json.dumps({"type": "text_delta", "text": "Foo bar"}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 5, "output": 3}}),
+    ]
+    resp = provider._parse_output("\n".join(lines))
+    assert resp.text == "Foo bar"
+
+
+def test_opencode_parse_output_message_event_string_content():
+    """Layout F: message event with content as a string."""
+    import json
+    provider = _make_opencode_provider()
+    lines = [
+        json.dumps({"type": "message", "role": "assistant",
+                    "message": {"role": "assistant", "content": "Baz"}}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 1, "output": 1}}),
+    ]
+    resp = provider._parse_output("\n".join(lines))
+    assert resp.text == "Baz"
+
+
+def test_opencode_parse_output_catch_all_part_type_text():
+    """Layout G (catch-all): unknown outer event type with part.type=='text'."""
+    import json
+    provider = _make_opencode_provider()
+    lines = [
+        json.dumps({"type": "future_event_x", "part": {"type": "text", "text": "Catch-all text"}}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 5, "output": 5}}),
+    ]
+    resp = provider._parse_output("\n".join(lines))
+    assert resp.text == "Catch-all text"
+
+
+def test_opencode_parse_output_step_finish_tokens_in_part():
+    """Tokens inside step_finish.part sub-object are extracted correctly."""
+    import json
+    provider = _make_opencode_provider()
+    lines = [
+        json.dumps({"type": "text", "data": "Hi"}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "part": {"type": "step-finish", "reason": "stop",
+                              "tokens": {"input": 42, "output": 17}}}),
+    ]
+    resp = provider._parse_output("\n".join(lines))
+    assert resp.text == "Hi"
+    assert resp.input_tokens == 42
+    assert resp.output_tokens == 17
+
+
+def test_opencode_parse_output_session_id_in_error_message():
+    """session_id from events is included in the ValueError message."""
+    import json
+    provider = _make_opencode_provider()
+    lines = [
+        json.dumps({"type": "step_start", "sessionID": "ses_abc123",
+                    "part": {"type": "step-start"}}),
+        json.dumps({"type": "step_finish", "sessionID": "ses_abc123", "reason": "stop",
+                    "tokens": {"input": 10, "output": 5}}),
+    ]
+    with pytest.raises(ValueError, match="ses_abc123"):
+        provider._parse_output("\n".join(lines))
+
+
+# ── OpencodeProvider: auto-retry on silent output ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_opencode_complete_retries_on_no_text_content():
+    """complete() retries once when _parse_output raises 'no text content'."""
+    import json
+    provider = _make_opencode_provider()
+
+    # First call: only step events (no text) → triggers retry.
+    silent_output = "\n".join([
+        json.dumps({"type": "step_start", "sessionID": "ses_x"}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 10, "output": 50}}),
+    ]).encode()
+
+    # Second call: text present → succeeds.
+    good_output = "\n".join([
+        json.dumps({"type": "text", "data": "Retry succeeded"}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 10, "output": 5}}),
+    ]).encode()
+
+    calls = 0
+
+    async def _fake_exec(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _make_mock_proc(
+            silent_output if calls == 1 else good_output,
+            b"", returncode=0,
+        )
+
+    from synthadoc.providers.base import Message
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        with patch("asyncio.sleep", new_callable=AsyncMock):  # skip real sleep
+            resp = await provider.complete([Message(role="user", content="hi")])
+
+    assert calls == 2, f"Expected 2 subprocess calls, got {calls}"
+    assert resp.text == "Retry succeeded"
+
+
+@pytest.mark.asyncio
+async def test_opencode_complete_raises_after_two_silent_failures():
+    """complete() raises ValueError after both attempts return no text."""
+    import json
+    provider = _make_opencode_provider()
+
+    silent_output = "\n".join([
+        json.dumps({"type": "step_start", "sessionID": "ses_y"}),
+        json.dumps({"type": "step_finish", "reason": "stop",
+                    "tokens": {"input": 5, "output": 20}}),
+    ]).encode()
+
+    async def _fake_exec(*args, **kwargs):
+        return _make_mock_proc(silent_output, b"", returncode=0)
+
+    from synthadoc.providers.base import Message
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(ValueError, match="no text content"):
+                await provider.complete([Message(role="user", content="hi")])
+
+
+@pytest.mark.asyncio
+async def test_opencode_complete_does_not_retry_on_other_errors():
+    """complete() does NOT retry when the error is not 'no text content'."""
+    provider = _make_opencode_provider()
+
+    calls = 0
+
+    async def _fake_exec(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _make_mock_proc(b"", b"auth failed", returncode=1)
+
+    from synthadoc.providers.base import Message
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        with pytest.raises(RuntimeError, match="auth failed"):
+            await provider.complete([Message(role="user", content="hi")])
+
+    assert calls == 1, "Should not retry on non-ValueError errors"


### PR DESCRIPTION
…ayouts

opencode occasionally exits cleanly (reason=stop, returncode=0) but emits only step_start/step_finish events to stdout — the text is flushed to its session database instead.  Fix in three layers:

1. Auto-retry once in OpencodeProvider.complete() when _parse_output raises 'no text content'.  A 2-second pause separates the attempts so the second subprocess gets a fresh opencode session.  Two consecutive silent failures still raise, so the ingest worker records the job as failed and moves on.

2. Expand _parse_output to handle newer opencode event layouts:
   - Layout E: content_block_delta / text_delta (OpenAI-compatible streaming)
   - Layout F: message / message_start / message_delta with string or list content
   - Layout G (catch-all): any event whose part.type == 'text' — covers future opencode versions that wrap text in typed part objects
   - Tokens: also read step_finish.part.tokens (some builds put them there)

3. Diagnostics: capture session_id from any event and include it in the ValueError message as 'session_id=ses_...' so the operator can run 'opencode session show <id>' to inspect the stored response.


issue: https://github.com/axoviq-ai/synthadoc/issues/374