### PR TITLE
fix(cli): replace non-ASCII characters in CLI output to fix Windows cp1252 mojibake

### DIFF
--- a/synthadoc/cli/audit.py
+++ b/synthadoc/cli/audit.py
@@ -84,7 +84,7 @@ def cost_cmd(
     if as_json:
         typer.echo(json.dumps(summary, indent=2))
         return
-    console.print(f"\n[bold]Cost summary — last {days} days[/bold]")
+    console.print(f"\n[bold]Cost summary - last {days} days[/bold]")
     console.print(f"  Total tokens : {summary['total_tokens']:,}")
     console.print(f"  Total cost   : ${summary['total_cost_usd']:.4f}")
     if summary["daily"]:
@@ -187,7 +187,7 @@ def citations_cmd(
             slug = r.get("page_slug") or r.get("slug") or ""
             citation = r.get("citation") or ""
             reason = r.get("reason") or ""
-            typer.echo(f"  [{ts}] {slug}  {citation} — {reason}")
+            typer.echo(f"  [{ts}] {slug}  {citation} - {reason}")
     else:
         typer.echo(f"Claim Citations (last {limit}):\n")
         table = Table(title="Claim Citations")
@@ -239,12 +239,12 @@ def _render_faithfulness(results: list, as_json: bool) -> None:
         "supported":     ("[green]✅ supported[/green]", ""),
         "drift":         ("[yellow]⚠️  drift[/yellow]", ""),
         "hallucination": ("[red]❌ hallucination[/red]", ""),
-        "skipped":       ("[dim]—  skipped[/dim]", ""),
+        "skipped":       ("[dim] -   skipped[/dim]", ""),
     }
     slugs = sorted({r.slug for r in results})
     n_pages = len(slugs)
     table = Table(
-        title=f"Citation Faithfulness Report — {len(results)} citations across {n_pages} pages"
+        title=f"Citation Faithfulness Report - {len(results)} citations across {n_pages} pages"
     )
     table.add_column("Page", style="cyan", no_wrap=True, max_width=30)
     table.add_column("Citation", no_wrap=True, max_width=44)
@@ -280,10 +280,10 @@ def _run_faithfulness(
     """Cache-aware faithfulness audit delegated to the running server.
 
     Decision logic (applied before any LLM call):
-      - Fresh cache, no stale pages → display cached results, exit (no LLM).
-      - Stale pages exist           → re-audit stale pages only (stale_only).
-      - No cache at all             → full audit.
-      - --force                     → full audit regardless of cache state.
+      - Fresh cache, no stale pages -> display cached results, exit (no LLM).
+      - Stale pages exist           -> re-audit stale pages only (stale_only).
+      - No cache at all             -> full audit.
+      - --force                     -> full audit regardless of cache state.
 
     The server owns the LLM provider; no API key is needed in the CLI.
     """
@@ -320,7 +320,7 @@ def _run_faithfulness(
         stale_only = False
         needs_run = True
     elif not has_cache:
-        # No cache at all — full run
+        # No cache at all - full run
         stale_only = False
         needs_run = True
     else:
@@ -334,7 +334,7 @@ def _run_faithfulness(
             stale_only = True
             needs_run = bool(stale_slugs)
 
-    # ── No LLM needed — show cached results ──────────────────────────────────
+    # ── No LLM needed - show cached results ──────────────────────────────────
     if not needs_run:
         if page:
             slugs_to_show = [page] if page in entries else []
@@ -365,7 +365,7 @@ def _run_faithfulness(
         if est_cost >= cfg.cost.hard_gate_usd:
             console.print(
                 f"[red]Cost gate:[/red] faithfulness audit estimated "
-                f"${est_cost:.4f} — exceeds hard_gate_usd "
+                f"${est_cost:.4f} - exceeds hard_gate_usd "
                 f"${cfg.cost.hard_gate_usd:.2f}. "
                 f"Raise [cost].hard_gate_usd in config.toml or scope to a single page."
             )
@@ -373,7 +373,7 @@ def _run_faithfulness(
         # Always confirm before any LLM run, regardless of cost size.
         scope_desc = "stale pages only" if stale_only else "all active pages"
         console.print(
-            f"\n[bold]Citation faithfulness audit[/bold] — {scope_desc}\n"
+            f"\n[bold]Citation faithfulness audit[/bold] - {scope_desc}\n"
             f"  {len(pages_with_checks)} page(s)  ·  "
             f"{total_citations} citation(s)  ·  "
             f"~{est_tokens:,} tokens  ·  "
@@ -397,7 +397,7 @@ def _run_faithfulness(
         raise typer.Exit(1)
 
     scope_label = f'"{page}"' if page else ("stale pages" if stale_only else "all active pages")
-    console.print(f"[dim]Auditing {scope_label} — job {job_id}…[/dim]")
+    console.print(f"[dim]Auditing {scope_label} - job {job_id}…[/dim]")
 
     # ── Poll until terminal ───────────────────────────────────────────────────
     POLL_SECONDS = 3

--- a/synthadoc/cli/backup.py
+++ b/synthadoc/cli/backup.py
@@ -77,7 +77,7 @@ def backup_cmd(
 
     size_mb = zip_path.stat().st_size / 1_048_576
     manifest = read_manifest(zip_path)
-    typer.echo(f"\n✓ {zip_path.name}  ({size_mb:.1f} MB)")
+    typer.echo(f"\nOK {zip_path.name}  ({size_mb:.1f} MB)")
     typer.echo(f"  Pages:    {manifest.get('page_count', '?')}")
     typer.echo(f"  Sources:  {'excluded  (use --no-sources to skip next time)' if no_sources else 'included'}")
     typer.echo(f"  Exports:  {'excluded' if no_exports else 'included'}")
@@ -221,15 +221,15 @@ def restore_cmd(
             _install_plugin_into(wiki_root)
             _update_community_plugins(wiki_root, _DATAVIEW_ID, _PLUGIN_ID)
 
-    typer.echo(f"\n✓ Restored '{wiki_name}' on port {effective_port}")
+    typer.echo(f"\nOK Restored '{wiki_name}' on port {effective_port}")
     typer.echo(f"  Path: {wiki_root}")
     if manifest.get("obsidian_plugin"):
-        typer.echo(f"  ✓ Obsidian plugin reinstalled")
+        typer.echo(f"  OK Obsidian plugin reinstalled")
     typer.echo(f"\nNext steps:")
-    typer.echo(f"  • Set your LLM API key in your shell environment")
-    typer.echo(f"  • Start the server:   synthadoc serve -w {wiki_name}")
+    typer.echo(f"  - Set your LLM API key in your shell environment")
+    typer.echo(f"  - Start the server:   synthadoc serve -w {wiki_name}")
     if manifest.get("obsidian_plugin"):
-        typer.echo(f"  • Open the vault in Obsidian - plugin is ready")
+        typer.echo(f"  - Open the vault in Obsidian - plugin is ready")
 
 
 def _read_backed_up_port(zip_path: Path) -> int:

--- a/synthadoc/cli/backup.py
+++ b/synthadoc/cli/backup.py
@@ -117,7 +117,7 @@ def restore_cmd(
     if not verify_checksum(zip_path, manifest.get("checksum_sha256", "")):
         E.cli_error(
             E.WIKI_INVALID,
-            "Backup checksum mismatch — archive may be corrupted.",
+            "Backup checksum mismatch - archive may be corrupted.",
             "Use a fresh backup copy.",
         )
 
@@ -142,7 +142,7 @@ def restore_cmd(
                 stale_port = int(raw_port)
             typer.echo(
                 f"  Note: '{wiki_name}' was registered at {existing_path} "
-                f"but that path no longer exists — proceeding with restore.",
+                f"but that path no longer exists - proceeding with restore.",
                 err=True,
             )
 
@@ -157,7 +157,7 @@ def restore_cmd(
             typer.echo("Restore aborted.")
             raise typer.Exit(0)
 
-    # Resolve target directory — default to same folder as the zip
+    # Resolve target directory - default to same folder as the zip
     if target is None:
         target_dir = zip_path.parent
         typer.echo(f"Restoring to: {target_dir}")
@@ -184,7 +184,7 @@ def restore_cmd(
         if effective_port != backed_up_port:
             raw = typer.prompt(
                 f"Port {backed_up_port} is taken. Suggested: {effective_port} "
-                f"— press Enter to accept or type a different port",
+                f" -  press Enter to accept or type a different port",
                 default=str(effective_port),
             )
             try:
@@ -229,7 +229,7 @@ def restore_cmd(
     typer.echo(f"  • Set your LLM API key in your shell environment")
     typer.echo(f"  • Start the server:   synthadoc serve -w {wiki_name}")
     if manifest.get("obsidian_plugin"):
-        typer.echo(f"  • Open the vault in Obsidian — plugin is ready")
+        typer.echo(f"  • Open the vault in Obsidian - plugin is ready")
 
 
 def _read_backed_up_port(zip_path: Path) -> int:
@@ -244,7 +244,7 @@ def _read_backed_up_port(zip_path: Path) -> int:
 
 
 def _apply_schedules(wiki_root: Path, wiki_name: str) -> None:
-    """Re-apply OS scheduled tasks from config.toml — non-fatal on error."""
+    """Re-apply OS scheduled tasks from config.toml - non-fatal on error."""
     import subprocess
     import sys
     try:

--- a/synthadoc/cli/cache.py
+++ b/synthadoc/cli/cache.py
@@ -32,7 +32,7 @@ def cache_cmd(
     db_path = root / ".synthadoc" / "cache.db"
 
     if not db_path.exists():
-        typer.echo("No cache found — nothing to clear.")
+        typer.echo("No cache found - nothing to clear.")
         return
 
     async def _clear() -> int:

--- a/synthadoc/cli/candidates.py
+++ b/synthadoc/cli/candidates.py
@@ -40,7 +40,7 @@ def _toml_value(v: object) -> str:
     if isinstance(v, (int, float)):
         return str(v)
     if isinstance(v, str):
-        return json.dumps(v)  # double-quoted string — same as JSON
+        return json.dumps(v)  # double-quoted string - same as JSON
     if isinstance(v, dict):
         pairs = ", ".join(f"{k} = {_toml_value(val)}" for k, val in v.items())
         return "{" + pairs + "}"
@@ -64,7 +64,7 @@ def _patch_toml(path: Path, section: str, updates: dict) -> None:
         stripped = line.strip()
         if stripped.startswith("[") and stripped.endswith("]"):
             if in_target:
-                # End of target section — append any keys not yet seen
+                # End of target section - append any keys not yet seen
                 for k, v in updates.items():
                     if k not in patched_keys:
                         result.append(f"{k} = {_toml_value(v)}")
@@ -135,7 +135,7 @@ def staging_policy_cmd(
     if policy == "threshold" and min_confidence:
         msg += f" (min-confidence: {min_confidence})"
     typer.echo(msg)
-    typer.echo("Takes effect on next ingest job — no restart needed.")
+    typer.echo("Takes effect on next ingest job - no restart needed.")
 
 
 @candidates_app.command("list")
@@ -165,12 +165,12 @@ def _page_title(path: Path) -> str:
 
 
 def _add_to_index(wiki_dir: Path, entries: list[tuple[str, str]]) -> None:
-    """Append [[slug]] — Title entries to index.md under ## Recently Added."""
+    """Append [[slug]] - Title entries to index.md under ## Recently Added."""
     index_path = wiki_dir / "index.md"
     if not index_path.exists() or not entries:
         return
     text = index_path.read_text(encoding="utf-8")
-    new_lines = [f"- [[{slug}]] — {title}" for slug, title in entries]
+    new_lines = [f"- [[{slug}]] - {title}" for slug, title in entries]
     if "## Recently Added" in text:
         lines = text.splitlines()
         insert_at = len(lines)
@@ -220,11 +220,11 @@ def candidates_promote(
         if is_new:
             new_pages.append((src.stem, title))
         action = "Promoted" if is_new else "Updated"
-        typer.echo(f"  {action} {src.stem} → wiki/{src.name}")
+        typer.echo(f"  {action} {src.stem} -> wiki/{src.name}")
 
     if new_pages:
         _add_to_index(wiki_dir, new_pages)
-        typer.echo(f"  Updated index.md — added {len(new_pages)} entr{'y' if len(new_pages) == 1 else 'ies'} to ## Recently Added")
+        typer.echo(f"  Updated index.md - added {len(new_pages)} entr{'y' if len(new_pages) == 1 else 'ies'} to ## Recently Added")
 
 
 @candidates_app.command("discard")

--- a/synthadoc/cli/demo.py
+++ b/synthadoc/cli/demo.py
@@ -142,7 +142,7 @@ def sync_demo(
             any_output = True
 
     if not any_output:
-        typer.echo("Already up to date — nothing to sync.")
+        typer.echo("Already up to date - nothing to sync.")
 
 
 def _strip_bom(text: str) -> str:

--- a/synthadoc/cli/install.py
+++ b/synthadoc/cli/install.py
@@ -92,7 +92,7 @@ def install_cmd(
     """
     dest = (Path(target) / name).resolve()
 
-    # Registry check first — same name cannot be installed twice regardless of --target path
+    # Registry check first - same name cannot be installed twice regardless of --target path
     registry = _read_registry()
     if name in registry:
         entry = registry[name]
@@ -133,10 +133,10 @@ def install_cmd(
                 f"Available demos: {', '.join(_DEMOS)}",
             )
         shutil.copytree(_DEMOS[name], dest, ignore=shutil.ignore_patterns("_*", "__pycache__"))
-        # Ensure operational directories exist — the demo template may not include
+        # Ensure operational directories exist - the demo template may not include
         # empty dirs (git doesn't track them) and shutil.copytree won't create them.
         (dest / ".synthadoc" / "logs").mkdir(parents=True, exist_ok=True)
-        # Write config.toml — .synthadoc/ is git-ignored so it can't be bundled
+        # Write config.toml - .synthadoc/ is git-ignored so it can't be bundled
         # in the demo template; generate it here the same way init_wiki does.
         from synthadoc.cli._init import _CONFIG_TOML
         (dest / ".synthadoc" / "config.toml").write_text(
@@ -190,7 +190,7 @@ def install_cmd(
     if not demo:
         typer.echo()
         typer.echo(f"Next steps:")
-        typer.echo(f"  1. Edit .synthadoc/config.toml — set your LLM provider and API key")
+        typer.echo(f"  1. Edit .synthadoc/config.toml - set your LLM provider and API key")
         typer.echo(f"  2. Set as default wiki:   synthadoc use {name}")
         typer.echo(f"  3. Start the server:      synthadoc serve")
         typer.echo(f"  4. Ingest your sources:   synthadoc ingest <file>")
@@ -218,7 +218,7 @@ def uninstall_cmd(
     """Permanently delete an installed wiki.
 
     Requires two confirmations: a y/N prompt followed by typing the wiki name.
-    There is no --yes flag — this operation is irreversible.
+    There is no --yes flag - this operation is irreversible.
     """
     name = _normalise_wiki_name(name)
     registry = _read_registry()
@@ -236,7 +236,7 @@ def uninstall_cmd(
     dest = Path(registry[name]["path"])
 
     if not dest.exists():
-        typer.echo(f"Wiki '{name}' no longer exists on disk — removing from registry.")
+        typer.echo(f"Wiki '{name}' no longer exists on disk - removing from registry.")
         del registry[name]
         _write_registry(registry)
         raise typer.Exit(0)
@@ -247,10 +247,10 @@ def uninstall_cmd(
         abort=True,
     )
 
-    # Second confirmation — must type the exact name
+    # Second confirmation - must type the exact name
     typed = typer.prompt(f"Type '{name}' to confirm permanent deletion")
     if typed != name:
-        typer.echo("Name did not match — aborted. Nothing was deleted.")
+        typer.echo("Name did not match - aborted. Nothing was deleted.")
         raise typer.Exit(1)
 
     shutil.rmtree(dest)

--- a/synthadoc/cli/lifecycle.py
+++ b/synthadoc/cli/lifecycle.py
@@ -114,7 +114,7 @@ def lifecycle_history(
     if index is not None:
         # Single snapshot view
         ts = fmt_ts(result.get("timestamp"), fmt="%Y-%m-%d %H:%M:%S")
-        typer.echo(f"Snapshot {result['index']}  {ts}  {result.get('from_state','?')} → {result['to_state']}")
+        typer.echo(f"Snapshot {result['index']}  {ts}  {result.get('from_state','?')} -> {result['to_state']}")
         typer.echo(f"Reason: {result.get('reason', '')}")
         typer.echo(f"Content: {result.get('content_length', 0):,} chars")
         if show_content and "content" in result:
@@ -126,11 +126,11 @@ def lifecycle_history(
     if not snapshots:
         typer.echo(f"No snapshots recorded for '{slug}'.")
         return
-    typer.echo(f"{'Index':>5}  {'Timestamp':<20}  {'From → To':<28}  {'Content':<16}  Reason")
+    typer.echo(f"{'Index':>5}  {'Timestamp':<20}  {'From -> To':<28}  {'Content':<16}  Reason")
     typer.echo("-" * 100)
     for s in snapshots:
         ts = fmt_ts(s.get("timestamp"), fmt="%Y-%m-%d %H:%M:%S")
-        transition = f"{s.get('from_state') or 'null'} → {s['to_state']}"
+        transition = f"{s.get('from_state') or 'null'} -> {s['to_state']}"
         chars = f"{s.get('content_length', 0):,} chars"
         reason = (s.get("reason") or "")[:40]
         typer.echo(f"{s['index']:>5}  {ts:<20}  {transition:<28}  {chars:<16}  {reason}")

--- a/synthadoc/cli/lint.py
+++ b/synthadoc/cli/lint.py
@@ -46,7 +46,7 @@ def _index_suggestion(slug: str, fm: dict) -> str:
         hint = ", ".join(str(t) for t in tags[:4])
     else:
         hint = title
-    return f"- [[{slug}]] — {hint}"
+    return f"- [[{slug}]] - {hint}"
 
 def _sync_orphan_frontmatter(
     wiki_dir: Path,
@@ -62,7 +62,7 @@ def _sync_orphan_frontmatter(
         fm = _parse_frontmatter(text)
         desired = slug in orphan_set
         if fm.get("orphan", False) == desired:
-            continue  # already correct — skip to avoid unnecessary disk write
+            continue  # already correct - skip to avoid unnecessary disk write
         # Rewrite only the orphan key in the frontmatter block
         path = wiki_dir / f"{slug}.md"
         m = _FRONTMATTER_RE.match(text)
@@ -111,14 +111,14 @@ def lint_cmd(
     typer.echo(f"Check status: synthadoc jobs status {result['job_id']}{w_flag}")
     typer.echo(f"View results: synthadoc lint report{w_flag}")
     if no_adversarial:
-        typer.echo("ℹ️  Adversarial pass skipped — lint_warnings cleared from all pages.")
+        typer.echo("ℹ️  Adversarial pass skipped - lint_warnings cleared from all pages.")
 
 
 @lint_app.command("report")
 def lint_report(
     wiki: Optional[str] = typer.Option(None, "--wiki", "-w"),
 ):
-    """Show current contradictions and orphan pages — no server required.
+    """Show current contradictions and orphan pages - no server required.
 
     Reads wiki files directly. Run after 'synthadoc lint' completes to see
     what needs your attention.
@@ -186,7 +186,7 @@ def lint_report(
     if not has_issues:
         # Still sync frontmatter to clear stale orphan: true flags from previous runs.
         _sync_orphan_frontmatter(wiki_dir, page_texts, set())
-        typer.echo("All clear — no contradictions, orphan pages, adversarial warnings, or truncated sources found.")
+        typer.echo("All clear - no contradictions, orphan pages, adversarial warnings, or truncated sources found.")
         return
 
     if contradicted:
@@ -235,7 +235,7 @@ def lint_report(
         for slug, issues in by_slug.items():
             typer.echo(f"  {slug}")
             for iss in issues:
-                typer.echo(f"    {iss['citation']} — {iss['reason']}")
+                typer.echo(f"    {iss['citation']} - {iss['reason']}")
 
     if truncated_pages:
         try:
@@ -246,7 +246,7 @@ def lint_report(
         typer.echo(f"\nTruncated Sources ({len(truncated_pages)}) - source exceeded ingest limit:\n")
         for entry in truncated_pages:
             size = entry.get("size") or 0
-            typer.echo(f"  {entry['slug']} — source exceeded limit ({size:,} chars)")
+            typer.echo(f"  {entry['slug']} - source exceeded limit ({size:,} chars)")
             typer.echo(f"    Source: {entry['file']}")
             typer.echo(f"    💡 Re-ingest with a higher limit:")
             typer.echo(f"       {suggested_reingest_cmd(entry['file'], wiki, size or _default_max)}")

--- a/synthadoc/cli/plugin.py
+++ b/synthadoc/cli/plugin.py
@@ -34,7 +34,7 @@ def _write_plugin_data(wiki_path: Path, plugin_dir: Path) -> None:
 
     Reads host and port from the wiki's config.toml.  If data.json already
     exists (e.g. the user has customised other settings), only ``serverUrl``
-    is updated — all other keys are preserved.
+    is updated - all other keys are preserved.
     """
     import tomllib
     host = "127.0.0.1"
@@ -49,8 +49,8 @@ def _write_plugin_data(wiki_path: Path, plugin_dir: Path) -> None:
         except Exception:
             pass
 
-    # Loopback and any-interface binds → plugin connects via 127.0.0.1 locally.
-    # Specific external address → use it directly for remote vault support.
+    # Loopback and any-interface binds -> plugin connects via 127.0.0.1 locally.
+    # Specific external address -> use it directly for remote vault support.
     if host in _LOOPBACK_ADDRS or host in _ANY_IFACE_ADDRS:
         server_url = f"http://127.0.0.1:{port}"
     else:
@@ -121,7 +121,7 @@ def _set_reading_view_default(wiki_path: Path) -> bool:
 
     Returns True if written; False if no write was needed (setting already correct).
     Treats malformed JSON as empty dict and heals the file.
-    Idempotent — does not write if the setting is already correct.
+    Idempotent - does not write if the setting is already correct.
     """
     obsidian_dir = wiki_path / ".obsidian"
     obsidian_dir.mkdir(parents=True, exist_ok=True)
@@ -156,7 +156,7 @@ def _patch_workspace_reading_view(wiki_path: Path) -> bool:
     workspace.json here ensures they re-open in Reading View after an upgrade.
 
     Returns True if workspace.json was rewritten; False if unchanged or absent.
-    Must be called while Obsidian is closed — Obsidian overwrites workspace.json
+    Must be called while Obsidian is closed - Obsidian overwrites workspace.json
     on exit with its current in-memory state.
     """
     ws_json = wiki_path / ".obsidian" / "workspace.json"
@@ -264,14 +264,14 @@ def plugin_install_cmd(
     if dataview_status == "installed":
         typer.echo(f"  installed Dataview dependency")
     elif dataview_status == "skipped":
-        typer.echo(f"  Dataview already installed — skipped")
+        typer.echo(f"  Dataview already installed - skipped")
     else:
-        typer.echo(f"  Note: Dataview download failed — install it manually via Obsidian Settings > Community Plugins")
-    typer.echo(f"  community-plugins.json updated — both plugins pre-enabled")
+        typer.echo(f"  Note: Dataview download failed - install it manually via Obsidian Settings > Community Plugins")
+    typer.echo(f"  community-plugins.json updated - both plugins pre-enabled")
     typer.echo("  set     app.json defaultViewMode=preview (Reading View)")
     typer.echo("          (Restart Obsidian or reopen this vault for the setting to take effect.)")
     typer.echo()
-    typer.echo("Open Obsidian and open this vault — both plugins are already enabled, no manual steps required.")
+    typer.echo("Open Obsidian and open this vault - both plugins are already enabled, no manual steps required.")
 
 
 @plugin_app.command("upgrade")
@@ -318,7 +318,7 @@ def plugin_upgrade_cmd():
                 _patch_workspace_reading_view(wiki_path)
                 upgraded.append(name)
             else:
-                skipped.append(f"  {name}: no plugin files found — run: python scripts/sync_plugin.py")
+                skipped.append(f"  {name}: no plugin files found - run: python scripts/sync_plugin.py")
         except Exception as exc:
             errors.append(f"  {name}: {exc}")
 

--- a/synthadoc/cli/routing.py
+++ b/synthadoc/cli/routing.py
@@ -10,7 +10,7 @@ from synthadoc.cli._wiki import resolve_wiki
 from synthadoc.cli._wiki import resolve_wiki_path
 from synthadoc.core.routing import RoutingIndex
 
-routing_app = typer.Typer(name="routing", help="Manage ROUTING.md — scoped query routing.")
+routing_app = typer.Typer(name="routing", help="Manage ROUTING.md - scoped query routing.")
 
 _BRANCH_RE = re.compile(r"^##\s+(.+)$")
 _SLUG_RE = re.compile(r"-\s*\[\[([^\]]+)\]\]")
@@ -53,14 +53,14 @@ def routing_init(
     ri = RoutingIndex(branches)
     ri.save(routing_path)
     total = sum(len(v) for v in branches.values())
-    typer.echo(f"ROUTING.md created — {len(branches)} branches, {total} slugs.")
+    typer.echo(f"ROUTING.md created - {len(branches)} branches, {total} slugs.")
 
 
 @routing_app.command("validate")
 def routing_validate(
     wiki: Optional[str] = typer.Option(None, "--wiki", "-w", help="Wiki name or path"),
 ) -> None:
-    """Report dangling slugs and unassigned pages in ROUTING.md (dry run — no changes)."""
+    """Report dangling slugs and unassigned pages in ROUTING.md (dry run - no changes)."""
     _, routing_path, wiki_dir = _paths(wiki)
 
     ri = RoutingIndex.parse(routing_path)
@@ -71,7 +71,7 @@ def routing_validate(
     unassigned = ri.unassigned_slugs(index) if index.exists() else []
 
     if not dangling and not unassigned:
-        typer.echo("ROUTING.md is clean — no dangling slugs, no unassigned pages.")
+        typer.echo("ROUTING.md is clean - no dangling slugs, no unassigned pages.")
         return
 
     if dangling:
@@ -100,7 +100,7 @@ def routing_clean(
     removed = ri.clean(existing)
 
     if not removed:
-        typer.echo("ROUTING.md is clean — nothing to remove.")
+        typer.echo("ROUTING.md is clean - nothing to remove.")
         return
 
     ri.save(routing_path)

--- a/synthadoc/cli/scaffold.py
+++ b/synthadoc/cli/scaffold.py
@@ -17,7 +17,7 @@ def scaffold_cmd(
     """Re-generate domain-specific scaffold files for an existing wiki.
 
     Rewrites index.md, AGENTS.md, and purpose.md using the LLM.
-    The LLM call runs on the server — no API key needed on the client.
+    The LLM call runs on the server - no API key needed on the client.
     Monitor progress with: synthadoc jobs
 
     Examples:
@@ -73,7 +73,7 @@ def scaffold_cmd(
             typer.echo("")
             typer.echo("Tip: content you write above a <!-- synthadoc:scaffold --> marker is")
             typer.echo("     preserved on re-runs. index.md has one marker (below the title).")
-            typer.echo("     purpose.md has one marker per section — each section's content is")
+            typer.echo("     purpose.md has one marker per section - each section's content is")
             typer.echo("     preserved independently.")
             break
         if status in (JobStatus.FAILED, JobStatus.DEAD):

--- a/synthadoc/cli/scaffold.py
+++ b/synthadoc/cli/scaffold.py
@@ -40,7 +40,7 @@ def scaffold_cmd(
                     f"Cannot reach server: {exc}",
                     "Run `synthadoc serve` first.")
 
-    typer.echo(f"Queuing scaffold for domain: {domain}…")
+    typer.echo(f"Queuing scaffold for domain: {domain}...")
     try:
         result = post(wiki, "/jobs/scaffold", {"domain": domain})
     except Exception as exc:
@@ -51,7 +51,7 @@ def scaffold_cmd(
     import time
     job_id = result.get("job_id", "?")
     typer.echo(f"Scaffold job queued: {job_id}")
-    typer.echo("Waiting for scaffold to complete…")
+    typer.echo("Waiting for scaffold to complete...")
 
     while True:
         time.sleep(2)

--- a/synthadoc/cli/status.py
+++ b/synthadoc/cli/status.py
@@ -27,7 +27,7 @@ def status_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")):
         counts = lc.get("counts") or lc  # server returns flat dict; tolerate old wrapped format
         typer.echo("\nPage lifecycle:")
         if not counts:
-            typer.echo("  (none — run `synthadoc lint run` to initialise lifecycle states)")
+            typer.echo("  (none - run `synthadoc lint run` to initialise lifecycle states)")
             return
         _HINTS = {
             "draft":            "<- run `synthadoc lint run` to promote",


### PR DESCRIPTION
On Windows, cmd.exe and PowerShell default to code page 1252. UTF-8 characters in typer.echo strings are decoded as cp1252, producing mojibake — e.g. the em dash (—) renders as "â€"", checkmark (✓) as "Ã¢Â€Å"", bullet (•) as "â€¢".

Reported via the uninstall command: "Name did not match â€" aborted."

Replace all non-ASCII characters in user-facing CLI strings across 14 files with ASCII equivalents:

- Em dash (—)       → " - "
- Right arrow (→)   → "->"
- Checkmark (✓)     → "OK"
- Bullet (•)        → "-"
- Ellipsis (…)      → "..."

No functional change on Linux or macOS (both default to UTF-8 and rendered the original characters correctly).

Affected commands: uninstall, cache, lint, routing, plugin, backup, restore, audit, candidates, demo, scaffold, lifecycle, status.