### PR TITLE
fix: language drift, CLI provider cost label, and ingest-lint live test failures

### DIFF
--- a/synthadoc/agents/action_agent.py
+++ b/synthadoc/agents/action_agent.py
@@ -424,6 +424,7 @@ class ActionAgent(BaseAgent):
         _session_id = session_id or str(_uuid.uuid4())
         _cfg = getattr(self._orch, "_cfg", None)
         _domain = getattr(getattr(_cfg, "wiki", None), "domain", "") or ""
+        from synthadoc.providers.coding_tool import CodingToolCLIProvider  # noqa: PLC0415
         ctx = WorkflowContext(
             session_id=_session_id,
             wiki_root=self._wiki_root,
@@ -439,6 +440,7 @@ class ActionAgent(BaseAgent):
                 getattr(self._orch, "_search", None), "invalidate_index", None
             ),
             search=getattr(self._orch, "_search", None),
+            is_cli_provider=isinstance(self._provider, CodingToolCLIProvider),
         )
 
         wf = workflow if workflow is not None else IngestLintWorkflow()
@@ -452,7 +454,6 @@ class ActionAgent(BaseAgent):
         # Workflows that set SUPPORTS_CLI_PROVIDER = True implement a one-shot
         # Python-driven path via ``run_for_cli_provider`` that avoids fake tools
         # entirely.  Others receive a clear error message with guidance.
-        from synthadoc.providers.coding_tool import CodingToolCLIProvider  # noqa: PLC0415
         if isinstance(self._provider, CodingToolCLIProvider):
             if not wf.SUPPORTS_CLI_PROVIDER:
                 binary = getattr(self._provider, "_tool_binary", "this CLI tool")

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -106,11 +106,53 @@ def _detect_cjk_language(text: str) -> str:
     return "Chinese (Mandarin)"
 
 
-def _history_block(history: list[dict]) -> str:
-    """Format conversation history as a preamble block for the synthesis prompt."""
+def _filter_history_by_language(
+    history: list[dict], question: str
+) -> list[dict]:
+    """Drop turn-pairs where the assistant response is in a different script than
+    the current question.
+
+    When a prior assistant turn was (incorrectly) produced in Chinese/Japanese/Korean
+    but the current question is in a Latin-script language, that turn biases the LLM
+    to repeat the wrong language even when the system prompt says otherwise.  Removing
+    the mismatched pair prevents the model from treating it as a precedent.
+
+    Only removes *pairs* (the user turn that preceded the mismatched assistant turn is
+    also dropped) so the history remains well-formed user/assistant alternation.
+    """
+    if not history:
+        return history
+    question_is_cjk = _has_cjk(question)
+    filtered: list[dict] = []
+    i = 0
+    while i < len(history):
+        msg = history[i]
+        if msg["role"] == "assistant":
+            response_is_cjk = _has_cjk(msg.get("content", ""))
+            if question_is_cjk != response_is_cjk:
+                # Language mismatch — drop this assistant turn AND its preceding user turn
+                if filtered and filtered[-1]["role"] == "user":
+                    filtered.pop()
+                i += 1
+                continue
+        filtered.append(msg)
+        i += 1
+    return filtered
+
+
+def _history_block(history: list[dict], question: str = "") -> str:
+    """Format conversation history as a preamble block for the synthesis prompt.
+
+    Filters out turns where the assistant responded in a different script than
+    *question* so that a prior incorrect-language response does not bias the model
+    into repeating that language.
+    """
     if not history:
         return ""
-    lines = "\n".join(f"{m['role'].capitalize()}: {m['content']}" for m in history)
+    kept = _filter_history_by_language(history, question) if question else history
+    if not kept:
+        return ""
+    lines = "\n".join(f"{m['role'].capitalize()}: {m['content']}" for m in kept)
     return f"\n[Conversation so far]\n{lines}\n"
 
 # Stopwords excluded when extracting key terms for the content-overlap gap check.
@@ -824,7 +866,7 @@ class QueryAgent(BaseAgent):
         history: list[dict] | None = None,
     ) -> str:
         """Build the LLM synthesis prompt. When history is provided it is prepended."""
-        prefix = _history_block(history) if history else ""
+        prefix = _history_block(history, question) if history else ""
         if gap:
             return prefix + (
                 f"The wiki does not yet have a dedicated page on this topic. "

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -791,6 +791,28 @@ class QueryAgent(BaseAgent):
             logger.debug("live wiki data fetch failed: %s", exc)
             return ""
 
+    def _build_synthesis_system(self, question: str) -> str:
+        """Return the language-enforcement system prompt for synthesis.
+
+        Keeping the language rule in the system prompt (rather than only in the
+        user-content turn) makes it significantly harder for the LLM to drift
+        into the language of conversation-history turns when the current question
+        is in a different language.
+        """
+        _lang = _detect_cjk_language(question) if _has_cjk(question) else ""
+        if _lang:
+            return (
+                f"The user's question is in {_lang}. "
+                f"You MUST respond in {_lang}. "
+                f"Do not respond in English or any other language, "
+                f"regardless of the conversation history."
+            )
+        return (
+            "Respond in the same language as the user's question. "
+            "Do NOT use the language of the wiki pages or the conversation history — "
+            "always match the language of the current question exactly."
+        )
+
     def _build_synthesis_prompt(
         self,
         question: str,
@@ -831,15 +853,10 @@ class QueryAgent(BaseAgent):
                 f"Do not reference or cite wiki page content.\n\n"
                 f"Question: {question}\n\nData:\n{context}"
             )
-        _lang = _detect_cjk_language(question) if _has_cjk(question) else ""
-        _lang_instr = (
-            f"The question is in {_lang}. Respond in {_lang}. Do not respond in English or any other language.\n"
-            if _lang
-            else "Respond in the same language as the Question below. Do not use the language of the Pages — always match the Question's language.\n"
-        )
         return prefix + (
             f"Answer using ONLY these wiki pages. Cite with [[PageTitle]].\n"
-            f"{_lang_instr}"
+            f"Respond in the same language as the Question. "
+            f"Do not use the language of the Pages or the conversation history.\n"
             f"Extract and include all specific facts from the pages — dates, years, numbers, and names — "
             f"even when they appear briefly or in passing. Do not claim a fact is absent unless it is "
             f"genuinely missing from every page below.\n"
@@ -1156,9 +1173,11 @@ class QueryAgent(BaseAgent):
             gap=_gap, system_ctx=_system_ctx, is_live_data=_is_live_data,
             history=_trimmed_history if _trimmed_history else None,
         )
+        _synthesis_system = self._build_synthesis_system(question)
 
         resp2 = await self._provider.complete(
             messages=[Message(role="user", content=synthesis_prompt)],
+            system=_synthesis_system,
             temperature=0.0,
             max_tokens=self._max_tokens,
         )
@@ -1461,6 +1480,7 @@ class QueryAgent(BaseAgent):
             gap=_gap, system_ctx=_system_ctx, is_live_data=_is_live_data,
             history=_trimmed_history if _trimmed_history else None,
         )
+        _synthesis_system = self._build_synthesis_system(question)
 
         yield {"event": "status", "data": {"phase": "synthesizing", "sources": len(citations)}}
 
@@ -1477,6 +1497,7 @@ class QueryAgent(BaseAgent):
         _last_line_buf = ""
         async for token in self._provider.complete_stream(
             messages=[Message(role="user", content=synthesis_prompt)],
+            system=_synthesis_system,
             temperature=0.0,
             max_tokens=self._max_tokens,
         ):

--- a/synthadoc/agents/rewrite_agent.py
+++ b/synthadoc/agents/rewrite_agent.py
@@ -12,7 +12,9 @@ _REWRITE_SYSTEM = (
     "Given a conversation history and a follow-up question, rewrite the follow-up "
     "as a fully self-contained question that can be understood without the history. "
     "If the question is already self-contained, return it exactly as given. "
-    "Return ONLY the rewritten question — no explanation, no punctuation changes."
+    "Return ONLY the rewritten question — no explanation, no punctuation changes. "
+    "IMPORTANT: Write the rewritten question in the same language as the follow-up "
+    "question itself, not the language of the conversation history."
 )
 
 

--- a/synthadoc/agents/workflows/_base.py
+++ b/synthadoc/agents/workflows/_base.py
@@ -85,6 +85,20 @@ class WorkflowContext:
     # BM25/vector search instance — used by tool_search_orphan_candidates.
     # None in tests that don't need search access.
     search: "HybridSearch | None" = None  # type: ignore[name-defined]
+    # True when the active provider is a CodingToolCLIProvider (opencode, claude-code).
+    # Used by cost-estimate tools to substitute "Covered by coding tool subscription"
+    # for the dollar figure — CLI providers bill via their own subscription, not per-token.
+    is_cli_provider: bool = False
+
+    def cost_label(self, usd: float) -> str:
+        """Human-readable cost string for a workflow estimate.
+
+        CLI providers (opencode, claude-code) bill via their own subscription,
+        so a per-token dollar figure would be misleading.
+        """
+        if self.is_cli_provider:
+            return "Covered by coding tool subscription"
+        return f"~${usd:.2f}"
 
 
 class AgenticWorkflow(ABC):

--- a/synthadoc/agents/workflows/ingest_lint.py
+++ b/synthadoc/agents/workflows/ingest_lint.py
@@ -300,11 +300,18 @@ class IngestLintWorkflow(AgenticWorkflow):
         parts.append("\n**Page states after re-ingest:**")
         for slug in attempted_slugs:
             result = ingest_results.get(slug, {})
-            ingest_status = result.get("status", "?")
+            # tool_ingest_source may return {"error": msg} (validation/file-not-found)
+            # rather than {"status": ...}; treat that as an error outcome so the
+            # summary clearly signals the failure (and live tests can detect it).
+            ingest_status = result.get("status") or ("error" if result.get("error") else "?")
             state = state_map.get(slug, "unknown")
             icon = _ICON.get(state, "○")
             if ingest_status == "skipped":
                 parts.append(f"  ○ {slug} — skipped (no source path)")
+            elif result.get("error"):
+                parts.append(
+                    f"  ✗ {slug}: error — {result['error']}"
+                )
             else:
                 parts.append(
                     f"  {icon} {slug}: ingest={ingest_status}, state={state}"

--- a/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
@@ -137,10 +137,12 @@ async def tool_cost_estimate(ctx: "WorkflowContext", page_count: int) -> dict:
         "estimated_minutes": minutes,
     }
 
+    cost_label = ctx.cost_label(estimate["estimated_usd"])
+
     # Show the estimate as a notice so the user can read it while the ConfirmCard loads.
     notice_text = (
         f"Updated estimate: {page_count} page(s), "
-        f"~${estimate['estimated_usd']:.2f}, "
+        f"{cost_label}, "
         f"about {estimate['estimated_minutes']} minute(s)."
     )
     try:
@@ -148,13 +150,13 @@ async def tool_cost_estimate(ctx: "WorkflowContext", page_count: int) -> dict:
     except Exception:  # noqa: BLE001
         pass
 
-    # Ask for approval — this blocks until the user responds (or 120 s timeout).
+    # Ask for approval — this blocks until the user responds (or 300 s timeout).
     confirm_result = await tool_confirm(
         ctx,
         message=(
             f"**Contradiction Resolver — ready to start**\n\n"
             f"- Pages to process: **{page_count}**\n"
-            f"- Estimated cost: ~**${estimate['estimated_usd']:.2f}**\n"
+            f"- Estimated cost: **{cost_label}**\n"
             f"- Estimated time: ~**{estimate['estimated_minutes']} min**\n\n"
             "Proceed with resolution?"
         ),

--- a/synthadoc/agents/workflows/tools/orphan_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/orphan_resolver_tools.py
@@ -145,7 +145,7 @@ async def tool_estimate_and_confirm(
         f"  Pages to process:    {orphan_count}\n"
         f"  Estimated tool calls: ~{estimated_calls}\n"
         f"  Estimated time:       ~{estimated_minutes} min\n"
-        f"  Estimated cost:       ~${estimated_usd:.2f} USD\n"
+        f"  Estimated cost:       {ctx.cost_label(estimated_usd)}\n"
         f"\nProceed with orphan resolver?"
     )
     result = await tool_confirm(ctx, message, yes_label="Proceed", no_label="Cancel")

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -1428,6 +1428,67 @@ async def test_ingest_lint_cli_path_workflow_b_no_source(tmp_path):
     assert any("cannot re-ingest" in t.lower() for t in texts)
 
 
+@pytest.mark.asyncio
+async def test_ingest_lint_cli_path_workflow_a_ingest_error_in_summary(tmp_path):
+    """Workflow A: tool_ingest_source returns {"error": ...} (e.g. file-not-found).
+
+    The summary must surface "error" so live tests can detect partial failure.
+    Regression: previously ingest_status fell back to "?" (no "status" key),
+    which matched no failure keyword the live assertion checked.
+    """
+    from unittest.mock import patch as _patch, AsyncMock as _AsyncMock
+    from synthadoc.agents.workflows.ingest_lint import IngestLintWorkflow
+    from synthadoc.agents.workflows._base import WorkflowContext
+
+    ctx = MagicMock(spec=WorkflowContext)
+    ctx.send_sse_event = _AsyncMock()
+    wf = IngestLintWorkflow()
+
+    stale_pages = [
+        {"slug": "page-ok",  "source_path": "/data/ok.txt",  "stale_since": "2026-08-01"},
+        {"slug": "page-bad", "source_path": "/data/bad.txt", "stale_since": "2026-08-01"},
+    ]
+
+    async def _fake_ingest(ctx, source_path):
+        if "bad" in source_path:
+            return {"error": f"File not found: {source_path!r}"}
+        return {"status": "success", "message": "done"}
+
+    with _patch(
+        "synthadoc.agents.workflows.ingest_lint.tool_find_stale_pages",
+        new=_AsyncMock(return_value={"pages": stale_pages}),
+    ), _patch(
+        "synthadoc.agents.workflows.ingest_lint.tool_confirm",
+        new=_AsyncMock(return_value={"confirmed": True}),
+    ), _patch(
+        "synthadoc.agents.workflows.ingest_lint.tool_ingest_source",
+        new=_fake_ingest,
+    ), _patch(
+        "synthadoc.agents.workflows.ingest_lint.tool_run_lint",
+        new=_AsyncMock(return_value={"status": "success", "message": "clean"}),
+    ), _patch(
+        "synthadoc.agents.workflows.ingest_lint.tool_get_page_states",
+        new=_AsyncMock(return_value={
+            "pages": [
+                {"slug": "page-ok",  "state": "active"},
+                {"slug": "page-bad", "state": "stale"},
+            ]
+        }),
+    ):
+        events = []
+        async for evt in wf.run_for_cli_provider(ctx, "re-ingest stale pages", MagicMock()):
+            events.append(evt)
+
+    token_text = "".join(e["data"]["text"] for e in events if e["event"] == "token")
+    # page-bad errored → summary must contain "error" (not "?") so live tests detect it
+    assert "error" in token_text.lower()
+    assert "page-bad" in token_text
+    # page-ok succeeded → should still appear
+    assert "page-ok" in token_text
+    assert "active" in token_text
+    assert "final_text" in [e["event"] for e in events]
+
+
 # ── BrokenWikilinksWorkflow CLI path ─────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/agents/workflows/test_tools.py
+++ b/tests/agents/workflows/test_tools.py
@@ -1374,3 +1374,21 @@ async def test_transition_lifecycle_set_page_state_exception_is_swallowed(tmp_pa
     assert result["success"] is True
     # set_page_state raised but the result is still success
     audit_db.set_page_state.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# WorkflowContext.cost_label
+# ---------------------------------------------------------------------------
+
+def test_cost_label_api_provider_formats_dollars():
+    ctx, _ = _make_ctx()
+    # Default: is_cli_provider=False → dollar amount
+    assert ctx.cost_label(0.06) == "~$0.06"
+    assert ctx.cost_label(1.23456) == "~$1.23"
+
+
+def test_cost_label_cli_provider_returns_subscription_note():
+    ctx, _ = _make_ctx()
+    ctx.is_cli_provider = True
+    assert ctx.cost_label(0.06) == "Covered by coding tool subscription"
+    assert ctx.cost_label(0.0) == "Covered by coding tool subscription"

--- a/tests/integration/test_http_server.py
+++ b/tests/integration/test_http_server.py
@@ -534,3 +534,41 @@ def test_session_purge_does_not_reference_session_state(tmp_wiki):
         "_worker_loop must not reference _session_state directly (it is out of scope); "
         "pass it as the session_state parameter instead"
     )
+
+
+# ---------------------------------------------------------------------------
+# /lint/report — contradiction detection uses parsed frontmatter
+# ---------------------------------------------------------------------------
+
+def test_lint_report_skips_system_slugs_and_handles_bad_yaml(tmp_wiki):
+    """/lint/report skips LINT_SKIP_SLUGS and doesn't crash on malformed YAML."""
+    from fastapi.testclient import TestClient
+    from synthadoc.storage.wiki import SYSTEM_PAGE_SLUGS
+
+    wiki_dir = tmp_wiki / "wiki"
+    # A system slug — should be skipped (exercises the `continue` branch).
+    skip_slug = next(iter(SYSTEM_PAGE_SLUGS))
+    (wiki_dir / f"{skip_slug}.md").write_text(
+        "---\nstatus: contradicted\n---\nSystem page.\n", encoding="utf-8"
+    )
+    # Malformed YAML frontmatter — exercises the `except Exception: pass` branch.
+    (wiki_dir / "bad-yaml.md").write_text(
+        "---\nstatus: [unclosed\n---\nContent.\n", encoding="utf-8"
+    )
+    # Normal active page — should not appear in contradictions.
+    (wiki_dir / "normal-page.md").write_text(
+        "---\nstatus: active\ntitle: Normal\n---\nContent.\n", encoding="utf-8"
+    )
+
+    app = _make_app(tmp_wiki)
+    with TestClient(app) as client:
+        resp = client.get("/lint/report")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    # The system slug must be excluded from contradictions even though its
+    # frontmatter says "contradicted".
+    assert skip_slug not in data["contradictions"]
+    # The malformed-YAML page must not cause a 500 and must not appear as
+    # contradicted (fm defaults to {} so status check is False).
+    assert "bad-yaml" not in data["contradictions"]

--- a/tests/live/test_agentic_ingest_lint_live.py
+++ b/tests/live/test_agentic_ingest_lint_live.py
@@ -445,6 +445,7 @@ def require_server():
 # ══════════════════════════════════════════════════════════════════════════════
 
 @pytest.mark.live
+@pytest.mark.timeout(300)
 def test_post_ingest_queues_job_for_valid_source():
     """POST /ingest with a valid source path inside wiki root → job_id; job completes."""
     wiki_root = _wiki_root()

--- a/tests/test_query_agent.py
+++ b/tests/test_query_agent.py
@@ -239,3 +239,81 @@ def test_synthesis_prompt_cjk_japanese_language_instruction():
     system = agent._build_synthesis_system("チューリングマシンとは何ですか？")
     assert "respond in Japanese" in system.lower() or "Japanese" in system
     assert "Do not respond in English or any other language" in system
+
+
+# ── _filter_history_by_language / _history_block ─────────────────────────────
+
+from synthadoc.agents.query_agent import _filter_history_by_language, _history_block  # noqa: E402
+
+
+def test_filter_history_keeps_same_script_turns():
+    """English question keeps English assistant turns."""
+    history = [
+        {"role": "user", "content": "Who is Grace Hopper?"},
+        {"role": "assistant", "content": "Grace Hopper was a computer scientist."},
+    ]
+    result = _filter_history_by_language(history, "When did she die?")
+    assert result == history
+
+
+def test_filter_history_drops_mismatched_script_pair():
+    """English question drops a user+assistant pair where assistant responded in Chinese."""
+    cjk_response = "她于1992年12月28日去世。"  # Chinese
+    history = [
+        {"role": "user", "content": "When does he die?"},
+        {"role": "assistant", "content": cjk_response},
+        {"role": "user", "content": "What year was she born?"},
+        {"role": "assistant", "content": "She was born in 1906."},
+    ]
+    result = _filter_history_by_language(history, "When does he pass away?")
+    # The first user+assistant pair (Chinese response) must be dropped
+    assert not any(cjk_response in m.get("content", "") for m in result)
+    # The second pair (English response) must be kept
+    assert any("1906" in m.get("content", "") for m in result)
+
+
+def test_filter_history_empty_returns_empty():
+    """Empty history returns empty list without error."""
+    assert _filter_history_by_language([], "hello") == []
+
+
+def test_history_block_passes_question_to_filter():
+    """_history_block with a question filters out cross-script turns."""
+    cjk_response = "她于1992年去世。"
+    history = [
+        {"role": "user", "content": "When does she die?"},
+        {"role": "assistant", "content": cjk_response},
+    ]
+    block = _history_block(history, question="When does she pass away?")
+    assert cjk_response not in block
+
+
+def test_history_block_no_question_keeps_all():
+    """_history_block without question keeps all history turns."""
+    cjk_response = "她于1992年去世。"
+    history = [
+        {"role": "user", "content": "When does she die?"},
+        {"role": "assistant", "content": cjk_response},
+    ]
+    block = _history_block(history)
+    assert cjk_response in block
+
+
+def test_build_synthesis_prompt_filters_history_for_english_question():
+    """_build_synthesis_prompt strips CJK assistant turns when question is English."""
+    cfg = QueryConfig()
+    agent = _make_agent(cfg, {})
+    cjk_response = "她于1992年去世。"
+    history = [
+        {"role": "user", "content": "When does she die?"},
+        {"role": "assistant", "content": cjk_response},
+    ]
+    prompt = agent._build_synthesis_prompt(
+        "When does she pass away?",
+        "Page content here.",
+        gap=False,
+        system_ctx="",
+        is_live_data=False,
+        history=history,
+    )
+    assert cjk_response not in prompt

--- a/tests/test_query_agent.py
+++ b/tests/test_query_agent.py
@@ -215,8 +215,11 @@ def test_synthesis_prompt_non_cjk_language_instruction():
         system_ctx="",
         is_live_data=False,
     )
-    assert "Do not use the language of the Pages" in prompt
-    assert "always match the Question's language" in prompt
+    assert "Do not use the language of the Pages or the conversation history" in prompt
+    # Language rule is also enforced via the system prompt; verify the helper
+    system = agent._build_synthesis_system("What is a Turing machine?")
+    assert "same language" in system
+    assert "conversation history" in system
 
 
 def test_synthesis_prompt_cjk_japanese_language_instruction():
@@ -231,5 +234,8 @@ def test_synthesis_prompt_cjk_japanese_language_instruction():
         system_ctx="",
         is_live_data=False,
     )
-    assert "Respond in Japanese" in prompt
-    assert "Do not respond in English or any other language" in prompt
+    # Language rule now lives primarily in the system prompt; prompt still has belt-and-suspenders
+    assert "same language" in prompt
+    system = agent._build_synthesis_system("チューリングマシンとは何ですか？")
+    assert "respond in Japanese" in system.lower() or "Japanese" in system
+    assert "Do not respond in English or any other language" in system


### PR DESCRIPTION
Two independent fixes bundled for this branch.

1. Query language drift (bd85232, a81edd2)

Follow-up English queries returned Chinese when a prior session turn contained a Chinese response. Root cause: prior Chinese assistant turns in AuditDB history biased the LLM even when the system prompt said otherwise - especially for opencode, which embeds the system prompt in stdin (not a real system-level instruction).

Two-layer fix:
- System prompt enforcement (_build_synthesis_system): constructs a language-specific system prompt per question; CJK questions get an explicit "You MUST respond in Japanese/Chinese/Korean" instruction
- History filtering (_filter_history_by_language): drops turn-pairs where the assistant's script mismatches the current question's script before they reach the synthesis prompt, preventing poisoned history from acting as a precedent
- RewriteAgent system prompt updated to rewrite in the follow-up question's language, not the history's language
- Tests: 7 new tests covering filter logic, history-block passthrough, and synthesis prompt integration; _build_synthesis_system tested independently

2. Ingest-lint CLI-provider live test failures (acb4d20)