### PR TITLE
fix(contradiction-resolver): render per-item summary lines in WebUI

### DIFF
--- a/synthadoc/agents/workflows/contradiction_resolver.py
+++ b/synthadoc/agents/workflows/contradiction_resolver.py
@@ -206,24 +206,25 @@ STEP 4 — Per-page resolution loop
 STEP 5 — Final summary (tool call FIRST, then plain text in exact format)
   ⚠ Do NOT output any plain text yet.
   FIRST call tool_get_wiki_status() — this fetches live lifecycle counts.
-  THEN output the summary as plain text in EXACTLY this format.
-  Each • item MUST be on its own line — NEVER put two items on the same line:
+  THEN output the summary in EXACTLY this markdown format.
+  Use markdown list syntax (hyphen-space) for items — the UI renders markdown,
+  so only "- item" syntax produces separate lines; bullet characters do not:
 
-    Contradiction Resolver — Complete
+    **Contradiction Resolver — Complete**
 
-    ✅ Fixed (<N>):
-      • <slug> — <one-sentence description of what changed>
-      • <slug> — <one-sentence description>
+    **✅ Fixed (<N>):**
+    - <slug> — <one-sentence description of what changed>
+    - <slug> — <one-sentence description>
 
-    ⚠ Unresolved (<N>):
-      • <slug>: <one-sentence reason; concrete suggested next step>
+    **⚠ Unresolved (<N>):**
+    - <slug>: <one-sentence reason; concrete suggested next step>
 
-    ⏭ Skipped (<N>):
-      • <slug>
+    **⏭ Skipped (<N>):**
+    - <slug>
 
-    Wiki status (live): active: <N>, draft: <N>, stale: <N>, contradicted: <N>, archived: <N>
+    **Wiki status (live):** active: <N>, draft: <N>, stale: <N>, contradicted: <N>, archived: <N>
 
-  When a section is empty write "  • (none)" on its own line.
+  When a section is empty write "- (none)" as the single list item.
   This plain-text output ends the loop — it must be your very last action.
 
 ━━━ CRITICAL RULES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/synthadoc/agents/workflows/contradiction_resolver.py
+++ b/synthadoc/agents/workflows/contradiction_resolver.py
@@ -30,6 +30,7 @@ from synthadoc.agents.workflows.tools.contradiction_resolver_tools import (
     tool_get_contradicted_pages,
     tool_read_source_content,
     tool_cost_estimate,
+    tool_format_summary,
 )
 
 if TYPE_CHECKING:
@@ -202,20 +203,22 @@ STEP 4 — Per-page resolution loop
         ⚠ MANDATORY — do NOT output any plain text before calling tool_confirm here.
         Text output ends the entire workflow before the confirmation is shown.
 
-STEP 5 — Final summary (tool call FIRST, then plain text)
-  ⚠ Do NOT output any plain text yet.
-  FIRST call tool_get_wiki_status() — this fetches live lifecycle counts.
-  THEN output a single plain-text summary combining per-page outcomes and
-  the live counts returned by tool_get_wiki_status():
-    "Contradiction Resolver — Complete\n\n✅ Fixed (<N>):\n  ...\n⚠ Unresolved (<N>):\n  ...\n⏭ Skipped (<N>):\n  ...\n\nWiki status (live): <key: value, ...>"
-  This plain-text output ends the loop — it must be your very last action.
+STEP 5 — Final summary (tool call only — no plain text)
+  ⚠ Do NOT output any plain text for the summary.
+  Call tool_format_summary with the per-page outcomes you collected:
+    fixed:      [{"slug": "<slug>", "note": "<one-sentence description of what changed>"}, ...]
+    unresolved: [{"slug": "<slug>", "reason": "<why it failed; concrete suggested next step>"}, ...]
+    skipped:    ["<slug>", ...]
+  The tool fetches live wiki counts and emits the formatted summary automatically.
+  This tool call is your very last action — no plain text after it.
 
 ━━━ CRITICAL RULES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-• Plain text ENDS THE LOOP — use it ONLY for the final summary (step 5),
-  or when cancelling (steps 2 and 3).
-• ALWAYS call tool_get_wiki_status() before outputting the step 5 summary —
-  never output any plain text before this tool call returns.
+• Plain text ENDS THE LOOP — use it ONLY when cancelling (steps 2 and 3).
+  The step 5 summary is produced by tool_format_summary — NEVER output plain
+  text for it; a text summary ends the loop before tool_format_summary runs.
+• NEVER call tool_get_wiki_status() directly — tool_format_summary calls it
+  internally. NEVER output the step 5 summary as plain text.
 • ALWAYS call tool_run_scoped_lint after every applied change.
 • When tool_run_scoped_lint returns pass: True — IMMEDIATELY call
   tool_transition_lifecycle_state. Do NOT call tool_propose_and_apply again.
@@ -312,6 +315,7 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
             "tool_get_contradicted_pages":     p(tool_get_contradicted_pages, ctx),
             "tool_read_source_content":        p(tool_read_source_content, ctx),
             "tool_cost_estimate":              p(tool_cost_estimate, ctx),
+            "tool_format_summary":             p(tool_format_summary, ctx),
             # Generic framework tools (from _tools.py)
             "tool_read_page_content":          p(tool_read_page_content, ctx),
             "tool_run_scoped_lint":            p(tool_run_scoped_lint, ctx),
@@ -374,8 +378,8 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
             return
 
         # ── 4. Per-page resolution loop ───────────────────────────────────────
-        fixed: list[str] = []
-        unresolved: list[tuple[str, str]] = []   # (slug, reason)
+        fixed: list[dict] = []       # [{"slug": str, "note": str}, ...]
+        unresolved: list[dict] = []  # [{"slug": str, "reason": str}, ...]
         skipped: list[str] = []
 
         for i, page_info in enumerate(pages):
@@ -399,7 +403,10 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
                             "— contradicted state was stale metadata"
                         ),
                     )
-                    fixed.append(slug)
+                    fixed.append({
+                        "slug": slug,
+                        "note": "Stale contradicted state; fresh lint passed, transitioned to active",
+                    })
                     # Still need to confirm between pages below
                 else:
                     # Real issue — treat as gate-demoted and fall through to rewrite
@@ -424,7 +431,7 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
                         message=f"⚠ {slug} — could not generate a rewrite; skipping",
                         level="warning",
                     )
-                    unresolved.append((slug, "LLM rewrite failed"))
+                    unresolved.append({"slug": slug, "reason": "LLM rewrite failed"})
                 else:
                     # 4d. Show diff and ask for approval (reuses propose_and_apply as-is)
                     apply_result = await tool_propose_and_apply(
@@ -451,7 +458,10 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
                                     "— CLI provider path, Strategy 1 (content rewrite)"
                                 ),
                             )
-                            fixed.append(slug)
+                            fixed.append({
+                                "slug": slug,
+                                "note": "Strategy 1 — content rewrite applied; lint passed, transitioned to active",
+                            })
                         else:
                             wc = lint_result.get("warnings_count", "?")
                             await tool_notify(
@@ -464,7 +474,10 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
                                 ),
                                 level="warning",
                             )
-                            unresolved.append((slug, f"lint still failing ({wc} warnings)"))
+                            unresolved.append({
+                                "slug": slug,
+                                "reason": f"lint still failing ({wc} warnings)",
+                            })
 
             # 4f. Confirm before next page
             if i < len(pages) - 1:
@@ -480,36 +493,10 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
                     break
 
         # ── 5. Final summary ──────────────────────────────────────────────────
-        wiki_status = await tool_get_wiki_status(ctx)
-
-        parts: list[str] = ["**Contradiction Resolver — Complete**\n"]
-
-        if fixed:
-            parts.append(f"✅ Fixed ({len(fixed)}):")
-            for s in fixed:
-                parts.append(f"  - {s}")
-
-        if unresolved:
-            parts.append(f"\n⚠ Unresolved ({len(unresolved)}):")
-            for s, reason in unresolved:
-                parts.append(f"  - {s}: {reason}")
-            parts.append(
-                "\n  Tip: run the full resolver with provider=anthropic for "
-                "multi-strategy retry on unresolved pages."
-            )
-
-        if skipped:
-            parts.append(f"\n⏭ Skipped ({len(skipped)}):")
-            for s in skipped:
-                parts.append(f"  - {s}")
-
-        status_str = ", ".join(f"{k}: {v}" for k, v in wiki_status.items()
-                               if k not in ("tool", "message"))
-        parts.append(f"\nWiki status (live): {status_str}")
-
-        summary = "\n".join(parts)
-        yield {"event": "token", "data": {"text": summary}}
-        yield {"event": "final_text", "data": {"text": summary}}
+        # tool_format_summary fetches live wiki status, renders the shared
+        # _format_cr_summary template, and emits token + final_text SSE events
+        # via ctx.send_sse_event — same code path as the API-provider path.
+        await tool_format_summary(ctx, fixed, unresolved, skipped)
 
     async def _cli_rewrite_page(
         self,

--- a/synthadoc/agents/workflows/contradiction_resolver.py
+++ b/synthadoc/agents/workflows/contradiction_resolver.py
@@ -203,22 +203,35 @@ STEP 4 — Per-page resolution loop
         ⚠ MANDATORY — do NOT output any plain text before calling tool_confirm here.
         Text output ends the entire workflow before the confirmation is shown.
 
-STEP 5 — Final summary (tool call only — no plain text)
-  ⚠ Do NOT output any plain text for the summary.
-  Call tool_format_summary with the per-page outcomes you collected:
-    fixed:      [{"slug": "<slug>", "note": "<one-sentence description of what changed>"}, ...]
-    unresolved: [{"slug": "<slug>", "reason": "<why it failed; concrete suggested next step>"}, ...]
-    skipped:    ["<slug>", ...]
-  The tool fetches live wiki counts and emits the formatted summary automatically.
-  This tool call is your very last action — no plain text after it.
+STEP 5 — Final summary (tool call FIRST, then plain text in exact format)
+  ⚠ Do NOT output any plain text yet.
+  FIRST call tool_get_wiki_status() — this fetches live lifecycle counts.
+  THEN output the summary as plain text in EXACTLY this format.
+  Each • item MUST be on its own line — NEVER put two items on the same line:
+
+    Contradiction Resolver — Complete
+
+    ✅ Fixed (<N>):
+      • <slug> — <one-sentence description of what changed>
+      • <slug> — <one-sentence description>
+
+    ⚠ Unresolved (<N>):
+      • <slug>: <one-sentence reason; concrete suggested next step>
+
+    ⏭ Skipped (<N>):
+      • <slug>
+
+    Wiki status (live): active: <N>, draft: <N>, stale: <N>, contradicted: <N>, archived: <N>
+
+  When a section is empty write "  • (none)" on its own line.
+  This plain-text output ends the loop — it must be your very last action.
 
 ━━━ CRITICAL RULES ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-• Plain text ENDS THE LOOP — use it ONLY when cancelling (steps 2 and 3).
-  The step 5 summary is produced by tool_format_summary — NEVER output plain
-  text for it; a text summary ends the loop before tool_format_summary runs.
-• NEVER call tool_get_wiki_status() directly — tool_format_summary calls it
-  internally. NEVER output the step 5 summary as plain text.
+• Plain text ENDS THE LOOP — use it ONLY for the final summary (step 5),
+  or when cancelling (steps 2 and 3).
+• ALWAYS call tool_get_wiki_status() before outputting the step 5 summary —
+  never output any plain text before this tool call returns.
 • ALWAYS call tool_run_scoped_lint after every applied change.
 • When tool_run_scoped_lint returns pass: True — IMMEDIATELY call
   tool_transition_lifecycle_state. Do NOT call tool_propose_and_apply again.
@@ -315,7 +328,6 @@ class ContradictionResolverWorkflow(AgenticWorkflow):
             "tool_get_contradicted_pages":     p(tool_get_contradicted_pages, ctx),
             "tool_read_source_content":        p(tool_read_source_content, ctx),
             "tool_cost_estimate":              p(tool_cost_estimate, ctx),
-            "tool_format_summary":             p(tool_format_summary, ctx),
             # Generic framework tools (from _tools.py)
             "tool_read_page_content":          p(tool_read_page_content, ctx),
             "tool_run_scoped_lint":            p(tool_run_scoped_lint, ctx),

--- a/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
@@ -190,42 +190,45 @@ def _format_cr_summary(
         wiki_status: raw dict from tool_get_wiki_status (may contain "tool"/"message" keys
                      that are filtered out)
     """
+    # Use markdown list syntax ("- item") so the WebUI renders each entry
+    # on its own line.  Plain bullet characters (•) collapse into a single
+    # paragraph in markdown; "- " list items do not.
     lines: list[str] = ["**Contradiction Resolver — Complete**", ""]
 
-    lines.append(f"✅ Fixed ({len(fixed)}):")
+    lines.append(f"**✅ Fixed ({len(fixed)}):**")
     if fixed:
         for item in fixed:
-            lines.append(f"  • {item['slug']} — {item['note']}")
+            lines.append(f"- {item['slug']} — {item['note']}")
     else:
-        lines.append("  • (none)")
+        lines.append("- (none)")
 
     lines.append("")
-    lines.append(f"⚠ Unresolved ({len(unresolved)}):")
+    lines.append(f"**⚠ Unresolved ({len(unresolved)}):**")
     if unresolved:
         for item in unresolved:
-            lines.append(f"  • {item['slug']}: {item['reason']}")
+            lines.append(f"- {item['slug']}: {item['reason']}")
         lines.append("")
         lines.append(
-            "  Tip: run the full resolver with provider=anthropic for "
-            "multi-strategy retry on unresolved pages."
+            "_Tip: run the full resolver with provider=anthropic for "
+            "multi-strategy retry on unresolved pages._"
         )
     else:
-        lines.append("  • (none)")
+        lines.append("- (none)")
 
     lines.append("")
-    lines.append(f"⏭ Skipped ({len(skipped)}):")
+    lines.append(f"**⏭ Skipped ({len(skipped)}):**")
     if skipped:
         for s in skipped:
-            lines.append(f"  • {s}")
+            lines.append(f"- {s}")
     else:
-        lines.append("  • (none)")
+        lines.append("- (none)")
 
     status_str = ", ".join(
         f"{k}: {v}" for k, v in wiki_status.items()
         if k not in ("tool", "message")
     )
     lines.append("")
-    lines.append(f"Wiki status (live): {status_str}")
+    lines.append(f"**Wiki status (live):** {status_str}")
 
     return "\n".join(lines)
 

--- a/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
@@ -165,3 +165,105 @@ async def tool_cost_estimate(ctx: "WorkflowContext", page_count: int) -> dict:
     )
 
     return {**estimate, "confirmed": confirm_result.get("confirmed", False)}
+
+
+# ---------------------------------------------------------------------------
+# _format_cr_summary / tool_format_summary
+# ---------------------------------------------------------------------------
+
+def _format_cr_summary(
+    fixed: list[dict],
+    unresolved: list[dict],
+    skipped: list[str],
+    wiki_status: dict,
+) -> str:
+    """Render the Contradiction Resolver final summary as a markdown string.
+
+    Shared by both execution paths:
+    • API-provider path  — called from ``tool_format_summary`` (LLM tool call)
+    • CLI-provider path  — called from ``tool_format_summary`` (direct Python call)
+
+    Args:
+        fixed:       [{"slug": str, "note": str}, ...]
+        unresolved:  [{"slug": str, "reason": str}, ...]
+        skipped:     [slug_str, ...]
+        wiki_status: raw dict from tool_get_wiki_status (may contain "tool"/"message" keys
+                     that are filtered out)
+    """
+    lines: list[str] = ["**Contradiction Resolver — Complete**", ""]
+
+    lines.append(f"✅ Fixed ({len(fixed)}):")
+    if fixed:
+        for item in fixed:
+            lines.append(f"  • {item['slug']} — {item['note']}")
+    else:
+        lines.append("  • (none)")
+
+    lines.append("")
+    lines.append(f"⚠ Unresolved ({len(unresolved)}):")
+    if unresolved:
+        for item in unresolved:
+            lines.append(f"  • {item['slug']}: {item['reason']}")
+        lines.append("")
+        lines.append(
+            "  Tip: run the full resolver with provider=anthropic for "
+            "multi-strategy retry on unresolved pages."
+        )
+    else:
+        lines.append("  • (none)")
+
+    lines.append("")
+    lines.append(f"⏭ Skipped ({len(skipped)}):")
+    if skipped:
+        for s in skipped:
+            lines.append(f"  • {s}")
+    else:
+        lines.append("  • (none)")
+
+    status_str = ", ".join(
+        f"{k}: {v}" for k, v in wiki_status.items()
+        if k not in ("tool", "message")
+    )
+    lines.append("")
+    lines.append(f"Wiki status (live): {status_str}")
+
+    return "\n".join(lines)
+
+
+async def tool_format_summary(
+    ctx: "WorkflowContext",
+    fixed: list[dict],
+    unresolved: list[dict],
+    skipped: list[str],
+) -> dict:
+    """Format and emit the final Contradiction Resolver summary.
+
+    Fetches live wiki lifecycle counts, renders the summary via
+    ``_format_cr_summary``, and emits ``token`` + ``final_text`` SSE events so
+    the result reaches the client via the same channel as the rest of the stream.
+
+    This is the LAST tool call of the workflow on both execution paths:
+    • API-provider path: LLM calls this tool instead of writing plain text.
+    • CLI-provider path: ``run_for_cli_provider`` awaits this directly.
+
+    Neither path needs to emit any further plain text or events after this call.
+
+    Args:
+        fixed:      [{"slug": str, "note": str}, ...]
+        unresolved: [{"slug": str, "reason": str}, ...]
+        skipped:    [slug_str, ...]
+
+    Returns:
+        {"status": "success", "summary": <formatted text>}
+    """
+    from synthadoc.agents.workflows._tools import (  # avoid circular at module level
+        tool_get_wiki_status,
+    )
+
+    wiki_status = await tool_get_wiki_status(ctx)
+    text = _format_cr_summary(fixed, unresolved, skipped, wiki_status)
+
+    await ctx.send_sse_event("token", {"text": text})
+    await ctx.send_sse_event("final_text", {"text": text})
+
+    return {"status": "success", "summary": text}

--- a/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
+++ b/synthadoc/agents/workflows/tools/contradiction_resolver_tools.py
@@ -238,15 +238,14 @@ async def tool_format_summary(
 ) -> dict:
     """Format and emit the final Contradiction Resolver summary.
 
-    Fetches live wiki lifecycle counts, renders the summary via
-    ``_format_cr_summary``, and emits ``token`` + ``final_text`` SSE events so
-    the result reaches the client via the same channel as the rest of the stream.
+    Used by the CLI-provider path (``run_for_cli_provider`` awaits this directly).
+    Fetches live wiki lifecycle counts, renders the summary via ``_format_cr_summary``,
+    and emits ``token`` + ``final_text`` SSE events via ``ctx.send_sse_event`` so they
+    reach the client through the shared SSE queue.
 
-    This is the LAST tool call of the workflow on both execution paths:
-    • API-provider path: LLM calls this tool instead of writing plain text.
-    • CLI-provider path: ``run_for_cli_provider`` awaits this directly.
-
-    Neither path needs to emit any further plain text or events after this call.
+    The API-provider path does NOT call this tool — the LLM outputs the summary as
+    plain text using the format template in the system prompt step 5.  This function
+    is therefore only called from Python (the CLI path), never from the tool-call loop.
 
     Args:
         fixed:      [{"slug": str, "note": str}, ...]
@@ -263,6 +262,10 @@ async def tool_format_summary(
     wiki_status = await tool_get_wiki_status(ctx)
     text = _format_cr_summary(fixed, unresolved, skipped, wiki_status)
 
+    # Emit token first so the content streams, then final_text to signal end-of-stream.
+    # The CLI-provider path calls this as the last step of run_for_cli_provider;
+    # the run_for_cli_provider generator returns immediately after, so no further
+    # events enter the queue before the _SENTINEL that closes the drain loop.
     await ctx.send_sse_event("token", {"text": text})
     await ctx.send_sse_event("final_text", {"text": text})
 

--- a/tests/agents/test_action_agent.py
+++ b/tests/agents/test_action_agent.py
@@ -1150,18 +1150,29 @@ async def test_contradiction_resolver_cli_path_resolves_page(tmp_path):
     ), patch(
         "synthadoc.agents.workflows.contradiction_resolver.tool_transition_lifecycle_state",
         new=_AsyncMock(return_value={"status": "success"}),
-    ), patch(
-        "synthadoc.agents.workflows.contradiction_resolver.tool_get_wiki_status",
-        new=_AsyncMock(return_value={"active": 1, "contradicted": 0, "stale": 0, "draft": 0, "archived": 0}),
-    ):
-        events = []
-        async for evt in wf.run_for_cli_provider(ctx, "resolve contradictions", fake_provider):
-            events.append(evt)
+    ) as _mock_transition:
+        mock_format_summary = _AsyncMock(return_value={"status": "success", "summary": "ok"})
+        with patch(
+            "synthadoc.agents.workflows.contradiction_resolver.tool_format_summary",
+            new=mock_format_summary,
+        ):
+            events = []
+            async for evt in wf.run_for_cli_provider(ctx, "resolve contradictions", fake_provider):
+                events.append(evt)
 
-    token_text = "".join(e["data"]["text"] for e in events if e["event"] == "token")
-    assert "Fixed" in token_text
-    assert "page-a" in token_text
-    assert "final_text" in [e["event"] for e in events]
+    # Summary is emitted via tool_format_summary (not yielded by the generator).
+    # Verify it was called with page-a in the fixed list.
+    mock_format_summary.assert_called_once()
+    call_args = mock_format_summary.call_args
+    fixed_arg = call_args.args[1]          # positional: ctx, fixed, unresolved, skipped
+    assert any(item.get("slug") == "page-a" for item in fixed_arg), (
+        f"Expected page-a in fixed list; got: {fixed_arg}"
+    )
+    # Early-exit events (tool_progress etc.) may still appear via ctx.send_sse_event;
+    # the generator itself yields nothing after tool_format_summary is awaited.
+    assert not any(e["event"] == "final_text" for e in events), (
+        "final_text must not be yielded by the generator — tool_format_summary emits it"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/agents/workflows/test_tools.py
+++ b/tests/agents/workflows/test_tools.py
@@ -1392,3 +1392,88 @@ def test_cost_label_cli_provider_returns_subscription_note():
     ctx.is_cli_provider = True
     assert ctx.cost_label(0.06) == "Covered by coding tool subscription"
     assert ctx.cost_label(0.0) == "Covered by coding tool subscription"
+
+
+# ── _format_cr_summary / tool_format_summary ──────────────────────────────────
+
+from synthadoc.agents.workflows.tools.contradiction_resolver_tools import (  # noqa: E402
+    _format_cr_summary,
+    tool_format_summary,
+)
+
+
+def test_format_cr_summary_per_item_newlines():
+    """Each fixed/unresolved/skipped item must appear on its own line, not inline."""
+    fixed = [
+        {"slug": "alan-turing", "note": "Stale metadata; lint passed"},
+        {"slug": "grace-hopper", "note": "Strategy 1 applied; lint passed"},
+    ]
+    unresolved = [{"slug": "bad-page", "reason": "lint still failing (2 warnings)"}]
+    skipped = ["skipped-page"]
+    wiki_status = {"active": 3, "contradicted": 0}
+
+    text = _format_cr_summary(fixed, unresolved, skipped, wiki_status)
+
+    # Each slug must appear on its own line (not all on one line separated by •)
+    lines = text.splitlines()
+    alan_lines = [l for l in lines if "alan-turing" in l]
+    grace_lines = [l for l in lines if "grace-hopper" in l]
+    bad_lines   = [l for l in lines if "bad-page" in l]
+    skip_lines  = [l for l in lines if "skipped-page" in l]
+
+    assert len(alan_lines) == 1,  "alan-turing must appear on exactly one line"
+    assert len(grace_lines) == 1, "grace-hopper must appear on exactly one line"
+    assert len(bad_lines) == 1,   "bad-page must appear on exactly one line"
+    assert len(skip_lines) == 1,  "skipped-page must appear on exactly one line"
+
+    # Counts in headers
+    assert "✅ Fixed (2):" in text
+    assert "⚠ Unresolved (1):" in text
+    assert "⏭ Skipped (1):" in text
+
+    # Wiki status line
+    assert "Wiki status (live):" in text
+    assert "active: 3" in text
+
+
+def test_format_cr_summary_empty_sections_show_none():
+    """Empty fixed/unresolved/skipped sections render '(none)' on their own line."""
+    text = _format_cr_summary([], [], [], {"active": 5})
+    assert "✅ Fixed (0):" in text
+    assert "⚠ Unresolved (0):" in text
+    assert "⏭ Skipped (0):" in text
+    assert text.count("• (none)") == 3
+
+
+def test_format_cr_summary_filters_tool_message_keys():
+    """'tool' and 'message' keys from wiki_status are excluded from the status line."""
+    wiki_status = {"tool": "get_wiki_status", "message": "ok", "active": 2, "stale": 0}
+    text = _format_cr_summary([], [], [], wiki_status)
+    assert "tool:" not in text
+    assert "message:" not in text
+    assert "active: 2" in text
+
+
+@pytest.mark.asyncio
+async def test_tool_format_summary_emits_sse_events():
+    """tool_format_summary fetches wiki status, emits token+final_text, returns dict."""
+    ctx = MagicMock(spec=WorkflowContext)
+    ctx.send_sse_event = AsyncMock()
+
+    fixed = [{"slug": "page-a", "note": "Strategy 1 applied"}]
+    unresolved: list = []
+    skipped: list = []
+
+    with patch(
+        "synthadoc.agents.workflows._tools.tool_get_wiki_status",
+        new=AsyncMock(return_value={"active": 1, "contradicted": 0}),
+    ):
+        result = await tool_format_summary(ctx, fixed, unresolved, skipped)
+
+    assert result["status"] == "success"
+    assert "page-a" in result["summary"]
+
+    # Must have emitted token and final_text via ctx.send_sse_event
+    calls = {call.args[0] for call in ctx.send_sse_event.call_args_list}
+    assert "token" in calls, "Expected a 'token' SSE event"
+    assert "final_text" in calls, "Expected a 'final_text' SSE event"

--- a/tests/agents/workflows/test_tools.py
+++ b/tests/agents/workflows/test_tools.py
@@ -1442,7 +1442,7 @@ def test_format_cr_summary_empty_sections_show_none():
     assert "✅ Fixed (0):" in text
     assert "⚠ Unresolved (0):" in text
     assert "⏭ Skipped (0):" in text
-    assert text.count("• (none)") == 3
+    assert text.count("- (none)") == 3
 
 
 def test_format_cr_summary_filters_tool_message_keys():


### PR DESCRIPTION
The contradiction resolver's final summary was displaying all resolved pages inline on a single line in the WebUI.  Root cause: the WebUI renders markdown, and Unicode bullet characters (•) separated by single newlines collapse into one paragraph.  Only markdown list items (`- item`) create per-line breaks.

Changes:
- `_format_cr_summary` now uses `- item` markdown list syntax and `**bold**` section headers instead of `•` bullets
- System prompt step 5 template updated to match the same format, so the API-provider path (LLM free-text output) and the CLI-provider path (Python formatter) produce consistent output 

Both execution paths (API-based providers and CLI providers) share the same `_format_cr_summary` formatter introduced in the previous refactor; this commit fixes its output format only.