### PR TITLE
fix(config): replace raw traceback with clean error when config.toml …

### DIFF
--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -23,7 +23,10 @@ def server_url(wiki: str) -> str:
             f"Wiki '{wiki}' is not installed.",
             f"Make sure wiki '{wiki}' was installed with 'synthadoc install'.",
         )
-    cfg = load_config(project_config=config_path)
+    try:
+        cfg = load_config(project_config=config_path)
+    except E.ConfigError as exc:
+        E.cli_error(exc.code, str(exc), exc.hint)
     port = cfg.server.port
     return f"http://127.0.0.1:{port}"
 

--- a/synthadoc/cli/audit.py
+++ b/synthadoc/cli/audit.py
@@ -307,7 +307,10 @@ def _run_faithfulness(
 
     wiki_name = resolve_wiki(wiki)
     wiki_root = resolve_wiki_path(wiki_name)
-    cfg = load_config(project_config=wiki_root / ".synthadoc" / "config.toml")
+    try:
+        cfg = load_config(project_config=wiki_root / ".synthadoc" / "config.toml")
+    except E.ConfigError as exc:
+        E.cli_error(exc.code, str(exc), exc.hint)
     store = WikiStorage(wiki_root / "wiki")
     agent_cfg = cfg.agents.resolve("adversarial")
 

--- a/synthadoc/cli/retract.py
+++ b/synthadoc/cli/retract.py
@@ -43,8 +43,12 @@ def _resolve_pages_dir(wiki_root: Path) -> Path:
 
 def _load_wiki_config(wiki_root: Path):
     from synthadoc.config import load_config
+    from synthadoc import errors as E
     cfg_path = wiki_root / ".synthadoc" / "config.toml"
-    return load_config(project_config=cfg_path if cfg_path.exists() else None)
+    try:
+        return load_config(project_config=cfg_path if cfg_path.exists() else None)
+    except E.ConfigError as exc:
+        E.cli_error(exc.code, str(exc), exc.hint)
 
 
 def _get_audit_db(wiki_root: Path):

--- a/synthadoc/cli/schedule.py
+++ b/synthadoc/cli/schedule.py
@@ -99,7 +99,10 @@ def apply_cmd(wiki: Optional[str] = typer.Option(None, "--wiki", "-w")) -> None:
     from synthadoc.config import load_config
     from synthadoc.core.scheduler import Scheduler, ScheduleEntry
     root = _resolve_and_validate(wiki)
-    cfg = load_config(project_config=root / ".synthadoc" / "config.toml")
+    try:
+        cfg = load_config(project_config=root / ".synthadoc" / "config.toml")
+    except E.ConfigError as exc:
+        E.cli_error(exc.code, str(exc), exc.hint)
     sched = Scheduler(wiki=wiki, wiki_root=str(root))
     ids = sched.apply([ScheduleEntry(op=j.op, cron=j.cron, wiki=wiki)
                        for j in cfg.schedule.jobs])

--- a/synthadoc/cli/serve.py
+++ b/synthadoc/cli/serve.py
@@ -264,7 +264,10 @@ def serve_cmd(
     from synthadoc.core.logging_config import setup_logging
 
     root = resolve_wiki_path(wiki)
-    cfg = load_config(project_config=root / ".synthadoc" / "config.toml")
+    try:
+        cfg = load_config(project_config=root / ".synthadoc" / "config.toml")
+    except E.ConfigError as exc:
+        E.cli_error(exc.code, str(exc), exc.hint)
     effective_port = port if port is not None else cfg.server.port
 
     if provider_override:

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -578,15 +578,20 @@ def load_config(
             with open(project_config, "rb") as fh:
                 project_raw = tomllib.load(fh)
         except tomllib.TOMLDecodeError as exc:
+            from synthadoc.errors import ConfigError, CFG_DUPLICATE_KEY, CFG_INVALID_TOML
             msg = str(exc)
             if "cannot overwrite" in msg.lower():
-                raise ValueError(
-                    f"[ERR-CFG-003] Duplicate key in {project_config}.\n"
+                raise ConfigError(
+                    CFG_DUPLICATE_KEY,
+                    f"Duplicate key in {project_config}.",
                     f"Only one 'default' line may be active under [agents] at a time.\n"
                     f"Comment out all but one provider and restart the server.\n"
-                    f"(TOML error: {exc})"
+                    f"(TOML error: {exc})",
                 ) from exc
-            raise ValueError(f"[ERR-CFG-003] Invalid TOML in {project_config}: {exc}") from exc
+            raise ConfigError(
+                CFG_INVALID_TOML,
+                f"Invalid TOML in {project_config}: {exc}",
+            ) from exc
         raw = _merge(raw, project_raw)
         any_file_loaded = True
 

--- a/synthadoc/errors.py
+++ b/synthadoc/errors.py
@@ -38,6 +38,21 @@ BACKUP_INCOMPATIBLE  = "ERR-WIKI-007"  # Backup requires newer db_schema_version
 # ── Config / Environment ──────────────────────────────────────────────────────
 CFG_MISSING_API_KEY  = "ERR-CFG-001"   # Required env var (API key) not set
 CFG_UNKNOWN_PROVIDER = "ERR-CFG-002"   # Provider name not recognised
+CFG_DUPLICATE_KEY    = "ERR-CFG-003"   # Duplicate TOML key (e.g. two active "default =" lines)
+CFG_INVALID_TOML     = "ERR-CFG-004"   # TOML syntax error in config file
+
+
+class ConfigError(Exception):
+    """Raised by load_config when the config file is malformed or contradictory.
+
+    Carries ``code`` (an ERR-CFG-* constant) and ``hint`` separately so the CLI
+    layer can route them through ``cli_error()`` without re-parsing the message.
+    """
+
+    def __init__(self, code: str, message: str, hint: str = "") -> None:
+        super().__init__(message)
+        self.code = code
+        self.hint = hint
 
 # ── Skills ────────────────────────────────────────────────────────────────────
 SKILL_NOT_FOUND   = "ERR-SKILL-001"  # No skill matched the source string

--- a/tests/live/live_cli_test.py
+++ b/tests/live/live_cli_test.py
@@ -394,7 +394,7 @@ def run_offline_tests(wiki_root: pathlib.Path) -> None:
         r_bk = check(
             "backup basic",
             ["backup", "-w", WIKI_NAME, "--output", str(_bk_dir)],
-            contains=["✓"],
+            contains=["OK "],
         )
         zips = sorted(_bk_dir.glob("synthadoc-backup-*.zip"))
         zip_path = zips[0] if zips else None
@@ -421,7 +421,7 @@ def run_offline_tests(wiki_root: pathlib.Path) -> None:
                     "--target", str(_restore_dir),
                     "--port",   "7099",
                 ],
-                contains=["✓ Restored", _RESTORE_NAME],
+                contains=["OK Restored", _RESTORE_NAME],
                 input="y\n",
             )
 
@@ -520,7 +520,7 @@ def run_offline_tests(wiki_root: pathlib.Path) -> None:
                     "--name",  _RESTORE_DFLT,
                     "--port",  "7098",
                 ],
-                contains=["Restoring to:", "✓ Restored"],
+                contains=["Restoring to:", "OK Restored"],
                 input="y\n",
             )
             dflt_dir = _bk_dir / _RESTORE_DFLT

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -449,3 +449,29 @@ def test_init_wiki_config_has_security_enabled(tmp_path):
     assert cfg_path.exists()
     data = tomllib.loads(cfg_path.read_text(encoding="utf-8"))
     assert data.get("security", {}).get("sensitive_scan_enabled") is True
+
+
+def test_load_config_raises_config_error_on_duplicate_key(tmp_path):
+    """[ERR-CFG-003] Duplicate 'default' key raises ConfigError, not a raw traceback."""
+    from synthadoc.errors import ConfigError, CFG_DUPLICATE_KEY
+    cfg_file = tmp_path / "config.toml"
+    # Two active 'default =' lines under [agents] — TOML rejects duplicate keys
+    cfg_file.write_text(
+        '[agents]\ndefault = { provider = "gemini", model = "gemini-2.5-flash-lite" }\n'
+        'default = { provider = "opencode" }\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError) as exc_info:
+        load_config(project_config=cfg_file)
+    assert exc_info.value.code == CFG_DUPLICATE_KEY
+    assert "Only one 'default' line" in exc_info.value.hint
+
+
+def test_load_config_raises_config_error_on_invalid_toml(tmp_path):
+    """[ERR-CFG-004] Malformed TOML raises ConfigError."""
+    from synthadoc.errors import ConfigError, CFG_INVALID_TOML
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("not valid toml = {{{", encoding="utf-8")
+    with pytest.raises(ConfigError) as exc_info:
+        load_config(project_config=cfg_file)
+    assert exc_info.value.code == CFG_INVALID_TOML


### PR DESCRIPTION
…has duplicate keys

When a user accidentally uncomments two 'default =' lines under [agents], tomllib raises TOMLDecodeError which previously propagated as an unhandled ValueError and dumped a full Rich traceback.

Fix:
- Add ConfigError exception class to errors.py (carries code + hint separately)
- Add CFG_DUPLICATE_KEY (ERR-CFG-003) and CFG_INVALID_TOML (ERR-CFG-004) constants
- config.py now raises ConfigError instead of ValueError so the CLI layer can route it through cli_error() for a clean one-line message + hint
- All load_config() call sites (serve, _http, audit, retract, schedule) catch ConfigError and call cli_error()
- Two new tests cover duplicate-key and invalid-TOML cases