### PR TITLE
fix(workflows): show subscription note instead of dollar cost for CLI providers

### DIFF
--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -424,6 +424,7 @@ class ActionAgent(BaseAgent):
         _session_id = session_id or str(_uuid.uuid4())
         _cfg = getattr(self._orch, "_cfg", None)
         _domain = getattr(getattr(_cfg, "wiki", None), "domain", "") or ""
+        from synthadoc.providers.coding_tool import CodingToolCLIProvider  # noqa: PLC0415
         ctx = WorkflowContext(
             session_id=_session_id,
             wiki_root=self._wiki_root,
@@ -439,6 +440,7 @@ class ActionAgent(BaseAgent):
                 getattr(self._orch, "_search", None), "invalidate_index", None
             ),
             search=getattr(self._orch, "_search", None),
+            is_cli_provider=isinstance(self._provider, CodingToolCLIProvider),
         )
 
         wf = workflow if workflow is not None else IngestLintWorkflow()
@@ -452,7 +454,6 @@ class ActionAgent(BaseAgent):
         # Workflows that set SUPPORTS_CLI_PROVIDER = True implement a one-shot
         # Python-driven path via ``run_for_cli_provider`` that avoids fake tools
         # entirely.  Others receive a clear error message with guidance.
-        from synthadoc.providers.coding_tool import CodingToolCLIProvider  # noqa: PLC0415
         if isinstance(self._provider, CodingToolCLIProvider):
             if not wf.SUPPORTS_CLI_PROVIDER:
                 binary = getattr(self._provider, "_tool_binary", "this CLI tool")

--- a/synthadoc/agents/workflows/_base.py
+++ b/synthadoc/agents/workflows/_base.py
@@ -85,6 +85,20 @@ class WorkflowContext:
     # BM25/vector search instance — used by tool_search_orphan_candidates.
     # None in tests that don't need search access.
     search: "HybridSearch | None" = None  # type: ignore[name-defined]
+    # True when the active provider is a CodingToolCLIProvider (opencode, claude-code).
+    # Used by cost-estimate tools to substitute "Covered by coding tool subscription"
+    # for the dollar figure — CLI providers bill via their own subscription, not per-token.
+    is_cli_provider: bool = False
+
+    def cost_label(self, usd: float) -> str:
+        """Human-readable cost string for a workflow estimate.
+
+        CLI providers (opencode, claude-code) bill via their own subscription,
+        so a per-token dollar figure would be misleading.
+        """
+        if self.is_cli_provider:
+            return "Covered by coding tool subscription"
+        return f"~${usd:.2f}"
 
 
 class AgenticWorkflow(ABC):

--- a/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
@@ -137,10 +137,12 @@ async def tool_cost_estimate(ctx: "WorkflowContext", page_count: int) -> dict:
         "estimated_minutes": minutes,
     }
 
+    cost_label = ctx.cost_label(estimate["estimated_usd"])
+
     # Show the estimate as a notice so the user can read it while the ConfirmCard loads.
     notice_text = (
         f"Updated estimate: {page_count} page(s), "
-        f"~${estimate['estimated_usd']:.2f}, "
+        f"{cost_label}, "
         f"about {estimate['estimated_minutes']} minute(s)."
     )
     try:
@@ -148,13 +150,13 @@ async def tool_cost_estimate(ctx: "WorkflowContext", page_count: int) -> dict:
     except Exception:  # noqa: BLE001
         pass
 
-    # Ask for approval — this blocks until the user responds (or 120 s timeout).
+    # Ask for approval — this blocks until the user responds (or 300 s timeout).
     confirm_result = await tool_confirm(
         ctx,
         message=(
             f"**Contradiction Resolver — ready to start**\n\n"
             f"- Pages to process: **{page_count}**\n"
-            f"- Estimated cost: ~**${estimate['estimated_usd']:.2f}**\n"
+            f"- Estimated cost: **{cost_label}**\n"
             f"- Estimated time: ~**{estimate['estimated_minutes']} min**\n\n"
             "Proceed with resolution?"
         ),

--- a/synthadoc/agents/workflows/tools/orphan_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/orphan_resolver_tools.py
@@ -145,7 +145,7 @@ async def tool_estimate_and_confirm(
         f"  Pages to process:    {orphan_count}\n"
         f"  Estimated tool calls: ~{estimated_calls}\n"
         f"  Estimated time:       ~{estimated_minutes} min\n"
-        f"  Estimated cost:       ~${estimated_usd:.2f} USD\n"
+        f"  Estimated cost:       {ctx.cost_label(estimated_usd)}\n"
         f"\nProceed with orphan resolver?"
     )
     result = await tool_confirm(ctx, message, yes_label="Proceed", no_label="Cancel")

--- a/tests/agents/workflows/test_tools.py
+++ b/tests/agents/workflows/test_tools.py
@@ -1374,3 +1374,21 @@ async def test_transition_lifecycle_set_page_state_exception_is_swallowed(tmp_pa
     assert result["success"] is True
     # set_page_state raised but the result is still success
     audit_db.set_page_state.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# WorkflowContext.cost_label
+# ---------------------------------------------------------------------------
+
+def test_cost_label_api_provider_formats_dollars():
+    ctx, _ = _make_ctx()
+    # Default: is_cli_provider=False → dollar amount
+    assert ctx.cost_label(0.06) == "~$0.06"
+    assert ctx.cost_label(1.23456) == "~$1.23"
+
+
+def test_cost_label_cli_provider_returns_subscription_note():
+    ctx, _ = _make_ctx()
+    ctx.is_cli_provider = True
+    assert ctx.cost_label(0.06) == "Covered by coding tool subscription"
+    assert ctx.cost_label(0.0) == "Covered by coding tool subscription"

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -534,3 +534,41 @@ def test_session_purge_does_not_reference_session_state(tmp_wiki):
         "_worker_loop must not reference _session_state directly (it is out of scope); "
         "pass it as the session_state parameter instead"
     )
+
+
+# ---------------------------------------------------------------------------
+# /lint/report — contradiction detection uses parsed frontmatter
+# ---------------------------------------------------------------------------
+
+def test_lint_report_skips_system_slugs_and_handles_bad_yaml(tmp_wiki):
+    """/lint/report skips LINT_SKIP_SLUGS and doesn't crash on malformed YAML."""
+    from fastapi.testclient import TestClient
+    from synthadoc.storage.wiki import SYSTEM_PAGE_SLUGS
+
+    wiki_dir = tmp_wiki / "wiki"
+    # A system slug — should be skipped (exercises the `continue` branch).
+    skip_slug = next(iter(SYSTEM_PAGE_SLUGS))
+    (wiki_dir / f"{skip_slug}.md").write_text(
+        "---\nstatus: contradicted\n---\nSystem page.\n", encoding="utf-8"
+    )
+    # Malformed YAML frontmatter — exercises the `except Exception: pass` branch.
+    (wiki_dir / "bad-yaml.md").write_text(
+        "---\nstatus: [unclosed\n---\nContent.\n", encoding="utf-8"
+    )
+    # Normal active page — should not appear in contradictions.
+    (wiki_dir / "normal-page.md").write_text(
+        "---\nstatus: active\ntitle: Normal\n---\nContent.\n", encoding="utf-8"
+    )
+
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        resp = client.get("/lint/report")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    # The system slug must be excluded from contradictions even though its
+    # frontmatter says "contradicted".
+    assert skip_slug not in data["contradictions"]
+    # The malformed-YAML page must not cause a 500 and must not appear as
+    # contradicted (fm defaults to {} so status check is False).
+    assert "bad-yaml" not in data["contradictions"]


### PR DESCRIPTION
issue: https://github.com/axoviq-ai/synthadoc/issues/376

Description:
When opencode or claude-code is configured as the provider, the contradiction
resolver and orphan resolver estimate gates were showing a dollar figure
(e.g. `~$0.06`) even though there is no per-token billing — cost is covered
by the coding tool subscription.

**Changes** (commit: [#6a3ed01](https://github.com/axoviq-ai/synthadoc/pull/378/changes/6a3ed018622b8fa7d8cab97bc8e8ec1e024837ca))
**Tests** (commit: [#7ad5909](https://github.com/axoviq-ai/synthadoc/pull/378/changes/7ad59097a9bdd5a7d6955399883e4aec5d2caafa))