### PR TITLE
feat(config): make CLI→server HTTP timeouts configurable; fix live-test timeouts

### DIFF
--- a/synthadoc/cli/_http.py
+++ b/synthadoc/cli/_http.py
@@ -8,13 +8,18 @@ import httpx
 import typer
 from typing import NoReturn
 
-from synthadoc.config import load_config
+from synthadoc.config import load_config, Config as _Config
 from synthadoc.cli._wiki import resolve_wiki_path
 from synthadoc import errors as E
 
 
 def server_url(wiki: str) -> str:
     """Return the base URL for the wiki's server."""
+    return _server_info(wiki)[0]
+
+
+def _server_info(wiki: str) -> tuple[str, _Config]:
+    """Return (base_url, config) for the wiki's server."""
     root = resolve_wiki_path(wiki)
     config_path = root / ".synthadoc" / "config.toml"
     if not config_path.exists():
@@ -27,42 +32,56 @@ def server_url(wiki: str) -> str:
         cfg = load_config(project_config=config_path)
     except E.ConfigError as exc:
         E.cli_error(exc.code, str(exc), exc.hint)
-    port = cfg.server.port
-    return f"http://127.0.0.1:{port}"
+    return f"http://127.0.0.1:{cfg.server.port}", cfg
 
 
-def get(wiki: str, path: str, timeout: int = 60, **params) -> dict:
-    url = server_url(wiki)
+def get(wiki: str, path: str, timeout: int | None = None, **params) -> dict:
+    url, cfg = _server_info(wiki)
+    t = timeout if timeout is not None else cfg.server.client_timeout_seconds
     try:
-        resp = httpx.get(f"{url}{path}", params=params, timeout=timeout)
+        resp = httpx.get(f"{url}{path}", params=params, timeout=t)
         resp.raise_for_status()
         return resp.json()
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.ReadTimeout:
-        _timeout_error(path, timeout)
+        _timeout_error(path, t)
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
-def post(wiki: str, path: str, body: dict, timeout: int = 60) -> dict:
-    url = server_url(wiki)
+def post(wiki: str, path: str, body: dict, timeout: int | None = None,
+         *, llm: bool = False) -> dict:
+    """POST *body* to *path* and return the JSON response.
+
+    *timeout* overrides the config value when given.
+    *llm=True* selects ``client_llm_timeout_seconds`` (default 180 s) instead of
+    the general ``client_timeout_seconds`` (default 60 s) — use it for endpoints
+    that block on a full LLM call (e.g. ``/analyse``, ``/context/build``).
+    """
+    url, cfg = _server_info(wiki)
+    if timeout is not None:
+        t = timeout
+    elif llm:
+        t = cfg.server.client_llm_timeout_seconds
+    else:
+        t = cfg.server.client_timeout_seconds
     try:
-        resp = httpx.post(f"{url}{path}", json=body, timeout=timeout)
+        resp = httpx.post(f"{url}{path}", json=body, timeout=t)
         resp.raise_for_status()
         return resp.json()
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.ReadTimeout:
-        _timeout_error(path, timeout)
+        _timeout_error(path, t)
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
 def delete(wiki: str, path: str) -> dict:
-    url = server_url(wiki)
+    url, cfg = _server_info(wiki)
     try:
         resp = httpx.delete(f"{url}{path}", timeout=10)
         resp.raise_for_status()
@@ -74,13 +93,18 @@ def delete(wiki: str, path: str) -> dict:
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
 
 
-def get_stream(wiki: str, path: str, timeout: int = 120, **params):
-    """Yield (event_name, data_dict) tuples from an SSE endpoint."""
+def get_stream(wiki: str, path: str, timeout: int | None = None, **params):
+    """Yield (event_name, data_dict) tuples from an SSE endpoint.
+
+    *timeout* overrides the config value when given; otherwise uses
+    ``client_stream_timeout_seconds`` (default 120 s).
+    """
     import json as _json
-    url = server_url(wiki)
+    url, cfg = _server_info(wiki)
+    t = timeout if timeout is not None else cfg.server.client_stream_timeout_seconds
     full_url = f"{url}{path}"
     try:
-        with httpx.Client(timeout=timeout) as client:
+        with httpx.Client(timeout=t) as client:
             with client.stream("GET", full_url, params=params) as resp:
                 resp.raise_for_status()
                 event_name = "message"
@@ -98,7 +122,7 @@ def get_stream(wiki: str, path: str, timeout: int = 120, **params):
     except httpx.ConnectError:
         _no_server(wiki)
     except httpx.ReadTimeout:
-        _timeout_error(path, timeout)
+        _timeout_error(path, t)
     except httpx.HTTPStatusError as e:
         E.cli_error(E.SRV_HTTP_ERROR,
                     f"Server returned {e.response.status_code}: {_detail(e.response)}")
@@ -124,7 +148,8 @@ def _timeout_error(path: str, timeout: int) -> NoReturn:
         E.cli_error(
             E.QUERY_TIMEOUT,
             f"The request timed out waiting for the server to respond ({timeout} s).",
-            "The wiki server is still running. Try again.",
+            "The wiki server is still running. Try again, or raise "
+            "client_llm_timeout_seconds in [server] of .synthadoc/config.toml.",
         )
 
 

--- a/synthadoc/cli/_init.py
+++ b/synthadoc/cli/_init.py
@@ -220,6 +220,11 @@ domain = "{domain}"
 port = {port}  # change this if running multiple wikis simultaneously
 # host = "0.0.0.0"  # bind to all interfaces — no built-in auth, restrict via firewall
 job_timeout_seconds = 600  # max seconds a single job runs before being killed
+# CLI → server HTTP timeouts (seconds).  Raise when using slow LLM providers
+# (e.g. opencode, local models, or heavily loaded cloud APIs).
+client_timeout_seconds = 60         # simple requests (status, job enqueue, …)
+client_llm_timeout_seconds = 180    # LLM-driven endpoints (/analyse, /context/build)
+client_stream_timeout_seconds = 120 # SSE streaming (/query/stream)
 
 [agents]
 default = {{ provider = "gemini", model = "gemini-2.5-flash-lite" }}

--- a/synthadoc/cli/context.py
+++ b/synthadoc/cli/context.py
@@ -16,7 +16,8 @@ app.add_typer(context_app)
 def _build_context_pack(wiki_or_root: Path | str, goal: str, tokens: int) -> str:
     """Call server POST /context/build and return Markdown string."""
     from synthadoc.cli._http import post
-    result = post(str(wiki_or_root), "/context/build", {"goal": goal, "token_budget": tokens})
+    result = post(str(wiki_or_root), "/context/build", {"goal": goal, "token_budget": tokens},
+                  llm=True)
     from synthadoc.agents.context_agent import ContextPack, ContextPage
     pages = [
         ContextPage(

--- a/synthadoc/cli/ingest.py
+++ b/synthadoc/cli/ingest.py
@@ -13,11 +13,6 @@ from synthadoc.cli._http import get, post
 _SUPPORTED = {".md", ".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".csv",
               ".png", ".jpg", ".jpeg", ".webp", ".gif", ".tiff"}
 
-# POST /analyse runs one LLM call via the coding-tool provider (e.g. opencode),
-# which can take 60-90 s on slower machines.  Use a generous budget so the CLI
-# does not time out before the server response arrives.
-_ANALYSE_TIMEOUT = 180  # seconds
-
 # Intent-phrase prefixes that are valid non-file sources (matched case-insensitively)
 _INTENT_PREFIXES = (
     "search for:", "find on the web:", "look up:", "web search:", "browse:",
@@ -106,8 +101,7 @@ def ingest_cmd(
             abs_source = str(Path(s).resolve())
         if analyse_only:
             import json as _json
-            result = post(wiki, "/analyse", {"source": abs_source},
-                          timeout=_ANALYSE_TIMEOUT)
+            result = post(wiki, "/analyse", {"source": abs_source}, llm=True)
             typer.echo(_json.dumps(result, indent=2))
             continue
         body: dict = {"source": abs_source, "force": force}

--- a/synthadoc/cli/ingest.py
+++ b/synthadoc/cli/ingest.py
@@ -13,6 +13,11 @@ from synthadoc.cli._http import get, post
 _SUPPORTED = {".md", ".txt", ".pdf", ".docx", ".pptx", ".xlsx", ".csv",
               ".png", ".jpg", ".jpeg", ".webp", ".gif", ".tiff"}
 
+# POST /analyse runs one LLM call via the coding-tool provider (e.g. opencode),
+# which can take 60-90 s on slower machines.  Use a generous budget so the CLI
+# does not time out before the server response arrives.
+_ANALYSE_TIMEOUT = 180  # seconds
+
 # Intent-phrase prefixes that are valid non-file sources (matched case-insensitively)
 _INTENT_PREFIXES = (
     "search for:", "find on the web:", "look up:", "web search:", "browse:",
@@ -101,7 +106,8 @@ def ingest_cmd(
             abs_source = str(Path(s).resolve())
         if analyse_only:
             import json as _json
-            result = post(wiki, "/analyse", {"source": abs_source})
+            result = post(wiki, "/analyse", {"source": abs_source},
+                          timeout=_ANALYSE_TIMEOUT)
             typer.echo(_json.dumps(result, indent=2))
             continue
         body: dict = {"source": abs_source, "force": force}

--- a/synthadoc/config.py
+++ b/synthadoc/config.py
@@ -151,6 +151,12 @@ class ServerConfig:
     reload: bool = False
     job_timeout_seconds: int = 600  # max time a single job runs before being killed
 
+    # CLI → server HTTP timeouts.  Raise these when using a slow LLM provider
+    # (e.g. opencode on an overloaded machine, local CPU-only models).
+    client_timeout_seconds: int = 60        # simple requests (status, job enqueue, …)
+    client_llm_timeout_seconds: int = 180   # LLM-driven endpoints (/analyse, /context/build)
+    client_stream_timeout_seconds: int = 120  # SSE streaming (/query/stream)
+
 
 @dataclass
 class ScheduleJob:
@@ -433,6 +439,9 @@ def _raw_to_config(raw: dict, source_has_agents: bool) -> Config:
         port=sv.get("port", 7070),
         reload=sv.get("reload", False),
         job_timeout_seconds=int(sv.get("job_timeout_seconds", 600)),
+        client_timeout_seconds=int(sv.get("client_timeout_seconds", 60)),
+        client_llm_timeout_seconds=int(sv.get("client_llm_timeout_seconds", 180)),
+        client_stream_timeout_seconds=int(sv.get("client_stream_timeout_seconds", 120)),
     )
 
     # --- cache ---

--- a/tests/cli/test_http_helpers.py
+++ b/tests/cli/test_http_helpers.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-# Copyright (C) 2026 William Johnason / axoviq.com
+# Copyright (C) 2026 Paul Chen / axoviq.com
 import httpx
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import typer
 
+import synthadoc.cli._http as _http_module
+
+
+# ── shared helpers ────────────────────────────────────────────────────────────
 
 def _make_status_error(status: int, method: str, url: str) -> httpx.HTTPStatusError:
     req = httpx.Request(method, url)
@@ -14,6 +18,22 @@ def _make_status_error(status: int, method: str, url: str) -> httpx.HTTPStatusEr
     resp.json.return_value = {"detail": f"HTTP {status}"}
     resp.text = f"HTTP {status}"
     return httpx.HTTPStatusError(str(status), request=req, response=resp)
+
+
+def _fake_server_info(
+    *,
+    client_timeout: int = 60,
+    client_llm_timeout: int = 180,
+    client_stream_timeout: int = 120,
+    port: int = 7070,
+) -> tuple[str, MagicMock]:
+    """Return a (url, cfg_mock) pair suitable for patching _server_info."""
+    cfg = MagicMock()
+    cfg.server.client_timeout_seconds = client_timeout
+    cfg.server.client_llm_timeout_seconds = client_llm_timeout
+    cfg.server.client_stream_timeout_seconds = client_stream_timeout
+    cfg.server.port = port
+    return (f"http://127.0.0.1:{port}", cfg)
 
 
 # ── _detail() ────────────────────────────────────────────────────────────────
@@ -56,82 +76,108 @@ def test_timeout_error_other_path_exits():
 # ── get() ────────────────────────────────────────────────────────────────────
 
 def test_get_connect_error_exits():
-    from synthadoc.cli._http import get
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "get", side_effect=httpx.ConnectError("refused")):
         with pytest.raises(typer.Exit):
-            get("my-wiki", "/status")
+            _http_module.get("my-wiki", "/status")
 
 
 def test_get_read_timeout_exits():
-    from synthadoc.cli._http import get
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "get", side_effect=httpx.ReadTimeout("timeout")):
         with pytest.raises(typer.Exit):
-            get("my-wiki", "/query")
+            _http_module.get("my-wiki", "/query")
 
 
 def test_get_http_status_error_exits():
-    from synthadoc.cli._http import get
     err = _make_status_error(500, "GET", "http://127.0.0.1:7070/status")
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "get", side_effect=err):
         with pytest.raises(typer.Exit):
-            get("my-wiki", "/status")
+            _http_module.get("my-wiki", "/status")
 
 
 # ── post() ───────────────────────────────────────────────────────────────────
 
 def test_post_connect_error_exits():
-    from synthadoc.cli._http import post
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "post", side_effect=httpx.ConnectError("refused")):
         with pytest.raises(typer.Exit):
-            post("my-wiki", "/ingest", {})
+            _http_module.post("my-wiki", "/ingest", {})
 
 
 def test_post_read_timeout_exits():
-    from synthadoc.cli._http import post
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "post", side_effect=httpx.ReadTimeout("timeout")):
         with pytest.raises(typer.Exit):
-            post("my-wiki", "/jobs/cancel", {})
+            _http_module.post("my-wiki", "/jobs/cancel", {})
 
 
 def test_post_http_status_error_exits():
-    from synthadoc.cli._http import post
     err = _make_status_error(422, "POST", "http://127.0.0.1:7070/ingest")
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "post", side_effect=err):
         with pytest.raises(typer.Exit):
-            post("my-wiki", "/ingest", {"source": "x"})
+            _http_module.post("my-wiki", "/ingest", {"source": "x"})
+
+
+def test_post_default_timeout_uses_client_timeout():
+    """post() with no flags uses client_timeout_seconds from config."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.json.return_value = {"ok": True}
+    with patch.object(_http_module, "_server_info",
+                      return_value=_fake_server_info(client_timeout=55)), \
+         patch.object(httpx, "post", return_value=mock_resp) as mock_post:
+        _http_module.post("my-wiki", "/jobs/ingest", {"source": "x"})
+    _, kwargs = mock_post.call_args
+    assert kwargs["timeout"] == 55
+
+
+def test_post_llm_flag_uses_llm_timeout():
+    """post(..., llm=True) uses client_llm_timeout_seconds from config."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.json.return_value = {"ok": True}
+    with patch.object(_http_module, "_server_info",
+                      return_value=_fake_server_info(client_llm_timeout=200)), \
+         patch.object(httpx, "post", return_value=mock_resp) as mock_post:
+        _http_module.post("my-wiki", "/analyse", {"source": "x"}, llm=True)
+    _, kwargs = mock_post.call_args
+    assert kwargs["timeout"] == 200
+
+
+def test_post_explicit_timeout_wins_over_config():
+    """An explicit timeout= always takes precedence over both config values."""
+    mock_resp = MagicMock(spec=httpx.Response)
+    mock_resp.json.return_value = {"ok": True}
+    with patch.object(_http_module, "_server_info",
+                      return_value=_fake_server_info(client_timeout=60, client_llm_timeout=180)), \
+         patch.object(httpx, "post", return_value=mock_resp) as mock_post:
+        _http_module.post("my-wiki", "/analyse", {"source": "x"}, timeout=42, llm=True)
+    _, kwargs = mock_post.call_args
+    assert kwargs["timeout"] == 42
 
 
 # ── delete() ─────────────────────────────────────────────────────────────────
 
 def test_delete_connect_error_exits():
-    from synthadoc.cli._http import delete
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "delete", side_effect=httpx.ConnectError("refused")):
         with pytest.raises(typer.Exit):
-            delete("my-wiki", "/jobs/abc")
+            _http_module.delete("my-wiki", "/jobs/abc")
 
 
 def test_delete_http_status_error_exits():
-    from synthadoc.cli._http import delete
     err = _make_status_error(404, "DELETE", "http://127.0.0.1:7070/jobs/abc")
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
          patch.object(httpx, "delete", side_effect=err):
         with pytest.raises(typer.Exit):
-            delete("my-wiki", "/jobs/abc")
+            _http_module.delete("my-wiki", "/jobs/abc")
 
 
 # ── get_stream() ─────────────────────────────────────────────────────────────
 
 def test_get_stream_yields_events():
     """get_stream must yield (event_name, data) tuples for SSE lines."""
-    from synthadoc.cli._http import get_stream
-
     sse_body = "event: token\ndata: {\"text\": \"hello\"}\n\nevent: done\ndata: {}\n\n"
 
     mock_resp = MagicMock()
@@ -145,48 +191,69 @@ def test_get_stream_yields_events():
     mock_client.__exit__ = MagicMock(return_value=False)
     mock_client.stream = MagicMock(return_value=mock_resp)
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
-         patch("synthadoc.cli._http.httpx.Client", return_value=mock_client):
-        events = list(get_stream("my-wiki", "/query/stream", q="test"))
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
+         patch.object(_http_module.httpx, "Client", return_value=mock_client):
+        events = list(_http_module.get_stream("my-wiki", "/query/stream", q="test"))
 
     assert events[0] == ("token", {"text": "hello"})
     assert events[1] == ("done", {})
 
 
+def test_get_stream_default_timeout_uses_stream_timeout():
+    """get_stream() with no explicit timeout uses client_stream_timeout_seconds."""
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.iter_lines = MagicMock(return_value=iter([]))
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = lambda s: s
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.stream = MagicMock(return_value=mock_resp)
+
+    captured = {}
+
+    def fake_client(timeout):
+        captured["timeout"] = timeout
+        return mock_client
+
+    with patch.object(_http_module, "_server_info",
+                      return_value=_fake_server_info(client_stream_timeout=99)), \
+         patch.object(_http_module.httpx, "Client", side_effect=fake_client):
+        list(_http_module.get_stream("my-wiki", "/query/stream"))
+
+    assert captured["timeout"] == 99
+
+
 def test_get_stream_connect_error_exits():
     """get_stream ConnectError must call _no_server."""
-    from synthadoc.cli._http import get_stream
-
     mock_client = MagicMock()
     mock_client.__enter__ = lambda s: s
     mock_client.__exit__ = MagicMock(return_value=False)
     mock_client.stream = MagicMock(side_effect=httpx.ConnectError("refused"))
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
-         patch("synthadoc.cli._http.httpx.Client", return_value=mock_client):
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
+         patch.object(_http_module.httpx, "Client", return_value=mock_client):
         with pytest.raises(typer.Exit):
-            list(get_stream("my-wiki", "/query/stream", q="test"))
+            list(_http_module.get_stream("my-wiki", "/query/stream", q="test"))
 
 
 def test_get_stream_read_timeout_exits():
     """get_stream ReadTimeout must call _timeout_error."""
-    from synthadoc.cli._http import get_stream
-
     mock_client = MagicMock()
     mock_client.__enter__ = lambda s: s
     mock_client.__exit__ = MagicMock(return_value=False)
     mock_client.stream = MagicMock(side_effect=httpx.ReadTimeout("timeout"))
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
-         patch("synthadoc.cli._http.httpx.Client", return_value=mock_client):
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
+         patch.object(_http_module.httpx, "Client", return_value=mock_client):
         with pytest.raises(typer.Exit):
-            list(get_stream("my-wiki", "/query/stream", q="test"))
+            list(_http_module.get_stream("my-wiki", "/query/stream", q="test"))
 
 
 def test_get_stream_http_status_error_exits():
     """get_stream HTTPStatusError must call cli_error."""
-    from synthadoc.cli._http import get_stream
-
     mock_resp_inner = MagicMock()
     mock_resp_inner.__enter__ = lambda s: s
     mock_resp_inner.__exit__ = MagicMock(return_value=False)
@@ -198,16 +265,14 @@ def test_get_stream_http_status_error_exits():
     mock_client.__exit__ = MagicMock(return_value=False)
     mock_client.stream = MagicMock(return_value=mock_resp_inner)
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
-         patch("synthadoc.cli._http.httpx.Client", return_value=mock_client):
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
+         patch.object(_http_module.httpx, "Client", return_value=mock_client):
         with pytest.raises(typer.Exit):
-            list(get_stream("my-wiki", "/query/stream", q="test"))
+            list(_http_module.get_stream("my-wiki", "/query/stream", q="test"))
 
 
 def test_get_stream_malformed_json_yields_raw():
     """get_stream must yield raw string dict when data line is not valid JSON."""
-    from synthadoc.cli._http import get_stream
-
     sse_body = "event: token\ndata: not-json\n\n"
 
     mock_resp = MagicMock()
@@ -221,8 +286,40 @@ def test_get_stream_malformed_json_yields_raw():
     mock_client.__exit__ = MagicMock(return_value=False)
     mock_client.stream = MagicMock(return_value=mock_resp)
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
-         patch("synthadoc.cli._http.httpx.Client", return_value=mock_client):
-        events = list(get_stream("my-wiki", "/query/stream", q="test"))
+    with patch.object(_http_module, "_server_info", return_value=_fake_server_info()), \
+         patch.object(_http_module.httpx, "Client", return_value=mock_client):
+        events = list(_http_module.get_stream("my-wiki", "/query/stream", q="test"))
 
     assert events[0] == ("token", {"raw": "not-json"})
+
+
+# ── config parsing ────────────────────────────────────────────────────────────
+
+def test_server_config_client_timeouts_parsed(tmp_path):
+    """[server] client_*_timeout_seconds are parsed from config.toml."""
+    from synthadoc.config import load_config
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text(
+        '[agents]\ndefault = { provider = "gemini", model = "gemini-2.5-flash-lite" }\n'
+        "[server]\n"
+        "client_timeout_seconds = 90\n"
+        "client_llm_timeout_seconds = 300\n"
+        "client_stream_timeout_seconds = 200\n"
+    )
+    cfg = load_config(project_config=cfg_file)
+    assert cfg.server.client_timeout_seconds == 90
+    assert cfg.server.client_llm_timeout_seconds == 300
+    assert cfg.server.client_stream_timeout_seconds == 200
+
+
+def test_server_config_client_timeouts_default(tmp_path):
+    """Omitting client_*_timeout_seconds from config.toml gives the correct defaults."""
+    from synthadoc.config import load_config
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text(
+        '[agents]\ndefault = { provider = "gemini", model = "gemini-2.5-flash-lite" }\n'
+    )
+    cfg = load_config(project_config=cfg_file)
+    assert cfg.server.client_timeout_seconds == 60
+    assert cfg.server.client_llm_timeout_seconds == 180
+    assert cfg.server.client_stream_timeout_seconds == 120

--- a/tests/live/live_plugin_test.py
+++ b/tests/live/live_plugin_test.py
@@ -705,8 +705,8 @@ def _test_context_budget() -> None:
         session_id = body.get("session_id", "")
 
         path = (f"/query/stream?q={urllib.parse.quote(q)}"
-                f"&session_id={urllib.parse.quote(session_id)}&no_cache=true&timeout_seconds=120")
-        events = _read_full_sse(path, timeout=150)
+                f"&session_id={urllib.parse.quote(session_id)}&no_cache=true&timeout_seconds=180")
+        events = _read_full_sse(path, timeout=210)
 
         error_events = [e for e in events if e.get("event") == "error"]
         assert not error_events, f"Query returned error: {error_events[0]['data']}"
@@ -763,8 +763,8 @@ def _test_streaming_query_audit() -> None:
 
     q = "streaming token audit live test"
     path = (f"/query/stream?q={urllib.parse.quote(q)}"
-            f"&session_id={urllib.parse.quote(session_id)}&no_cache=true&timeout_seconds=120")
-    events = _read_full_sse(path, timeout=150)
+            f"&session_id={urllib.parse.quote(session_id)}&no_cache=true&timeout_seconds=180")
+    events = _read_full_sse(path, timeout=210)
 
     error_events = [e for e in events if e.get("event") == "error"]
     assert not error_events, f"SSE query returned error: {error_events[0]['data']}"

--- a/tests/live/live_template_install_test.py
+++ b/tests/live/live_template_install_test.py
@@ -107,14 +107,15 @@ def _oneline(text: str, maxlen: int = 160) -> str:
     return " | ".join(parts)[:maxlen]
 
 
-def _poll_job(job_id: str, label: str) -> JobStatus | None:
+def _poll_job(job_id: str, label: str, *, timeout_seconds: int = 600) -> JobStatus | None:
     """Poll a job via the server HTTP API until it reaches a terminal state.
 
     Logs each status transition as INFO. Returns the final JobStatus, or None
-    if the server's job_timeout_seconds (default 600s) elapses without a
-    terminal state — which means the job is stuck, not just slow.
+    if *timeout_seconds* elapses without a terminal state — pass the same
+    value used for the server's job_timeout_seconds so the poll deadline
+    and the server-side kill deadline stay in sync.
     """
-    deadline = time.monotonic() + 600  # matches server default job_timeout_seconds
+    deadline = time.monotonic() + timeout_seconds
     last_logged: str | None = None
     while time.monotonic() < deadline:
         try:
@@ -284,6 +285,41 @@ def _patch_provider(wiki_root: pathlib.Path, provider_name: str) -> None:
         flags=re.MULTILINE,
     )
     config_path.write_text(text, encoding="utf-8")
+
+
+# Providers known to need longer timeouts than the config.toml defaults.
+# job_timeout_seconds     — how long the SERVER lets a single job run.
+# client_llm_timeout_seconds — how long the CLI waits for /analyse, /context/build.
+_SLOW_PROVIDER_TIMEOUTS: dict[str, dict[str, int]] = {
+    "opencode":   {"job_timeout_seconds": 1200, "client_llm_timeout_seconds": 600},
+    "claude-code": {"job_timeout_seconds":  900, "client_llm_timeout_seconds": 360},
+}
+
+
+def _patch_slow_provider_timeouts(wiki_root: pathlib.Path, provider_name: str) -> int:
+    """Raise job_timeout_seconds and client_llm_timeout_seconds in config.toml
+    for providers known to be slower than the defaults.
+
+    Returns the effective job_timeout_seconds so callers can set their poll
+    deadline to match (avoids timing out before the server kills the job).
+    """
+    import re
+
+    overrides = _SLOW_PROVIDER_TIMEOUTS.get(provider_name, {})
+    if not overrides:
+        return 600  # server default — no patch needed
+
+    config_path = wiki_root / ".synthadoc" / "config.toml"
+    text = config_path.read_text(encoding="utf-8")
+    for key, value in overrides.items():
+        text = re.sub(
+            rf"^({re.escape(key)}\s*=\s*)\d+",
+            rf"\g<1>{value}",
+            text,
+            flags=re.MULTILINE,
+        )
+    config_path.write_text(text, encoding="utf-8")
+    return overrides.get("job_timeout_seconds", 600)
 
 
 # ── Server helpers ────────────────────────────────────────────────────────────
@@ -516,11 +552,15 @@ def run_tier2(wiki_root: pathlib.Path) -> None:
     # ── [8a] provider detection & config patch ────────────────────────────────
     print("\n[8a] provider detection")
     coding = _find_coding_provider()
+    job_timeout_seconds = 600  # server default; raised below for slow providers
     if coding:
         provider_name, binary = coding
         _patch_provider(wiki_root, provider_name)
+        job_timeout_seconds = _patch_slow_provider_timeouts(wiki_root, provider_name)
         ok("provider patched",
-           f"config.toml → provider = {provider_name!r} (binary: {binary})")
+           f"config.toml → provider = {provider_name!r} (binary: {binary})"
+           + (f", job_timeout={job_timeout_seconds}s"
+              if job_timeout_seconds != 600 else ""))
     else:
         warn("provider detection",
              "neither 'claude' nor 'opencode' found in PATH — "
@@ -562,7 +602,10 @@ def run_tier2(wiki_root: pathlib.Path) -> None:
             # Poll until the job reaches a terminal state. Pages may land in
             # wiki/candidates/ (staging_policy=all) or directly in wiki/.
             job_id = _extract_job_id(ingest_out)
-            final_status: JobStatus | None = _poll_job(job_id, "ingest job") if job_id else None
+            final_status: JobStatus | None = (
+                _poll_job(job_id, "ingest job", timeout_seconds=job_timeout_seconds)
+                if job_id else None
+            )
 
             # Report where the ingest output landed.
             if final_status == JobStatus.COMPLETED:
@@ -583,10 +626,10 @@ def run_tier2(wiki_root: pathlib.Path) -> None:
                      f"job {job_id[:8] if job_id else '?'} "
                      f"reached status={final_status.value!r}")
             else:
-                # Job did not reach terminal state within 600s — may be stuck.
+                # Job did not reach terminal state within job_timeout_seconds — may be stuck.
                 warn("ingest job",
                      f"job {job_id[:8] if job_id else '?'} did not complete within "
-                     f"600s — check server logs for errors")
+                     f"{job_timeout_seconds}s — check server logs for errors")
         finally:
             tmp_file.unlink(missing_ok=True)
 
@@ -625,13 +668,17 @@ def run_tier2(wiki_root: pathlib.Path) -> None:
             except Exception as exc:
                 warn("scaffold enqueue", f"POST /jobs/scaffold failed: {exc}")
 
-            scaffold_status = _poll_job(scaffold_job_id, "scaffold job") if scaffold_job_id else None
+            scaffold_status = (
+                _poll_job(scaffold_job_id, "scaffold job", timeout_seconds=job_timeout_seconds)
+                if scaffold_job_id else None
+            )
             if scaffold_status == JobStatus.COMPLETED:
                 info("scaffold completed")
             elif scaffold_status is not None:
                 warn("scaffold job", f"reached status={scaffold_status.value!r}")
             elif scaffold_job_id:
-                warn("scaffold job", "did not complete within 600s — check server logs")
+                warn("scaffold job",
+                     f"did not complete within {job_timeout_seconds}s — check server logs")
 
             purpose_after = _text_before_marker(purpose_path)
             if purpose_before.strip() == purpose_after.strip():

--- a/tests/live/live_template_install_test.py
+++ b/tests/live/live_template_install_test.py
@@ -549,6 +549,12 @@ def run_tier1(wiki_root: pathlib.Path) -> None:
 
 def run_tier2(wiki_root: pathlib.Path) -> None:
 
+    # Guard: if [1] install failed, wiki files were never created — skip Tier 2
+    # rather than crashing inside _patch_provider on a missing config.toml.
+    if not (wiki_root / ".synthadoc" / "config.toml").exists():
+        warn("Tier 2 skipped", "[1] install failed — wiki files not present")
+        return
+
     # ── [8a] provider detection & config patch ────────────────────────────────
     print("\n[8a] provider detection")
     coding = _find_coding_provider()
@@ -720,6 +726,11 @@ def main() -> None:
 
     tmpdir   = pathlib.Path(tempfile.mkdtemp(prefix="synthadoc_live_tmpl_"))
     wiki_root = tmpdir / WIKI_NAME
+
+    # Pre-cleanup: silently uninstall any stale registration left by a previous
+    # interrupted run.  The install in [1] will fail with ERR-WIKI-004 if the
+    # wiki name is already registered, even if the old tmpdir is gone.
+    run(["uninstall", WIKI_NAME], input=f"y\n{WIKI_NAME}\n")
 
     try:
         run_tier1(wiki_root)

--- a/tests/live/test_adversarial_gate_live.py
+++ b/tests/live/test_adversarial_gate_live.py
@@ -204,7 +204,7 @@ def _run_lint(scope: str = "all", auto_resolve: bool = False) -> dict:
         "adversarial": True,
         "lifecycle": True,
     })
-    return _wait_job(resp["job_id"], timeout=300)
+    return _wait_job(resp["job_id"], timeout=480)
 
 
 def _setup_test_page(wiki_path: Path) -> None:
@@ -252,7 +252,7 @@ def require_server():
 # ══════════════════════════════════════════════════════════════════════════════
 
 @pytest.mark.live
-@pytest.mark.timeout(360)
+@pytest.mark.timeout(540)
 def test_gate_demotes_page_on_lint_run():
     """
     A full lint run with adversarial_gate_threshold=2 must auto-demote the

--- a/tests/live/test_orphan_resolver_live.py
+++ b/tests/live/test_orphan_resolver_live.py
@@ -279,7 +279,7 @@ def test_resolves_single_orphan():
 
 
 @pytest.mark.live
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(480)
 def test_escalation_on_isolated_orphan():
     """Orphan with all link proposals declined leaves the orphan unresolved.
 
@@ -325,6 +325,7 @@ def test_escalation_on_isolated_orphan():
         events = _run_workflow(
             f"run orphan resolver --slug {_ISOLATED_SLUG}",
             confirm_response=_accept_estimate_decline_proposals,
+            timeout=240,
         )
 
         # Workflow must have produced at least some events
@@ -347,7 +348,7 @@ def test_escalation_on_isolated_orphan():
 
 
 @pytest.mark.live
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(540)
 def test_slug_filter_targets_single():
     """--slug flag limits workflow to just the specified orphan."""
     wiki_root = _get_wiki_root()
@@ -361,6 +362,7 @@ def test_slug_filter_targets_single():
         events = _run_workflow(
             f"run orphan resolver --slug {_ORPHAN_SLUG}",
             confirm_response=_accept_estimate_decline_proposals,
+            timeout=240,
         )
 
         # _ORPHAN_SLUG must appear somewhere in the event stream (targeted).

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -14,6 +14,24 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+# ── shared test helpers ───────────────────────────────────────────────────────
+
+def _fake_server_info_cb(
+    *,
+    client_timeout: int = 60,
+    client_llm_timeout: int = 180,
+    client_stream_timeout: int = 120,
+    port: int = 7070,
+):
+    """Return a (url, cfg_mock) pair for patching synthadoc.cli._http._server_info."""
+    cfg = MagicMock()
+    cfg.server.client_timeout_seconds = client_timeout
+    cfg.server.client_llm_timeout_seconds = client_llm_timeout
+    cfg.server.client_stream_timeout_seconds = client_stream_timeout
+    cfg.server.port = port
+    return (f"http://127.0.0.1:{port}", cfg)
+
+
 # ── cli/_utils.py ─────────────────────────────────────────────────────────────
 
 def test_resolve_root_returns_cwd_when_none():
@@ -137,8 +155,9 @@ def test_ingest_analyse_only_calls_analyse_endpoint(tmp_path):
     from synthadoc.cli.main import app
     runner = CliRunner()
 
-    def fake_post(wiki, path, body, timeout=60):
+    def fake_post(wiki, path, body, timeout=None, *, llm=False):
         assert "/analyse" in path
+        assert llm is True, "analyse endpoint must set llm=True"
         return {"entities": [], "tags": [], "summary": "test"}
 
     with patch("synthadoc.cli.ingest.post", side_effect=fake_post), \
@@ -616,45 +635,48 @@ def test_server_url_missing_config_exits(tmp_path):
 
 def test_http_get_happy_path():
     """get() returns parsed JSON on a 200 response."""
-    from synthadoc.cli._http import get
+    import synthadoc.cli._http as _http_mod
     import httpx
     mock_resp = MagicMock(spec=httpx.Response)
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = {"status": "ok"}
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    fake_info = _fake_server_info_cb()
+    with patch.object(_http_mod, "_server_info", return_value=fake_info), \
          patch.object(httpx, "get", return_value=mock_resp):
-        result = get("my-wiki", "/health")
+        result = _http_mod.get("my-wiki", "/health")
 
     assert result == {"status": "ok"}
 
 
 def test_http_post_happy_path():
     """post() returns parsed JSON on a 200 response."""
-    from synthadoc.cli._http import post
+    import synthadoc.cli._http as _http_mod
     import httpx
     mock_resp = MagicMock(spec=httpx.Response)
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = {"job_id": "abc-123"}
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    fake_info = _fake_server_info_cb()
+    with patch.object(_http_mod, "_server_info", return_value=fake_info), \
          patch.object(httpx, "post", return_value=mock_resp):
-        result = post("my-wiki", "/jobs/ingest", {"source": "file.md"})
+        result = _http_mod.post("my-wiki", "/jobs/ingest", {"source": "file.md"})
 
     assert result["job_id"] == "abc-123"
 
 
 def test_http_delete_happy_path():
     """delete() returns parsed JSON on a 200 response."""
-    from synthadoc.cli._http import delete
+    import synthadoc.cli._http as _http_mod
     import httpx
     mock_resp = MagicMock(spec=httpx.Response)
     mock_resp.raise_for_status = MagicMock()
     mock_resp.json.return_value = {"deleted": True}
 
-    with patch("synthadoc.cli._http.server_url", return_value="http://127.0.0.1:7070"), \
+    fake_info = _fake_server_info_cb()
+    with patch.object(_http_mod, "_server_info", return_value=fake_info), \
          patch.object(httpx, "delete", return_value=mock_resp):
-        result = delete("my-wiki", "/jobs/abc-123")
+        result = _http_mod.delete("my-wiki", "/jobs/abc-123")
 
     assert result["deleted"] is True
 


### PR DESCRIPTION
Hardcoded CLI→server HTTP timeouts made Synthadoc brittle with slow LLM providers (opencode, local models, heavily loaded cloud APIs). This PR moves them to `config.toml` so users can tune them without touching source code, and
fixes a cascade of live-test failures caused by those same tight timeouts.

## Changes

### Configurable CLI timeouts (`config.toml`)

Three new `[server]` fields, active with sensible defaults so existing wikis need no changes:

```toml
client_timeout_seconds = 60         # simple requests (status, job enqueue, …)
client_llm_timeout_seconds = 180    # LLM-driven endpoints (/analyse, /context/build)
client_stream_timeout_seconds = 120 # SSE streaming (/query/stream)
```

- post() gains an llm=True flag to select client_llm_timeout_seconds; callers (/analyse, /context/build) use it instead of a hardcoded constant.
- get_stream() defaults to client_stream_timeout_seconds.
- _http.py refactored: server_url() now delegates to _server_info() which returns (url, Config), enabling config-based timeout selection without an extra file read per call.
- _init.py config template includes all three lines (active, not commented out).
- Error hint updated to mention client_llm_timeout_seconds by name.

Live-test timeout fixes

- Orphan-resolver test_slug_filter_targets_single and test_escalation_on_isolated_orphan: raised @pytest.mark.timeout and
  internal _run_workflow budget for the exhaust-all-strategies paths.
- Template install test: _patch_slow_provider_timeouts() now patches job_timeout_seconds and client_llm_timeout_seconds into the ephemeral test wiki's config automatically when opencode or claude-code is detected — no manual config editing required. _poll_job accepts a timeout_seconds kwarg so its poll deadline stays in sync with the server's job kill deadline.
- Adversarial lint and query/stream live-test timeouts raised.
