### PR TITLE
fix(pre-prompt): surface broken citation count suggestion after lint

### DIFF
--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -580,7 +580,10 @@ _BROKEN_CITATIONS_HEADER_RE = re.compile(
     re.IGNORECASE,
 )
 _BROKEN_CITATIONS_AFTER_RE = re.compile(
-    r'\b(?:broken\s+)?citation\s*(?:issue|ref|problem)s?\s*:\s*([1-9]\d*)',
+    # "citation issues: 2"  /  "citation refs: 2"
+    r'\b(?:broken\s+)?citation\s*(?:issue|ref|problem)s?\s*:\s*([1-9]\d*)'
+    # "broken citations: 2"  (lint-report summary line — the most reliable total)
+    r'|\bbroken\s+citations?\s*:\s*([1-9]\d*)',
     re.IGNORECASE,
 )
 _NO_BROKEN_CITATIONS_RE = re.compile(
@@ -670,9 +673,11 @@ def _build_pre_prompt(answer: str) -> str | None:
     # invisible in navigation but do not block page rendering.
     if not _NO_BROKEN_CITATIONS_RE.search(answer):
         for pat in (
-            _BROKEN_CITATIONS_COUNT_RE,
-            _BROKEN_CITATIONS_HEADER_RE,
+            # Try summary/total formats first so a "Broken citations: 2" line
+            # wins over per-page "(1 broken citation(s))" detail lines.
             _BROKEN_CITATIONS_AFTER_RE,
+            _BROKEN_CITATIONS_HEADER_RE,
+            _BROKEN_CITATIONS_COUNT_RE,
         ):
             m = pat.search(answer)
             if m:

--- a/synthadoc/agents/query_agent.py
+++ b/synthadoc/agents/query_agent.py
@@ -566,6 +566,31 @@ _NO_ORPHAN_RE = re.compile(
     r'|\borphan\b[^(\n]*\(0\)',
     re.IGNORECASE,
 )
+# Broken citation patterns — three output formats:
+#   LLM text / CLI summary: "2 broken citations" / "2 citation issue(s)"
+#   CLI section header:     "Citation Issues (2 across 1 pages):"
+#   LLM / colon form:       "citation issues: 2" / "broken citations: 2"
+_BROKEN_CITATIONS_COUNT_RE = re.compile(
+    r'\b([1-9]\d*)\s+(?:broken\s+)?citation\s*(?:issue|ref|problem)s?\b'
+    r'|\b([1-9]\d*)\s+broken\s+citations?\b',
+    re.IGNORECASE,
+)
+_BROKEN_CITATIONS_HEADER_RE = re.compile(
+    r'\bcitation\s*(?:issue|ref|problem)s?\s*\(\s*([1-9]\d*)',
+    re.IGNORECASE,
+)
+_BROKEN_CITATIONS_AFTER_RE = re.compile(
+    r'\b(?:broken\s+)?citation\s*(?:issue|ref|problem)s?\s*:\s*([1-9]\d*)',
+    re.IGNORECASE,
+)
+_NO_BROKEN_CITATIONS_RE = re.compile(
+    r'\b0\s+citation\s*(?:issue|ref|problem)s?\b'
+    r'|no\s+citation\s*(?:issue|ref|problem)s?\b'
+    r'|zero\s+broken\s+citations?\b'
+    r'|\bcitation\s*(?:issue|ref|problem)s?\s*\(\s*0\s*\)'
+    r'|\bcitation\s*(?:issue|ref|problem)s?\s*:\s*0\b',
+    re.IGNORECASE,
+)
 
 
 def _build_pre_prompt(answer: str) -> str | None:
@@ -581,6 +606,10 @@ def _build_pre_prompt(answer: str) -> str | None:
          Four formats: LLM text, lint-report summary ("- Orphan pages: N"),
          lint-report section header ("Orphan pages (N)…"), wiki-status table
       5. Broken wikilinks → prompt to scan
+      6. Broken citations → prompt to run the citation resolver
+         Three formats: LLM text / CLI summary ("N citation issue(s)"),
+         CLI section header ("Citation Issues (N across M pages)"),
+         colon form ("citation issues: N")
 
     Returns None if no clear next action is present.
     """
@@ -635,6 +664,24 @@ def _build_pre_prompt(answer: str) -> str | None:
     # Trigger when lint/status reports broken wikilinks.
     if _BROKEN_LINKS_RE.search(answer) and not _NO_BROKEN_LINKS_RE.search(answer):
         return "Scan for broken wikilinks"
+    # Trigger when lint/status reports broken source citations.
+    # Three formats matched: "2 citation issue(s)", "Citation Issues (2 across…)",
+    # "citation issues: 2".  Priority below broken wikilinks — citations are
+    # invisible in navigation but do not block page rendering.
+    if not _NO_BROKEN_CITATIONS_RE.search(answer):
+        for pat in (
+            _BROKEN_CITATIONS_COUNT_RE,
+            _BROKEN_CITATIONS_HEADER_RE,
+            _BROKEN_CITATIONS_AFTER_RE,
+        ):
+            m = pat.search(answer)
+            if m:
+                # _BROKEN_CITATIONS_COUNT_RE has two alternation groups;
+                # take the first non-None capture.
+                raw = next(g for g in m.groups() if g is not None)
+                n = int(raw)
+                word = "citation" if n == 1 else "citations"
+                return f"Fix {n} broken {word} — run the citation resolver?"
     return None
 
 

--- a/tests/agents/test_hint_engine_v12.py
+++ b/tests/agents/test_hint_engine_v12.py
@@ -172,3 +172,26 @@ def test_pre_prompt_broken_citations_triggers_resolver_phrase():
     prompt = _build_pre_prompt("2 citation issue(s) detected.")
     assert prompt is not None
     assert "citation resolver" in prompt.lower()
+
+
+def test_pre_prompt_broken_citations_summary_wins_over_per_page_detail():
+    """Lint report shows 'Broken citations: 2' in the summary but each
+    per-page entry says '1 broken citation(s)'.  The total (2) must win."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    answer = (
+        "Broken citations: 2\n"
+        "[[artificial-intelligence-history]] (1 broken citation(s))\n"
+        "[[programming-languages-overview]] (1 broken citation(s))\n"
+    )
+    prompt = _build_pre_prompt(answer)
+    assert prompt is not None
+    assert "2" in prompt, f"Expected total '2', got: {prompt!r}"
+    assert "1" not in prompt, f"Per-page count '1' leaked into prompt: {prompt!r}"
+
+
+def test_pre_prompt_broken_citations_bare_summary_line():
+    """'Broken citations: N' alone (lint-report summary line format) is matched."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("Broken citations: 3")
+    assert prompt is not None
+    assert "3" in prompt

--- a/tests/agents/test_hint_engine_v12.py
+++ b/tests/agents/test_hint_engine_v12.py
@@ -101,3 +101,74 @@ def test_broken_wikilinks_hint_chip_in_answer():
     )
     assert any("broken" in h.lower() or "wikilink" in h.lower() for h in hints), \
         f"Expected broken wikilinks hint, got: {hints}"
+
+
+# ── _build_pre_prompt — broken citation patterns ──────────────────────────────
+
+def test_pre_prompt_broken_citations_count_before():
+    """'2 citation issue(s)' — CLI summary format with count before keyword."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("Lint found 2 citation issue(s) across 1 page.")
+    assert prompt is not None, "Expected a pre-prompt for broken citations"
+    assert "citation" in prompt.lower()
+    assert "2" in prompt
+
+
+def test_pre_prompt_broken_citations_natural_language():
+    """'2 broken citations' — natural language from LLM response."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("There are 2 broken citations that need fixing.")
+    assert prompt is not None
+    assert "citation" in prompt.lower()
+    assert "2" in prompt
+
+
+def test_pre_prompt_broken_citations_cli_header():
+    """'Citation Issues (2 across 1 pages)' — CLI section header format."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt(
+        "Citation Issues (2 across 1 pages):\n  grace-hopper: ^[sources/bib.txt:1-5]"
+    )
+    assert prompt is not None
+    assert "citation" in prompt.lower()
+    assert "2" in prompt
+
+
+def test_pre_prompt_broken_citations_colon_form():
+    """'citation issues: 2' — colon-separated form."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("Summary: citation issues: 2, orphans: 0")
+    assert prompt is not None
+    assert "citation" in prompt.lower()
+
+
+def test_pre_prompt_broken_citations_singular():
+    """'1 broken citation' → singular word in returned prompt."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("1 citation issue found in grace-hopper.")
+    assert prompt is not None
+    assert "citation" in prompt.lower()
+    assert "1" in prompt
+
+
+def test_pre_prompt_no_broken_citations_when_zero():
+    """'0 citation issue(s)' → no pre-prompt."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("Lint complete: 0 citation issues found. All good.")
+    assert prompt is None
+
+
+def test_pre_prompt_no_broken_citations_when_none():
+    """'no citation issues' → no pre-prompt."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("There are no citation issues in your wiki.")
+    assert prompt is None
+
+
+def test_pre_prompt_broken_citations_triggers_resolver_phrase():
+    """The returned pre-prompt must contain 'citation resolver' so the router
+    routes it to BrokenCitationResolverWorkflow."""
+    from synthadoc.agents.query_agent import _build_pre_prompt
+    prompt = _build_pre_prompt("2 citation issue(s) detected.")
+    assert prompt is not None
+    assert "citation resolver" in prompt.lower()


### PR DESCRIPTION
Two related fixes to `_build_pre_prompt` in `query_agent.py` so the web UI pre-fills the Ask field with the correct broken-citation suggestion after a lint run.

---

### Fix 1: missing broken-citation case (`1fdef3b`)

`_build_pre_prompt` handled 5 signals (re-ingest complete, contradicted, stale, orphan, broken wikilinks) but had no case for broken source citations. When lint found citation issues and the LLM reported them, the function returned `None` and the input field stayed blank.

**Changes:**
- Added three compiled regex patterns covering all output formats the lint response can produce:
  - `_BROKEN_CITATIONS_COUNT_RE` — `"2 citation issue(s)"` / `"2 broken citations"`
  - `_BROKEN_CITATIONS_HEADER_RE` — `"Citation Issues (2 across 1 pages):"`  (CLI section header)
  - `_BROKEN_CITATIONS_AFTER_RE` — `"citation issues: 2"` / `"broken citations: 2"`
  - `_NO_BROKEN_CITATIONS_RE` — negation guard (`"0 citation issues"`, `"no citation issues"`)
- Added priority-6 case in `_build_pre_prompt` returning
  `"Fix N broken citations — run the citation resolver?"` which matches
  `BrokenCitationResolverWorkflow.MATCH_RE` so the router dispatches correctly.

---

### Fix 2: wrong count when lint report lists per-page detail (`e671e44`)

When the lint report contained both a summary line `Broken citations: 2` and per-page entries `[[slug]] (1 broken citation(s))`, the pre-prompt showed "Fix 1 broken citation" instead of "Fix 2 broken citations".

**Root causes:**
1. `_BROKEN_CITATIONS_AFTER_RE` required `issue|ref|problem` between "citation"
   and the colon, so the bare summary format `Broken citations: N` was never
   matched.
2. The pattern loop tried `_BROKEN_CITATIONS_COUNT_RE` first, which matched
   the per-page `1 broken citation` detail before the summary total.

**Changes:**
- Added `|\bbroken\s+citations?\s*:\s*([1-9]\d*)` branch to  `_BROKEN_CITATIONS_AFTER_RE` so `"Broken citations: 2"` is matched.
- Reordered the loop: summary/colon patterns run before count-before patterns so the overall total always wins over per-page detail lines.

---